### PR TITLE
feat(pll_and_dll): support per-satellite loop filter bandwidths

### DIFF
--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -29,18 +29,24 @@ Holds initial Doppler values and loop filter states.
     init_code_doppler::typeof(1.0Hz)
     carrier_loop_filter::CA = ThirdOrderBilinearLF()
     code_loop_filter::CO = SecondOrderBilinearLF()
+    carrier_loop_filter_bandwidth::typeof(1.0Hz) = 18.0Hz
+    code_loop_filter_bandwidth::typeof(1.0Hz) = 1.0Hz
 end
 
 function SatConventionalPLLAndDLL(
     sat_state::SatState,
     carrier_loop_filter::CA,
-    code_loop_filter::CO,
+    code_loop_filter::CO;
+    carrier_loop_filter_bandwidth::typeof(1.0Hz) = 18.0Hz,
+    code_loop_filter_bandwidth::typeof(1.0Hz) = 1.0Hz,
 ) where {CA<:AbstractLoopFilter,CO<:AbstractLoopFilter}
     SatConventionalPLLAndDLL(
         sat_state.carrier_doppler,
         sat_state.code_doppler,
         carrier_loop_filter,
         code_loop_filter,
+        carrier_loop_filter_bandwidth,
+        code_loop_filter_bandwidth,
     )
 end
 
