### PR TITLE
Add benchmark Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /Manifest.toml
 test/Manifest.toml
 ext/**/test/Manifest.toml
+benchmark/Manifest.toml
 
 docs/build/
 docs/pdf/build/

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Tracking = "10b2438b-ffd4-5096-aa58-44041d5c8f3b"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"


### PR DESCRIPTION
## Summary
- Add `benchmark/Project.toml` with all dependencies needed by `benchmarks.jl` (BenchmarkTools, GNSSSignals, StaticArrays, Tracking, Unitful)
- Add `benchmark/Manifest.toml` to `.gitignore`

## Test plan
- [x] `julia -t 8 --project=benchmark -e 'include("benchmark/benchmarks.jl"); run(SUITE; verbose=true, seconds=3)'` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)