### PR TITLE
Rename the sampling frequency variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ using Tracking
 using Tracking: Hz, GPSL1
 carrier_doppler = 1000Hz
 code_phase = 50
-sample_frequency = 2.5e6Hz
+sampling_frequency = 2.5e6Hz
 prn = 1
 state = TrackingState(GPSL1, carrier_doppler, code_phase)
-results = track(signal, state, prn, sample_frequency)
-next_results = track(next_signal, get_state(results), prn, sample_frequency)
+results = track(signal, state, prn, sampling_frequency)
+next_results = track(next_signal, get_state(results), prn, sampling_frequency)
 ```
 
 If you'd like to track several signals at once (e.g. in the case of phased antenna arrays), you will have to specify the optional parameter `num_ants::NumAnts{N}` and pass a beamforming function to the `track` function:
 
 ```julia
 state = TrackingState(GPSL1, carrier_doppler, code_phase, num_ants = NumAnts(4)) # 4 antenna channels
-results = track(signal, state, prn, sample_frequency, post_corr_filter = x -> x[1]) # Post corr filter is optional
+results = track(signal, state, prn, sampling_frequency, post_corr_filter = x -> x[1]) # Post corr filter is optional
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,16 +37,16 @@ These parameters are usually provided by the acquisition process of the satellit
 
 The signal is tracked by
 ```julia
-results = track(signal, state, prn, sample_frequency)
+results = track(signal, state, prn, sampling_frequency)
 ```
-where `prn` is the PRN and `sample_frequency` the sample frequency. Refer to [`track`](@ref)
+where `prn` is the PRN and `sampling_frequency` the sampling frequency. Refer to [`track`](@ref)
 to find about other optional parameters. The result contains the current state as well as
 some additional information such as the last valid correlator output, found data bits, etc.
 For each of those parameters a helper function exists to get the parameter
 (e.g. `get_prompt(results)`) - see [Tracking Results](@ref). The next track function needs
 the updated state:
 ```julia
-next_results = track(next_signal, get_state(results), prn, sample_frequency)
+next_results = track(next_signal, get_state(results), prn, sampling_frequency)
 ```
 
 Here is an example for a single PRN:
@@ -55,11 +55,11 @@ using Tracking
 using Tracking: Hz, GPSL1
 carrier_doppler = 1000Hz
 code_phase = 50
-sample_frequency = 2.5e6Hz
+sampling_frequency = 2.5e6Hz
 prn = 1
 state = TrackingState(GPSL1, carrier_doppler, code_phase)
-results = track(signal, state, prn, sample_frequency)
-next_results = track(next_signal, get_state(results), prn, sample_frequency)
+results = track(signal, state, prn, sampling_frequency)
+next_results = track(next_signal, get_state(results), prn, sampling_frequency)
 ```
 
 ## Track multiple signals coherently
@@ -77,7 +77,7 @@ drive the discriminators etc. However, an appropiate beamforming algorithm will 
 suit better. For that, you'll have to pass a function `post_corr_filter` to the track
 function like the following:
 ```julia