@@ -48,6 +54,8 @@ function SatConventionalPLLAndDLL(
     sat_conventional_pll_and_dll::SatConventionalPLLAndDLL{CA,CO};
     carrier_loop_filter::Maybe{CA} = nothing,
     code_loop_filter::Maybe{CO} = nothing,
+    carrier_loop_filter_bandwidth::Maybe{typeof(1.0Hz)} = nothing,
+    code_loop_filter_bandwidth::Maybe{typeof(1.0Hz)} = nothing,
 ) where {CA<:AbstractLoopFilter,CO<:AbstractLoopFilter}
     SatConventionalPLLAndDLL{CA,CO}(
         sat_conventional_pll_and_dll.init_carrier_doppler,
@@ -56,6 +64,12 @@ function SatConventionalPLLAndDLL(
         carrier_loop_filter,
         isnothing(code_loop_filter) ? sat_conventional_pll_and_dll.code_loop_filter :
         code_loop_filter,
+        isnothing(carrier_loop_filter_bandwidth) ?
+        sat_conventional_pll_and_dll.carrier_loop_filter_bandwidth :
+        carrier_loop_filter_bandwidth,
+        isnothing(code_loop_filter_bandwidth) ?
+        sat_conventional_pll_and_dll.code_loop_filter_bandwidth :
+        code_loop_filter_bandwidth,
     )
 end
 
@@ -115,7 +129,10 @@ function ConventionalPLLAndDLL(
 ) where {CA<:AbstractLoopFilter,CO<:AbstractLoopFilter}
     states = map(multiple_system_sats_state) do system_sats_state
         map(system_sats_state.states) do sat_state
-            SatConventionalPLLAndDLL(sat_state, CA(), CO())
+            SatConventionalPLLAndDLL(
+                sat_state, CA(), CO();
+                carrier_loop_filter_bandwidth, code_loop_filter_bandwidth,
+            )
         end
     end
     ConventionalPLLAndDLL(states; carrier_loop_filter_bandwidth, code_loop_filter_bandwidth)
@@ -185,6 +202,8 @@ function merge_sats(
             sat_state.code_doppler,
             constructorof(CA)(),
             constructorof(CO)(),
+            pll_and_dll.carrier_loop_filter_bandwidth,
+            pll_and_dll.code_loop_filter_bandwidth,
         )
     end
     @set pll_and_dll.states[system_idx] =
@@ -282,7 +301,7 @@ function estimate_dopplers_and_filter_prompt(
                     filtered_correlator,
                     get_last_fully_integrated_filtered_prompt(sat_state),
                     integration_time,
-                    track_state.doppler_estimator.carrier_loop_filter_bandwidth,
+                    pll_and_dll_state.carrier_loop_filter_bandwidth,
                 )
             code_freq_update, code_loop_filter = calculate_code_frequency_update(
                 system_sats_state.system,
@@ -291,7 +310,7 @@ function estimate_dopplers_and_filter_prompt(
                 sat_state.code_doppler,
                 sampling_frequency,
                 integration_time,
-                track_state.doppler_estimator.code_loop_filter_bandwidth,
+                pll_and_dll_state.code_loop_filter_bandwidth,
             )
             carrier_doppler, code_doppler = aid_dopplers(
                 system_sats_state.system,

--- a/test/conventional_pll_and_dll.jl
+++ b/test/conventional_pll_and_dll.jl
@@ -5,6 +5,7 @@ using Unitful: Hz
 using GNSSSignals: GPSL1, get_code_center_frequency_ratio
 using TrackingLoopFilters: ThirdOrderBilinearLF, SecondOrderBilinearLF
 using StaticArrays: SVector
+using Dictionaries: Dictionary
 using Tracking:
     aid_dopplers,
     SatConventionalPLLAndDLL,
@@ -18,7 +19,9 @@ using Tracking:
     get_code_doppler,
     get_last_fully_integrated_filtered_prompt,
     update_accumulator,
-    get_default_correlator
+    get_default_correlator,
+    get_sat_state,
+    merge_sats
 
 @testset "Doppler aiding" begin
     gpsl1 = GPSL1()
@@ -49,6 +52,33 @@ end
     @test pll_and_dll.init_code_doppler == 100.0Hz
     @test pll_and_dll.carrier_loop_filter == ThirdOrderBilinearLF()
     @test pll_and_dll.code_loop_filter == SecondOrderBilinearLF()
+    @test pll_and_dll.carrier_loop_filter_bandwidth == 18.0Hz
+    @test pll_and_dll.code_loop_filter_bandwidth == 1.0Hz
+
+    gpsl1 = GPSL1()
+    sat_state = SatState(gpsl1, 1, 0.5, 100.0Hz)
+    from_sat_state = @inferred SatConventionalPLLAndDLL(
+        sat_state,
+        ThirdOrderBilinearLF(),
+        SecondOrderBilinearLF();
+        carrier_loop_filter_bandwidth = 25.0Hz,
+        code_loop_filter_bandwidth = 2.0Hz,
+    )
+    @test from_sat_state.carrier_loop_filter_bandwidth == 25.0Hz
+    @test from_sat_state.code_loop_filter_bandwidth == 2.0Hz
+
+    # Update-from-existing constructor preserves bandwidth when not overridden,
+    # and overrides when provided.
+    preserved = @inferred SatConventionalPLLAndDLL(from_sat_state)
+    @test preserved.carrier_loop_filter_bandwidth == 25.0Hz
+    @test preserved.code_loop_filter_bandwidth == 2.0Hz
+
+    overridden = @inferred SatConventionalPLLAndDLL(
+        from_sat_state;
+        carrier_loop_filter_bandwidth = 30.0Hz,
+    )
+    @test overridden.carrier_loop_filter_bandwidth == 30.0Hz
+    @test overridden.code_loop_filter_bandwidth == 2.0Hz
 end
 
 @testset "Conventional PLL and DLL" begin
@@ -112,6 +142,106 @@ end
     @test get_last_fully_integrated_filtered_prompt(
         new_track_state_after_full_integration,
     ) == 0.4 + 0.004im
+end
+
+@testset "Per-satellite bandwidths drive the loop filters" begin
+    sampling_frequency = 5e6Hz
+    gpsl1 = GPSL1()
+    carrier_doppler = 100.0Hz
+    code_phase = 0.5
+    preferred_num_code_blocks_to_integrate = 1
+    num_samples = 5000
+    correlator = update_accumulator(
+        get_default_correlator(gpsl1),
+        SVector(1000.0 + 10im, 2000.0 + 20im, 750.0 + 10im),
+    )
+
+    # Two sats, both fully integrated with the same correlator: any difference
+    # in the Doppler update must come from per-sat bandwidths.
+    sat1_initial = SatState(gpsl1, 1, code_phase, carrier_doppler)
+    sat2_initial = SatState(gpsl1, 2, code_phase, carrier_doppler)
+    sat1 = SatState(
+        sat1_initial;
+        is_integration_completed = true,
+        integrated_samples = num_samples,
+        correlator,
+    )
+    sat2 = SatState(
+        sat2_initial;
+        is_integration_completed = true,
+        integrated_samples = num_samples,
+        correlator,
+    )
+    system_sats_state = (SystemSatsState(gpsl1, [sat1, sat2]),)
+
+    # Build a doppler estimator, then bump sat2's bandwidths via the
+    # update-from-existing constructor.
+    base_estimator = ConventionalPLLAndDLL(system_sats_state)
+    per_sat_states = only(base_estimator.states)
+    sat2_state_wide = SatConventionalPLLAndDLL(
+        per_sat_states[2];
+        carrier_loop_filter_bandwidth = 36.0Hz,
+        code_loop_filter_bandwidth = 2.0Hz,
+    )
+    new_sat_states = (Dictionary(
+        [1, 2], [per_sat_states[1], sat2_state_wide],
+    ),)
+    doppler_estimator = ConventionalPLLAndDLL(base_estimator, new_sat_states)
+
+    @test doppler_estimator.states[1][1].carrier_loop_filter_bandwidth == 18.0Hz
+    @test doppler_estimator.states[1][2].carrier_loop_filter_bandwidth == 36.0Hz
+    @test doppler_estimator.states[1][2].code_loop_filter_bandwidth == 2.0Hz
+
+    track_state = TrackState(
+        gpsl1, [sat1, sat2]; doppler_estimator,
+    )
+    new_track_state = @inferred estimate_dopplers_and_filter_prompt(
+        track_state,
+        preferred_num_code_blocks_to_integrate,
+        sampling_frequency,
+    )
+
+    # Sat 1 matches the baseline result from the previous testset.
+    @test get_carrier_doppler(new_track_state, 1) == 100.52615628464486Hz
+    @test get_code_doppler(new_track_state, 1) == -0.16073504885813858Hz
+
+    # Sat 2 has different bandwidths so must produce a different update.
+    @test get_carrier_doppler(new_track_state, 2) != get_carrier_doppler(new_track_state, 1)
+    @test get_code_doppler(new_track_state, 2) != get_code_doppler(new_track_state, 1)
+end
+
+@testset "Bandwidths propagate through ConventionalPLLAndDLL constructor" begin
+    gpsl1 = GPSL1()
+    sat_state = SatState(gpsl1, 1, 0.5, 100.0Hz)
+    system_sats_state = (SystemSatsState(gpsl1, sat_state),)
+
+    estimator = ConventionalPLLAndDLL(
+        system_sats_state;
+        carrier_loop_filter_bandwidth = 22.0Hz,
+        code_loop_filter_bandwidth = 1.5Hz,
+    )
+    @test estimator.carrier_loop_filter_bandwidth == 22.0Hz
+    @test estimator.code_loop_filter_bandwidth == 1.5Hz
+    # Per-sat entries inherit the estimator-level bandwidths.
+    @test only(estimator.states[1]).carrier_loop_filter_bandwidth == 22.0Hz
+    @test only(estimator.states[1]).code_loop_filter_bandwidth == 1.5Hz
+end
+
+@testset "merge_sats propagates bandwidths to new sats" begin
+    gpsl1 = GPSL1()
+    sat1 = SatState(gpsl1, 1, 0.5, 100.0Hz)
+    system_sats_state = (SystemSatsState(gpsl1, sat1),)
+    estimator = ConventionalPLLAndDLL(
+        system_sats_state;
+        carrier_loop_filter_bandwidth = 22.0Hz,
+        code_loop_filter_bandwidth = 1.5Hz,
+    )
+
+    sat2 = SatState(gpsl1, 2, 0.25, 200.0Hz)
+    merged = merge_sats(estimator, 1, Dictionary([2], [sat2]))
+
+    @test merged.states[1][2].carrier_loop_filter_bandwidth == 22.0Hz
+    @test merged.states[1][2].code_loop_filter_bandwidth == 1.5Hz
 end
 
 end


### PR DESCRIPTION
## Summary
- Move carrier and code loop filter bandwidths from `ConventionalPLLAndDLL` onto each `SatConventionalPLLAndDLL`, so every satellite can use its own values.
- The estimator-level bandwidths stay as defaults that seed per-sat entries when building a `ConventionalPLLAndDLL` and when `merge_sats` adds new satellites.
- `estimate_dopplers_and_filter_prompt` now reads bandwidths from the per-sat state instead of the shared estimator.

## Test plan
- [x] `test/conventional_pll_and_dll.jl` — existing tests still pass (defaults preserved at 18 Hz / 1 Hz).
- [x] New testset "Per-satellite bandwidths drive the loop filters": two sats with identical state but different bandwidths produce different Doppler updates.
- [x] New testset "Bandwidths propagate through ConventionalPLLAndDLL constructor".
- [x] New testset "merge_sats propagates bandwidths to new sats".
- [x] Extended "Satellite Conventional PLL and DLL" to cover the new `SatState`-based and update-from-existing constructors (preserve + override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)