### PR TITLE
Speculative: Move PRN to TrackingState

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 DocStringExtensions = "0.6, 0.7, 0.8"
-GNSSSignals = "0.15.3"
+GNSSSignals = "0.15.3, 0.16"
 LoopVectorization = "0.8, 0.9, 0.10, 0.11, 0.12"
 StaticArrays = "0.9, 0.10, 0.11, 0.12, 1.0"
 StructArrays = "0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 DocStringExtensions = "0.6, 0.7, 0.8"
-GNSSSignals = "0.15.3, 0.16"
+GNSSSignals = "0.15.3"
 LoopVectorization = "0.8, 0.9, 0.10, 0.11, 0.12"
 StaticArrays = "0.9, 0.10, 0.11, 0.12, 1.0"
 StructArrays = "0.4"

--- a/src/tracking_loop.jl
+++ b/src/tracking_loop.jl
@@ -20,7 +20,6 @@ Track the signal `signal` based on the current tracking `state`, the sampling fr
 function track(
         signal,
         state::TrackingState{S, C, CALF, COLF, CN, DS, CAR, COR},
-        prn::Integer,
         sampling_frequency;
         post_corr_filter = get_default_post_corr_filter(get_correlator(state)),
         intermediate_frequency = 0.0Hz,
@@ -43,6 +42,7 @@ function track(
     CAR,
     COR
 }
+    prn = get_prn(state)
     system = get_system(state)
     if get_data_frequency(system) != 0Hz
         @assert rem(1 / get_data_frequency(system), max_integration_time) == 0ms
@@ -191,6 +191,7 @@ function track(
         signal_start_sample += num_samples_left
     end
     next_state = TrackingState{S, C, CALF, COLF, CN, DS, CAR, COR}(
+        prn,
         system,
         init_carrier_doppler,
         init_code_doppler,

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -67,6 +67,7 @@ struct TrackingState{
         CAR <: CarrierReplicaCPU, # Union{CarrierReplicaCPU, CuArray{ComplexF32}}
         COR <: Vector{Int8}, # Union{Vector{Int8}, CuArray{Float32}}
     }
+    prn::Int
     system::S
     init_carrier_doppler::typeof(1.0Hz)
     init_code_doppler::typeof(1.0Hz)
@@ -103,6 +104,7 @@ carrier doppler `carrier_doppler` and the code phase `code_phase`. Optional para
 - CN0 estimator `cn0_estimator`, that defaults to `MomentsCN0Estimator(20)`
 """
 function TrackingState(
+    prn::Integer,
     system::S,
     carrier_doppler,
     code_phase;
@@ -134,6 +136,7 @@ function TrackingState(
     code = Vector{Int8}(undef, 0)
 
     TrackingState{S, C, CALF, COLF, CN, typeof(downconverted_signal), typeof(carrier), typeof(code)}(
+        prn,
         system,
         carrier_doppler,
         code_doppler,
@@ -171,3 +174,4 @@ end
 @inline get_downconverted_signal(state::TrackingState) = state.downconverted_signal
 @inline get_carrier(state::TrackingState) = state.carrier
 @inline get_code(state::TrackingState) = state.code
+@inline get_prn(state::TrackingState) = state.prn

--- a/test/tracking_loop.jl
+++ b/test/tracking_loop.jl
@@ -155,7 +155,7 @@ end
     prn = 1
     range = 0:3999
     start_carrier_phase = π / 2
-    state = TrackingState(gpsl1, carrier_doppler - 20Hz, start_code_phase)
+    state = TrackingState(prn, gpsl1, carrier_doppler - 20Hz, start_code_phase)
 
     signal_temp = cis.(
             2π .* carrier_doppler .* range ./ sampling_frequency .+ start_carrier_phase
@@ -168,7 +168,7 @@ end
     scaling = 512
     signal = type <: Integer ? complex.(floor.(type, real.(signal_temp) * scaling), floor.(type, imag.(signal_temp) * scaling)) : Complex{type}.(signal_temp)
 
-    track_result = @inferred track(signal, state, prn, sampling_frequency)
+    track_result = @inferred track(signal, state, sampling_frequency)
 
     iterations = 2000
     code_phases = zeros(iterations)
@@ -196,7 +196,6 @@ end
         track_result = @inferred track(
             signal,
             get_state(track_result),
-            prn,
             sampling_frequency
         )
         comp_carrier_phase = mod2pi(2π * carrier_doppler * 4000 * (i + 1) /
@@ -242,7 +241,7 @@ end
     prn = 1
     range = 0:3999
     start_carrier_phase = π / 2
-    state = TrackingState(gpsl1, carrier_doppler - 20Hz, start_code_phase, num_ants = NumAnts(3))
+    state = TrackingState(prn, gpsl1, carrier_doppler - 20Hz, start_code_phase, num_ants = NumAnts(3))
 
     signal = cis.(
             2π .* carrier_doppler .* range ./ sampling_frequency .+ start_carrier_phase
@@ -256,9 +255,9 @@ end
     scaling = 512
     signal_mat = type <: Integer ? complex.(floor.(type, real.(signal_mat_temp) * scaling), floor.(type, imag.(signal_mat_temp) * scaling)) : Complex{type}.(signal_mat_temp)
 
-    @test_throws ArgumentError track(signal_mat', state, prn, sampling_frequency)
+    @test_throws ArgumentError track(signal_mat', state, sampling_frequency)
 
-    track_result = @inferred track(signal_mat, state, prn, sampling_frequency)
+    track_result = @inferred track(signal_mat, state, sampling_frequency)
 
     iterations = 2000
     code_phases = zeros(iterations)
@@ -286,7 +285,6 @@ end
         track_result = @inferred track(
             signal_mat,
             get_state(track_result),
-            prn,
             sampling_frequency
         )
         comp_carrier_phase = mod2pi(2π * carrier_doppler * 4000 * (i + 1) /

--- a/test/tracking_results.jl
+++ b/test/tracking_results.jl
@@ -1,7 +1,7 @@
 @testset "Tracking results" begin
     gpsl1 = GPSL1()
     results = Tracking.TrackingResults(
-        TrackingState(gpsl1, 100Hz, 100),
+        TrackingState(1, gpsl1, 100Hz, 100),
         EarlyPromptLateCorrelator(NumAnts(2)),
         SVector(-1, 0, 1),
         1,
@@ -31,7 +31,7 @@
     @test @inferred(get_cn0(results)) == 45dBHz
 
     results = Tracking.TrackingResults(
-        TrackingState(gpsl1, 100Hz, 100),
+        TrackingState(1, gpsl1, 100Hz, 100),
         EarlyPromptLateCorrelator(NumAnts(2)),
         SVector(-1, 0, 1),
         1,

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -3,8 +3,9 @@
     carrier_doppler = 100Hz
     code_phase = 100
     gpsl1 = GPSL1()
-    state = TrackingState(gpsl1, carrier_doppler, code_phase)
+    state = TrackingState(1, gpsl1, carrier_doppler, code_phase)
 
+    @test @inferred(Tracking.get_prn(state)) == 1
     @test @inferred(Tracking.get_code_phase(state)) == 100
     @test @inferred(Tracking.get_carrier_phase(state)) == 0.0
     @test @inferred(Tracking.get_init_code_doppler(state)) == 100Hz / 1540
@@ -19,6 +20,7 @@
     @test @inferred(Tracking.get_integrated_samples(state)) == 0
 
     state = TrackingState(
+        1,
         gpsl1,
         carrier_doppler,
         code_phase;
@@ -32,6 +34,7 @@
         prompt_accumulator = zero(ComplexF64)
     )
 
+    @test @inferred(Tracking.get_prn(state)) == 1
     @test @inferred(Tracking.get_code_phase(state)) == 100
     @test @inferred(Tracking.get_carrier_phase(state)) == 0.0
     @test @inferred(Tracking.get_init_code_doppler(state)) == 100Hz / 1540
@@ -45,7 +48,7 @@
     @test @inferred(Tracking.get_prompt_accumulator(state)) == 0.0
     @test @inferred(Tracking.get_integrated_samples(state)) == 0
 
-    state = TrackingState(gpsl1, carrier_doppler, code_phase, num_ants = NumAnts(2))
+    state = TrackingState(1, gpsl1, carrier_doppler, code_phase, num_ants = NumAnts(2))
     @test @inferred(Tracking.get_correlator(state)) == EarlyPromptLateCorrelator(NumAnts(2))
 
 end


### PR DESCRIPTION
This moves the PRN to the TrackingState struct.
The PRN was previously passed to the `track` function.
Reason: The `track` function should get parameters, that could change with each function call?! However, it doesn't make sense to change the PRN after consecutive function calls.
@dominformant what do you think? Unfortunately this is a breaking change. Do you think it is worth it?