-results = track(signal, state, prn, sample_frequency, post_corr_filter = x -> x[end])
+results = track(signal, state, prn, sampling_frequency, post_corr_filter = x -> x[end])
 ```
 
 ## Q/A

--- a/docs/src/loop_filter.md
+++ b/docs/src/loop_filter.md
@@ -27,7 +27,7 @@ next_results = track(
   next_signal,
   get_state(results),
   prn,
-  sample_frequency,
+  sampling_frequency,
   carrier_loop_filter_bandwidth = 18Hz,
   code_loop_filter_bandwidth = 1Hz
 )

--- a/src/carrier_replica.jl
+++ b/src/carrier_replica.jl
@@ -1,7 +1,7 @@
 function gen_carrier_replica!(
     carrier_replica::StructArray{Complex{Int16}},
     carrier_frequency,
-    sample_frequency,
+    sampling_frequency,
     start_phase,
     carrier_amplitude_power::Val{N},
     start_sample,
@@ -10,7 +10,7 @@ function gen_carrier_replica!(
     fpcarrier!(
         carrier_replica,
         carrier_frequency,
-        sample_frequency,
+        sampling_frequency,
         start_phase,
         start_sample = start_sample,
         num_samples = num_samples,
@@ -27,13 +27,13 @@ Updates the carrier phase.
 function update_carrier_phase(
     num_samples,
     carrier_frequency,
-    sample_frequency,
+    sampling_frequency,
     start_phase,
     carrier_amplitude_power::Val{N}
 ) where N
     n = N + 2
     fixed_point = 32 - n - 2
-    delta = floor(Int32, carrier_frequency * 1 << (fixed_point + n) / sample_frequency)
+    delta = floor(Int32, carrier_frequency * 1 << (fixed_point + n) / sampling_frequency)
     fixed_point_start_phase = floor(Int32, start_phase * 1 << (fixed_point + n))
     phase_fixed_point = delta * num_samples + fixed_point_start_phase
     mod(

--- a/src/code_replica.jl
+++ b/src/code_replica.jl
@@ -2,7 +2,7 @@ function gen_code_replica!(
     code_replica,
     ::Type{S},
     code_frequency,
-    sample_frequency,
+    sampling_frequency,
     start_code_phase::AbstractFloat,
     start_sample::Integer,
     num_samples::Integer,
@@ -10,7 +10,7 @@ function gen_code_replica!(
     prn::Integer
 ) where S <: AbstractGNSSSystem
     fixed_point = sizeof(Int) * 8 - 1 - min_bits_for_code_length(S)
-    delta = floor(Int, code_frequency * 1 << fixed_point / sample_frequency)
+    delta = floor(Int, code_frequency * 1 << fixed_point / sampling_frequency)
     modded_start_code_phase = mod(
         start_code_phase,
         get_code_length(S) * get_secondary_code_length(S)
@@ -37,7 +37,7 @@ function update_code_phase(
     ::Type{S},
     num_samples,
     code_frequency,
-    sample_frequency,
+    sampling_frequency,
     start_code_phase,
     secondary_code_or_bit_found
 ) where S <: AbstractGNSSSystem
@@ -49,9 +49,9 @@ function update_code_phase(
     end
     code_length = get_code_length(S) *
         (secondary_code_or_bit_found ? secondary_code_or_bit_length : 1)
-    mod(code_frequency * num_samples / sample_frequency + start_code_phase, code_length)
+    mod(code_frequency * num_samples / sampling_frequency + start_code_phase, code_length)
 #    fixed_point = sizeof(Int) * 8 - 1 - min_bits_for_code_length(S)
-#    delta = floor(Int, code_frequency * 1 << fixed_point / sample_frequency)
+#    delta = floor(Int, code_frequency * 1 << fixed_point / sampling_frequency)
 #    fixed_point_start_phase = floor(Int, start_code_phase * 1 << fixed_point)
 #    phase_fixed_point = delta * num_samples + fixed_point_start_phase
 #    mod(phase_fixed_point / 1 << fixed_point, code_length)

--- a/src/correlator.jl
+++ b/src/correlator.jl
@@ -102,10 +102,10 @@ Calculate the shift between the early and late in samples.
 function get_early_late_sample_shift(
     ::Type{S},
     correlator::EarlyPromptLateCorrelator,
-    sample_frequency,
+    sampling_frequency,
     preferred_code_shift
 ) where S <: AbstractGNSSSystem
-    round(Int, preferred_code_shift * sample_frequency / get_code_frequency(S))
+    round(Int, preferred_code_shift * sampling_frequency / get_code_frequency(S))
 end
 
 """

--- a/src/tracking_loop.jl
+++ b/src/tracking_loop.jl
@@ -1,8 +1,8 @@
 """
 $(SIGNATURES)
 
-Track the signal `signal` based on the current tracking `state`, the sample frequency
-`sample_frequency` and PRN `prn`. Optional configurations are:
+Track the signal `signal` based on the current tracking `state`, the sampling frequency
+`sampling_frequency` and PRN `prn`. Optional configurations are:
 - Post correlation filter `post_corr_filter` defaults to `get_default_post_corr_filter(...)`
 - Intermediate frequency `intermediate_frequency` defaults to 0Hz
 - Maximal integration time `max_integration_time` defaults to 1ms. The actual integration
@@ -21,13 +21,13 @@ function track(
         gain_controlled_signal::GainControlledSignal,
         state::TrackingState{S, C, CALF, COLF, CN, DS},
         prn::Integer,
-        sample_frequency;
+        sampling_frequency;
         post_corr_filter = get_default_post_corr_filter(get_correlator(state)),
         intermediate_frequency = 0.0Hz,
         max_integration_time::typeof(1ms) = 1ms,
         min_integration_time::typeof(1.0ms) = 0.75ms,
         early_late_sample_shift = get_early_late_sample_shift(S,
-            get_correlator(state), sample_frequency, 0.5),
+            get_correlator(state), sampling_frequency, 0.5),
         carrier_loop_filter_bandwidth = 18Hz,
         code_loop_filter_bandwidth = 1Hz,
         velocity_aiding = 0Hz,
@@ -73,7 +73,7 @@ function track(
         num_samples_left_to_integrate = get_num_samples_left_to_integrate(
             S,
             max_integration_time,
-            sample_frequency,
+            sampling_frequency,
             code_doppler,
             code_phase,
             found(sc_bit_detector)
@@ -89,7 +89,7 @@ function track(
             code_replica,
             S,
             code_frequency,
-            sample_frequency,
+            sampling_frequency,
             code_phase,
             signal_start_sample,
             num_samples_left,
@@ -99,7 +99,7 @@ function track(
         carrier_replica = gen_carrier_replica!(
             carrier_replica,
             carrier_frequency,
-            sample_frequency,
+            sampling_frequency,
             carrier_phase,
             carrier_amplitude_power,
             signal_start_sample,
@@ -127,7 +127,7 @@ function track(
         carrier_phase = update_carrier_phase(
             num_samples_left,
             carrier_frequency,
-            sample_frequency,
+            sampling_frequency,
             carrier_phase,
             carrier_amplitude_power
         )
@@ -136,11 +136,11 @@ function track(
             S,
             num_samples_left,
             code_frequency,
-            sample_frequency,
+            sampling_frequency,
             code_phase,
             found(sc_bit_detector)
         )
-        integration_time = integrated_samples / sample_frequency
+        integration_time = integrated_samples / sampling_frequency
         if num_samples_left == num_samples_left_to_integrate &&
                 integration_time >= min_integration_time
             got_correlator = true
@@ -153,7 +153,7 @@ function track(
                 S,
                 filtered_correlator,
                 early_late_sample_shift,
-                code_frequency / sample_frequency
+                code_frequency / sampling_frequency
             )
             carrier_freq_update, carrier_loop_filter = filter_loop(
                 carrier_loop_filter,
@@ -220,13 +220,13 @@ end
         signal::AbstractArray,
         state::TrackingState{S, C, CALF, COLF, CN, DS},
         prn::Integer,
-        sample_frequency;
+        sampling_frequency;
         post_corr_filter = get_default_post_corr_filter(get_correlator(state)),
         intermediate_frequency = 0.0Hz,
         max_integration_time::typeof(1ms) = 1ms,
         min_integration_time::typeof(1.0ms) = 0.75ms,
         early_late_sample_shift = get_early_late_sample_shift(S,
-            get_correlator(state), sample_frequency, 0.5),
+            get_correlator(state), sampling_frequency, 0.5),
         carrier_loop_filter_bandwidth = 18Hz,
         code_loop_filter_bandwidth = 1Hz,
         velocity_aiding = 0Hz
@@ -245,7 +245,7 @@ end
         GainControlledSignal(signal),
         state,
         prn,
-        sample_frequency,
+        sampling_frequency,
         post_corr_filter = post_corr_filter,
         intermediate_frequency = intermediate_frequency,
         max_integration_time = max_integration_time,
@@ -316,7 +316,7 @@ Calculates the number of samples to integrate.
 function get_num_samples_left_to_integrate(
     ::Type{S},
     max_integration_time,
-    sample_frequency,
+    sampling_frequency,
     current_code_doppler,
     current_code_phase,
     secondary_code_or_bit_found
@@ -328,7 +328,7 @@ function get_num_samples_left_to_integrate(
         secondary_code_or_bit_found
     )
     code_frequency = get_code_frequency(S) + current_code_doppler
-    ceil(Int, phase_to_integrate * sample_frequency / code_frequency)
+    ceil(Int, phase_to_integrate * sampling_frequency / code_frequency)
 end
 
 """

--- a/test/carrier_replica.jl
+++ b/test/carrier_replica.jl
@@ -19,12 +19,12 @@ end
 @testset "Update carrier phase" begin
     carrier_phase = 0.25
     carrier_frequency = 10Hz
-    sample_frequency = 100Hz
+    sampling_frequency = 100Hz
     num_samples = 2000
     phase = @inferred Tracking.update_carrier_phase(
         num_samples,
         carrier_frequency,
-        sample_frequency,
+        sampling_frequency,
         carrier_phase,
         Val(7)
     )
@@ -32,12 +32,12 @@ end
 
     carrier_phase = 0.25
     carrier_frequency = 10Hz
-    sample_frequency = 2.5e6Hz
+    sampling_frequency = 2.5e6Hz
     num_samples = 2500
     phase = @inferred Tracking.update_carrier_phase(
         num_samples,
         carrier_frequency,
-        sample_frequency,
+        sampling_frequency,
         carrier_phase,
         Val(7)
     )

--- a/test/cn0_estimation.jl
+++ b/test/cn0_estimation.jl
@@ -29,7 +29,7 @@ end
     carrier_doppler = 0Hz
     start_code_phase = 0
     code_frequency = 1023kHz
-    sample_frequency = 4MHz
+    sampling_frequency = 4MHz
     prn = 1
     range = 0:3999
     start_carrier_phase = π / 2
@@ -42,7 +42,7 @@ end
     for i = 1:20
         signal = get_code.(
                 GPSL1,
-                code_frequency .* range ./ sample_frequency .+ start_code_phase,
+                code_frequency .* range ./ sampling_frequency .+ start_code_phase,
                 prn
             ) .* 10^(45 / 20) .+
             randn(ComplexF64, length(range)) .* sqrt(4e6)
@@ -53,7 +53,7 @@ end
         ))
         code = get_code.(
             GPSL1,
-            code_frequency .* (-2:4001) ./ sample_frequency .+ start_code_phase,
+            code_frequency .* (-2:4001) ./ sampling_frequency .+ start_code_phase,
             prn
         )
         correlator = EarlyPromptLateCorrelator()

--- a/test/code_replica.jl
+++ b/test/code_replica.jl
@@ -20,14 +20,14 @@ end
 @testset "Update code phase" begin
     code_phase = 10
     code_frequency = 10Hz
-    sample_frequency = 100Hz
+    sampling_frequency = 100Hz
     num_samples = 2000
     bit_found = true
     phase = @inferred Tracking.update_code_phase(
         GPSL1,
         num_samples,
         code_frequency,
-        sample_frequency,
+        sampling_frequency,
         code_phase,
         bit_found
     )

--- a/test/tracking_loop.jl
+++ b/test/tracking_loop.jl
@@ -62,14 +62,14 @@ end
 
 @testset "Number of samples to integrate" begin
     max_integration_time = 1ms
-    sample_frequency = 4e6Hz
+    sampling_frequency = 4e6Hz
     current_code_doppler = 0Hz
     current_code_phase = 0
     bit_found = true
     samples = @inferred Tracking.get_num_samples_left_to_integrate(
         GPSL1,
         max_integration_time,
-        sample_frequency,
+        sampling_frequency,
         current_code_doppler,
         current_code_phase,
         bit_found
@@ -119,22 +119,22 @@ end
     carrier_doppler = 200Hz
     start_code_phase = 100
     code_frequency = carrier_doppler / 1540 + 1023kHz
-    sample_frequency = 4MHz
+    sampling_frequency = 4MHz
     prn = 1
     range = 0:3999
     start_carrier_phase = π / 2# 0.0 #π / 2
     state = TrackingState(GPSL1, carrier_doppler - 20Hz, start_code_phase)
 
     signal = cis.(
-            2π .* carrier_doppler .* range ./ sample_frequency .+ start_carrier_phase
+            2π .* carrier_doppler .* range ./ sampling_frequency .+ start_carrier_phase
         ) .*
         get_code.(
             GPSL1,
-            code_frequency .* range ./ sample_frequency .+ start_code_phase,
+            code_frequency .* range ./ sampling_frequency .+ start_code_phase,
             prn
         )
 
-    track_result = @inferred track(signal, state, prn, sample_frequency)
+    track_result = @inferred track(signal, state, prn, sampling_frequency)
 
     iterations = 2000
     code_phases = zeros(iterations)
@@ -145,30 +145,30 @@ end
     tracked_carrier_dopplers = zeros(iterations)
     tracked_prompts = zeros(ComplexF64, iterations)
     for i = 1:iterations
-        carrier_phase = mod2pi(2π * carrier_doppler * 4000 * i / sample_frequency +
+        carrier_phase = mod2pi(2π * carrier_doppler * 4000 * i / sampling_frequency +
             start_carrier_phase + π) - π
         code_phase = mod(
-            code_frequency * 4000 * i / sample_frequency + start_code_phase,
+            code_frequency * 4000 * i / sampling_frequency + start_code_phase,
             1023
         )
         signal = cis.(
-                2π .* carrier_doppler .* range ./ sample_frequency .+ carrier_phase
+                2π .* carrier_doppler .* range ./ sampling_frequency .+ carrier_phase
             ) .*
             get_code.(
                 GPSL1,
-                code_frequency .* range ./ sample_frequency .+ code_phase,
+                code_frequency .* range ./ sampling_frequency .+ code_phase,
                 prn
             )
         track_result = @inferred track(
             signal,
             get_state(track_result),
             prn,
-            sample_frequency
+            sampling_frequency
         )
         comp_carrier_phase = mod2pi(2π * carrier_doppler * 4000 * (i + 1) /
-            sample_frequency + start_carrier_phase + π) - π
+            sampling_frequency + start_carrier_phase + π) - π
         comp_code_phase = mod(
-            code_frequency * 4000 * (i + 1) / sample_frequency + start_code_phase,
+            code_frequency * 4000 * (i + 1) / sampling_frequency + start_code_phase,
             1023
         )
         tracked_code_phases[i] = get_code_phase(track_result)
@@ -204,25 +204,25 @@ end
     carrier_doppler = 200Hz
     start_code_phase = 100
     code_frequency = carrier_doppler / 1540 + 1023kHz
-    sample_frequency = 4MHz
+    sampling_frequency = 4MHz
     prn = 1
     range = 0:3999
     start_carrier_phase = π / 2
     state = TrackingState(GPSL1, carrier_doppler - 20Hz, start_code_phase, num_ants = NumAnts(3))
 
     signal = cis.(
-            2π .* carrier_doppler .* range ./ sample_frequency .+ start_carrier_phase
+            2π .* carrier_doppler .* range ./ sampling_frequency .+ start_carrier_phase
         ) .*
         get_code.(
             GPSL1,
-            code_frequency .* range ./ sample_frequency .+ start_code_phase,
+            code_frequency .* range ./ sampling_frequency .+ start_code_phase,
             prn
         )
     signal_mat = repeat(signal, outer = (1,3))
 
-    @test_throws ArgumentError track(signal_mat', state, prn, sample_frequency)
+    @test_throws ArgumentError track(signal_mat', state, prn, sampling_frequency)
 
-    track_result = @inferred track(signal_mat, state, prn, sample_frequency)
+    track_result = @inferred track(signal_mat, state, prn, sampling_frequency)
 
     iterations = 2000
     code_phases = zeros(iterations)
@@ -232,18 +232,18 @@ end
     tracked_code_dopplers = zeros(iterations)
     tracked_carrier_dopplers = zeros(iterations)
     for i = 1:iterations
-        carrier_phase = mod2pi(2π * carrier_doppler * 4000 * i / sample_frequency +
+        carrier_phase = mod2pi(2π * carrier_doppler * 4000 * i / sampling_frequency +
             start_carrier_phase + π) - π
         code_phase = mod(
-            code_frequency * 4000 * i / sample_frequency + start_code_phase,
+            code_frequency * 4000 * i / sampling_frequency + start_code_phase,
             1023
         )
         signal = cis.(
-                2π .* carrier_doppler .* range ./ sample_frequency .+ carrier_phase
+                2π .* carrier_doppler .* range ./ sampling_frequency .+ carrier_phase
             ) .*
             get_code.(
                 GPSL1,
-                code_frequency .* range ./ sample_frequency .+ code_phase,
+                code_frequency .* range ./ sampling_frequency .+ code_phase,
                 prn
             )
         signal_mat = repeat(signal, outer = (1,3))
@@ -251,12 +251,12 @@ end
             signal_mat,
             get_state(track_result),
             prn,
-            sample_frequency
+            sampling_frequency
         )
         comp_carrier_phase = mod2pi(2π * carrier_doppler * 4000 * (i + 1) /
-            sample_frequency + start_carrier_phase + π) - π
+            sampling_frequency + start_carrier_phase + π) - π
         comp_code_phase = mod(
-            code_frequency * 4000 * (i + 1) / sample_frequency + start_code_phase,
+            code_frequency * 4000 * (i + 1) / sampling_frequency + start_code_phase,
             1023
         )
         tracked_code_phases[i] = get_code_phase(track_result)


### PR DESCRIPTION
All instances of the sampling frequency variable have been renamed from `sample_frequency` to `sampling_frequency`. 

Took care of the comments too.

This reflects the established terminology in signal processing and increases the readability of the code.