### PR TITLE
ci(semanitc-release): use personal access token

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v5
         id: semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
           RUNNER_DEBUG: 1
         with:
           branches: |


### PR DESCRIPTION
Semantic release needs personal access token when master branch is protected.