### PR TITLE
Correct downconvert and code replica

### DIFF
--- a/src/code_replica.jl
+++ b/src/code_replica.jl
@@ -23,23 +23,35 @@ function gen_code_replica!(
 )
     most_early_sample_shift = correlator_sample_shifts[end]
     most_late_sample_shift  = correlator_sample_shifts[1]
-    num_early_late_samples = most_early_sample_shift - most_late_sample_shift
+    early_late_samples = most_early_sample_shift - most_late_sample_shift
+    code_length = get_code_length(system)
     fixed_point = sizeof(Int) * 8 - 1 - min_bits_for_code_length(system)
     delta = floor(Int, code_frequency * 1 << fixed_point / sampling_frequency)
-    ((most_late_sample_shift * delta) >> fixed_point < -get_code_length(system) ||
-        (most_early_sample_shift * delta) >> fixed_point > get_code_length(system)) &&
-        throw(ArgumentError("The number of taps or the tab spacing is too large."))
     modded_start_code_phase = mod(
-        start_code_phase,
-        get_code_length(system) * get_secondary_code_length(system)
-    )
+        start_code_phase + (most_late_sample_shift - start_sample) * code_frequency/sampling_frequency,
+        code_length * get_secondary_code_length(system)
+        )
     fixed_point_start_code_phase = floor(Int, modded_start_code_phase * 1 << fixed_point)
-    # Assumes, that the number of early shifts is identical to the number of late shifts
-    @inbounds for i = start_sample:num_samples + num_early_late_samples + start_sample - 1
-        fixed_point_code_phase = (i + most_late_sample_shift - start_sample) * delta +
-            fixed_point_start_code_phase
-        code_index = fixed_point_code_phase >> fixed_point
-        code_replica[i] = get_code_unsafe(system, code_index, prn)
+    code_length_fixed_point = code_length << fixed_point
+
+    end_code_phase = modded_start_code_phase + (start_sample + num_samples + early_late_samples) * code_frequency / sampling_frequency
+    number_of_iterations = floor(Int, end_code_phase / code_length)
+    first_iteration = floor(Int, (modded_start_code_phase + start_sample * code_frequency / sampling_frequency) / code_length)
+    fixed_point_code_phase = (start_sample - 1) * delta + fixed_point_start_code_phase - (first_iteration - 1) * code_length_fixed_point
+
+    samples_left = num_samples + early_late_samples
+    for m = first_iteration:number_of_iterations
+        phase_correction = m * code_length_fixed_point
+        number_of_samples = min(samples_left,
+            floor(Int, (2 * code_length_fixed_point - fixed_point_code_phase - delta) / delta)
+        )
+        samples_left -= number_of_samples
+        @inbounds for i = start_sample:start_sample+number_of_samples-1
+            fixed_point_code_phase = i * delta + fixed_point_start_code_phase - phase_correction
+            code_index = fixed_point_code_phase >> fixed_point
+            code_replica[i] = get_code_unsafe(system, code_index, prn)
+        end
+        start_sample += number_of_samples
     end
     code_replica
 end

--- a/src/downconvert.jl
+++ b/src/downconvert.jl
@@ -42,6 +42,6 @@ function downconvert!(
     num_samples::Integer
 )    
     sample_range = start_sample:start_sample + num_samples - 1
-    downconverted_signal[sample_range] .= @view(signal[sample_range]) .* conj.(@view(carrier_replica[sample_range]))
+    downconverted_signal[sample_range,:] .= @view(signal[sample_range,:]) .* conj.(@view(carrier_replica[sample_range]))
     downconverted_signal
 end

--- a/test/code_replica.jl
+++ b/test/code_replica.jl
@@ -1,6 +1,6 @@
 @testset "Code replica" begin
 
-    code = zeros(Int16, 2502)
+    code = zeros(Int8, 2502)
     gpsl1 = GPSL1()
     Tracking.gen_code_replica!(
         code,
@@ -15,6 +15,42 @@
     )
 
     @test code[11:2492] == get_code.(gpsl1, (-1:2480) * 1023e3 / 2.5e6 .+ 2.0, 1)
