### PR TITLE
Fix bugs in new correlator implementation

### DIFF
--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -15,7 +15,7 @@ module Tracking
         get_late,
         get_correlator,
         get_accumulators,
-        get_num_correlators,
+        get_num_accumulators,
         get_early_index,
         get_prompt_index,
         get_late_index,

--- a/src/correlator.jl
+++ b/src/correlator.jl
@@ -37,8 +37,8 @@ $(SIGNATURES)
 EarlyPromptLateCorrelator constructor for large number of accumulators.
 """
 function EarlyPromptLateCorrelator(
-    num_accumulators::Integer,
-    num_ants = NumAnts(1)
+    num_ants::NumAnts,
+    num_accumulators::Integer
 )
     EarlyPromptLateCorrelator(
         [zero(type_for_num_ants(num_ants)) for i = 1:num_accumulators]
@@ -303,7 +303,7 @@ function correlate(
             code
         )
     end
-    
+
     typeof(correlator)(map(+, get_accumulators(correlator), accumulators))
 end
 


### PR DESCRIPTION
The recently merged correlator changes missed to rename the export of `get_num_correlators` to `get_num_accumulators`. Besides that, the argument order of `EarlyPromptLateCorrelator` was changed to be consistent over the different parameter types.