### PR TITLE
Allow image band processing

### DIFF
--- a/src/tracking_loop.jl
+++ b/src/tracking_loop.jl
@@ -166,7 +166,8 @@ function track(
                 init_code_doppler,
                 carrier_freq_update,
                 code_freq_update,
-                velocity_aiding
+                velocity_aiding,
+                get_image_band(state)
             )
             cn0_estimator = update(
                 cn0_estimator,
@@ -197,6 +198,7 @@ function track(
     next_state = TrackingState{S, C, CALF, COLF, CN, DS, CAR, COR}(
         prn,
         system,
+        state.image_band,
         init_carrier_doppler,
         init_code_doppler,
         carrier_doppler,
@@ -454,10 +456,11 @@ function aid_dopplers(
     init_code_doppler,
     carrier_freq_update,
     code_freq_update,
-    velocity_aiding
+    velocity_aiding,
+    image_band = false
 )
     carrier_doppler = carrier_freq_update + velocity_aiding
-    code_doppler = code_freq_update + carrier_doppler * get_code_center_frequency_ratio(system)
+    code_doppler = code_freq_update + (1 - 2image_band) * carrier_doppler * get_code_center_frequency_ratio(system)
     init_carrier_doppler + carrier_doppler, init_code_doppler + code_doppler
 end
 

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -67,6 +67,7 @@ struct TrackingState{
     }
     prn::Int
     system::S
+    image_band::Bool
     init_carrier_doppler::typeof(1.0Hz)
     init_code_doppler::typeof(1.0Hz)
     carrier_doppler::typeof(1.0Hz)
@@ -106,7 +107,8 @@ function TrackingState(
     system::S,
     carrier_doppler,
     code_phase;
-    code_doppler = carrier_doppler * get_code_center_frequency_ratio(system),
+    image_band = false,
+    code_doppler = (1 - 2image_band) * carrier_doppler * get_code_center_frequency_ratio(system),
     carrier_phase = 0.0,
     carrier_loop_filter::CALF = ThirdOrderBilinearLF(),
     code_loop_filter::COLF = SecondOrderBilinearLF(),
@@ -138,6 +140,7 @@ function TrackingState(
     TrackingState{S, C, CALF, COLF, CN, typeof(downconverted_signal), typeof(carrier), typeof(code)}(
         prn,
         system,
+        image_band,
         carrier_doppler,
         code_doppler,
         carrier_doppler,
@@ -164,7 +167,8 @@ function TrackingState(
     carrier_doppler,
     code_phase;
     num_samples,
-    code_doppler = carrier_doppler * get_code_center_frequency_ratio(system),
+    image_band = false,
+    code_doppler = (1 - 2image_band) * carrier_doppler * get_code_center_frequency_ratio(system),
     carrier_phase = 0.0,
     carrier_loop_filter::CALF = ThirdOrderBilinearLF(),
     code_loop_filter::COLF = SecondOrderBilinearLF(),
@@ -195,6 +199,7 @@ function TrackingState(
     TrackingState{S, C, CALF, COLF, CN, Nothing, Nothing, Nothing}(
         prn,
         system,
+        image_band,
         carrier_doppler,
         code_doppler,
         carrier_doppler,
@@ -242,3 +247,4 @@ end
 @inline get_carrier(state::TrackingState) = state.carrier
 @inline get_code(state::TrackingState) = state.code
 @inline get_prn(state::TrackingState) = state.prn
+@inline get_image_band(state::TrackingState) = state.image_band

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -6,6 +6,7 @@
     state = TrackingState(1, gpsl1, carrier_doppler, code_phase)
 
     @test @inferred(Tracking.get_prn(state)) == 1
+    @test @inferred(Tracking.get_image_band(state)) == false
     @test @inferred(Tracking.get_code_phase(state)) == 100
     @test @inferred(Tracking.get_carrier_phase(state)) == 0.0
     @test @inferred(Tracking.get_init_code_doppler(state)) == 100Hz / 1540
@@ -35,6 +36,7 @@
     )
 
     @test @inferred(Tracking.get_prn(state)) == 1
+    @test @inferred(Tracking.get_image_band(state)) == false
     @test @inferred(Tracking.get_code_phase(state)) == 100
     @test @inferred(Tracking.get_carrier_phase(state)) == 0.0
     @test @inferred(Tracking.get_init_code_doppler(state)) == 100Hz / 1540
@@ -66,4 +68,7 @@
     @test @inferred(Tracking.get_code_loop_filter(state)) == SecondOrderBilinearLF()
     @test @inferred(Tracking.get_prompt_accumulator(state)) == 0.0
     @test @inferred(Tracking.get_integrated_samples(state)) == 0
+
+    state = TrackingState(1, GPSL1(), 100Hz, 0.0; image_band = true)
+    @test @inferred(Tracking.get_code_doppler(state)) == -100Hz / 1540
 end


### PR DESCRIPTION
Added a parameter to `TrackingState` in order to process signals recorded in image bands resulting in a sign change between carrier and code doppler.