### PR TITLE
ci(semantic-release): add workflow for semantic releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,31 @@
+---
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          semantic_version: 23.0.2
+          extends: |
+            @ethima/semantic-release-configuration
+          extra_plugins: |
+            @ethima/semantic-release-configuration
+      - name: Notify JuliaRegistrator of new release
+        uses: peter-evans/commit-comment@v3
+        if: steps.semantic-release.outputs.new_release_published == 'true'
+        with:
+          body: '@JuliaRegistrator register branch=${{ steps.semantic-release.outputs.new_release_git_tag }}'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGNSS.github.io/Tracking.jl/dev)
 [![DOI](https://zenodo.org/badge/171484097.svg)](https://zenodo.org/badge/latestdoi/171484097)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaGNSS/Tracking.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaGNSS/Tracking.jl?branch=master)
+[![[Semantic Release]](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 # Tracking
 This package implements the tracking functionality of GNSS satellites that's part of the larger GNSS receiver.


### PR DESCRIPTION
This enables an automatic release workflow as soon as a commit is merged into master. The commit message determines what kind of release is created patch / minor / major or also known as fix / feature / breaking.
Have a look into https://www.conventionalcommits.org/en/v1.0.0/ for further reference.
From now on the commit message needs to start with a conventional commit type, e.g. `fix:` will create a fix release `feat:` a feature release. If you don't want to bump the release version you can use `refactor:`, but there is also `ci:`, `docs:`, `build:`, `chore:` and some others.
Also see https://github.com/jaantollander/SemanticReleaseExample.jl