### PR TITLE
feat: add possibility to inject a post process

### DIFF
--- a/src/track.jl
+++ b/src/track.jl
@@ -46,11 +46,14 @@ function track(
         )
         system_sats_states =
             update(system_sats_states, dopplers_and_prompts, sat_sample_params)
+        track_state = TrackState(
+            track_state.post_process,
+            system_sats_states,
+            doppler_estimator,
+            track_state.downconvert_and_correlator,
+            track_state.num_samples,
+        )
+        track_state = post_process(track_state)
     end
-    TrackState(
-        system_sats_states,
-        doppler_estimator,
-        track_state.downconvert_and_correlator,
-        track_state.num_samples,
-    )
+    return track_state
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,6 @@ using TrackingLoopFilters
 using Acquisition: AcquisitionResults
 using Unitful: MHz, kHz, Hz, s, ms, dBHz
 
-#=
 include("conventional_pll_and_dll.jl")
 include("sat_state.jl")
 include("sample_parameters.jl")
@@ -27,7 +26,6 @@ include("galileo_e1b.jl")
 include("secondary_code_or_bit_detector.jl")
 include("bit_buffer.jl")
 include("correlator.jl")
-=#
 include("cn0_estimation.jl")
-#include("tracking_state.jl")
-#include("track.jl")
+include("tracking_state.jl")
+include("track.jl")


### PR DESCRIPTION
This commit adds the possibility to inject a post process after each integration process. This could for example be used to inject a complete position, velocity and time estimation into the tracking function.