### PR TITLE
fix: detect secondary code or bit before bits are buffered

### DIFF
--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -104,15 +104,15 @@ function estimate_dopplers_and_filter_prompt(
                 filtered_correlator = apply(post_corr_filter, normalized_correlator)
                 prompt = get_prompt(filtered_correlator)
                 cn0_estimator = update(get_cn0_estimator(sat_state), prompt)
+                sc_bit_detector =
+                    find(system_sats_state.system, sat_state.sc_bit_detector, prompt)
                 bit_buffer = buffer(
                     system_sats_state.system,
                     sat_state.bit_buffer,
                     integrated_code_blocks,
-                    found(sat_state.sc_bit_detector), # TODO: should the detector be updated before this?
+                    found(sc_bit_detector),
                     prompt,
                 )
-                sc_bit_detector =
-                    find(system_sats_state.system, sat_state.sc_bit_detector, prompt)
                 integration_time = sat_state.integrated_samples / sampling_frequency
                 pll_discriminator =
                     pll_disc(system_sats_state.system, filtered_correlator)


### PR DESCRIPTION
Secondary code or bit should be detected before bits are buffered.