### PR TITLE
fix: use Threads.maxthreadid() instead of Threads.nthreads()

### DIFF
--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -28,7 +28,7 @@ end
 
 function CPUThreadedDownconvertAndCorrelator(
     ::Val{MESF};
-    nthreads::Int = Threads.nthreads(),
+    nthreads::Int = Threads.maxthreadid(),
 ) where {MESF}
     buffers = [SlabBuffer() for _ = 1:nthreads]
     CPUThreadedDownconvertAndCorrelator{MESF}(buffers)


### PR DESCRIPTION
## Summary
- Replace `Threads.nthreads()` with `Threads.maxthreadid()` in `CPUThreadedDownconvertAndCorrelator` default argument
- `Threads.nthreads()` returns only the default thread pool size, which can be less than the actual number of thread IDs when interactive threads are enabled, leading to insufficient buffer allocation
- `Threads.maxthreadid()` returns the correct upper bound for thread IDs

## Test plan
- [x] Verify existing tests pass with the change
- [x] Test with Julia started with interactive threads (`--threads=auto,auto`) to confirm correct buffer count

🤖 Generated with [Claude Code](https://claude.com/claude-code)