+
+    @testset "More than 1ms" begin
+        code = zeros(Int8, 6502)
+        gpsl1 = GPSL1()
+        Tracking.gen_code_replica!(
+            code,
+            gpsl1,
+            1023e3,
+            2.5e6,
+            2.0,
+            11,
+            6480,
+            SVector(-1, 0, 1),
+            1
+        )
+
+        @test code[11:6492] == get_code.(gpsl1, (-1:6480) * 1023e3 / 2.5e6 .+ 2.0, 1)
+    end
+
+    @testset "code_length is less than 1ms" begin
+        code = zeros(Int8, 2502)
+        gpsl1 = GPSL1()
+        Tracking.gen_code_replica!(
+            code,
+            gpsl1,
+            1023e3 * 3,
+            7.5e6,
+            2.0,
+            11,
+            2480,
+            SVector(-1, 0, 1),
+            1
+        )
+
+        @test code[11:2492] == get_code.(gpsl1, (-1:2480) * 1023e3 * 3 / 7.5e6 .+ 2.0, 1)
+    end
 end
 
 @testset "Update code phase" begin

--- a/test/downconvert.jl
+++ b/test/downconvert.jl
@@ -1,15 +1,26 @@
 @testset "Downconvert" begin
 
-    downconverted_signal = StructArray{Complex{Int16}}(undef, 2500)
+    downconverted_signal = StructArray{Complex{Float32}}(undef, 2500)
 
     phases = 2π * (1:2500) * 1000 / 2.5e6
-    signal = StructArray{Complex{Int16}}((
-        floor.(Int16, cos.(phases) * 1 << 7),
-        floor.(Int16, sin.(phases) * 1 << 7)
+    signal_struct = StructArray{Complex{Float32}}((
+        Float32.(cos.(phases)),
+        Float32.(sin.(phases))
     ))
 
-    carrier_replica = copy(signal)
+    carrier_replica = copy(signal_struct)
 
+    Tracking.downconvert!(
+        downconverted_signal,
+        signal_struct,
+        carrier_replica,
+        11,
+        2490
+    )
+
+    @test downconverted_signal[11:2500] ≈ signal_struct[11:2500] .* conj(carrier_replica[11:2500])
+    downconverted_signal = StructArray{Complex{Float32}}(undef, 2500)
+    signal = Array(signal_struct)
     Tracking.downconvert!(
         downconverted_signal,
         signal,
@@ -17,23 +28,33 @@
         11,
         2490
     )
-
-    @test signal[11:2500] .* conj(carrier_replica[11:2500]) == downconverted_signal[11:2500]
+    @test downconverted_signal[11:2500] ≈ signal[11:2500] .* conj(carrier_replica[11:2500])
 end
 
 @testset "Downconvert multiple signals" begin
 
-    downconverted_signal = StructArray{Complex{Int16}}(undef, 2500, 3)
+    downconverted_signal = StructArray{Complex{Float32}}(undef, 2500, 3)
 
     phases = 2π * (1:2500) * 1000 / 2.5e6
-    signal = StructArray{Complex{Int16}}((
-        floor.(Int16, cos.(phases) * 1 << 7),
-        floor.(Int16, sin.(phases) * 1 << 7)
+    signal = StructArray{Complex{Float32}}((
+        Float32.(cos.(phases)),
+        Float32.(sin.(phases))
     ))
-    signal_mat = repeat(signal, outer = (1,3))
+    signal_mat_struct = repeat(signal, outer = (1,3))
 
     carrier_replica = copy(signal)
 
+    Tracking.downconvert!(
+        downconverted_signal,
+        signal_mat_struct,
+        carrier_replica,
+        11,
+        2490
+    )
+
+    @test downconverted_signal[11:2500,:] ≈ signal_mat_struct[11:2500,:] .* conj(carrier_replica[11:2500])
+    downconverted_signal = StructArray{Complex{Float32}}(undef, 2500, 3)
+    signal_mat = Array(signal_mat_struct)
     Tracking.downconvert!(
         downconverted_signal,
         signal_mat,
@@ -42,6 +63,5 @@ end
         2490
     )
 
-    @test signal_mat[11:2500,:] .* conj(carrier_replica[11:2500]) ==
-        downconverted_signal[11:2500,:]
+    @test downconverted_signal[11:2500,:] ≈ signal_mat[11:2500,:] .* conj(carrier_replica[11:2500])
 end


### PR DESCRIPTION
This pull request will fix downconvert for multiple antennas, if the incoming signal is a regular complex array.
It will also fix the code replica, if more than 1ms is tracked or if the code length is less than 1ms.

There is an error in one sample of the code when testing:
```
code = zeros(Int8, 2502)
    gpsl1 = GPSL1()
    Tracking.gen_code_replica!(
        code,
        gpsl1,
        1023e3 * 2,
        7.5e6,
        2.0,
        11,
        2480,
        SVector(-1, 0, 1),
        1
    )

@test code[11:2492] == get_code.(gpsl1, (-1:2480) * 1023e3 * 2 / 7.5e6 .+ 2.0, 1)
```
But this might be due to round off errors of the float representation.
In the tests I used `1023e3 * 3` and that works fine