### PR TITLE
ci: stop double-caching the Flexiband capture; make integration test opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,13 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      # The Flexiband integration test downloads a 1.6 GB capture. Run it on a
-      # single job (Linux / Julia 1) and skip it elsewhere, so the matrix stays
-      # fast and the download is cached once for one OS instead of three. The
-      # test passes on Linux/macOS/Windows; ongoing CI only needs one of them.
-      TRACKING_SKIP_INTEGRATION_TEST: ${{ !(matrix.os == 'ubuntu-latest' && matrix.version == '1') }}
+      # The Flexiband integration test downloads a 1.6 GB capture. It is
+      # opt-in (skipped unless this is "true"), so a plain local `]test` never
+      # triggers the download. Run it on a single job (Linux / Julia 1), so
+      # the matrix stays fast and the download is cached once for one OS
+      # instead of three. The test passes on Linux/macOS/Windows; ongoing CI
+      # only needs one of them.
+      TRACKING_RUN_INTEGRATION_TEST: ${{ matrix.os == 'ubuntu-latest' && matrix.version == '1' }}
     strategy:
       matrix:
         version:
@@ -33,7 +35,14 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
+      # cache-scratchspaces is disabled because the only scratchspace content
+      # is the 1.6 GB Flexiband capture, which the dedicated fixed-key cache
+      # step below already pins. julia-actions/cache uses a per-run key, so it
+      # would re-upload the capture on every run and double-store it against
+      # the 10 GB repo cache limit.
       - uses: julia-actions/cache@v3
+        with:
+          cache-scratchspaces: 'false'
       # Cache the 1.6 GB Flexiband capture that the integration test downloads
       # into Tracking's Scratch.jl scratchspace, so it is fetched once and
       # reused across runs instead of re-downloaded on every job. The key is

--- a/test/flexiband_integration_test.jl
+++ b/test/flexiband_integration_test.jl
@@ -9,9 +9,11 @@ module FlexibandIntegrationTest
 # GPS L5I (on the L5 band) — exercising the multi-band `track!` path with two
 # front-ends running at different sample rates.
 #
-# The 1.6 GB zip is cached in a Scratch.jl scratchspace so it is only
-# downloaded once. Set `ENV["TRACKING_SKIP_INTEGRATION_TEST"] = "true"` to
-# skip the whole file (e.g. on a network-less machine).
+# The test is OPT-IN: it is skipped unless
+# `ENV["TRACKING_RUN_INTEGRATION_TEST"] = "true"` is set, so a plain `]test`
+# never triggers the 1.6 GB download. CI enables it on a single matrix job.
+# The zip is cached in a Scratch.jl scratchspace so it is only downloaded
+# once.
 #
 # ── Capture format (Flexiband / ION SDR-metadata standard) ─────────────────
 # The `.usb` file is a stream of fixed 1024-byte USB frames:
@@ -183,8 +185,9 @@ const IF_L5 = 2.903125e6Hz    # GPS L5 within the 1173.546875 MHz band
 
 # ── Test ───────────────────────────────────────────────────────────────────
 
-if get(ENV, "TRACKING_SKIP_INTEGRATION_TEST", "false") == "true"
-    @info "Skipping Flexiband integration test (TRACKING_SKIP_INTEGRATION_TEST=true)"
+if get(ENV, "TRACKING_RUN_INTEGRATION_TEST", "false") != "true"
+    @info "Skipping Flexiband integration test (downloads a 1.6 GB capture). " *
+          "Set ENV[\"TRACKING_RUN_INTEGRATION_TEST\"] = \"true\" to run it."
 else
     @testset "Flexiband III-7a multi-band acquire + track" begin
         zippath = download_capture()


### PR DESCRIPTION
## Summary

Two CI / release-mechanics fixes from the review of #113.

**1. Stop double-storing the 1.6 GB Flexiband capture.**
`julia-actions/cache@v3` caches `~/.julia/scratchspaces` by default with a per-run key, so the ubuntu/Julia-1 job re-uploaded the 1.6 GB capture into the julia cache on every run — on top of the dedicated fixed-key `actions/cache` entry that already pins it. That's ~3.2 GB+ steady state against the 10 GB repo cache limit, risking eviction of the very cache the dedicated step pins. Added `cache-scratchspaces: 'false'` to the `julia-actions/cache` step.

**2. Flexiband integration test is now opt-in.**
Flipped the gate from opt-out (`TRACKING_SKIP_INTEGRATION_TEST=true` skips) to opt-in (`TRACKING_RUN_INTEGRATION_TEST=true` runs), so a plain local `]test` no longer triggers a 1.6 GB download. CI enables it on the single ubuntu/Julia-1 job, unchanged in behavior.

The third point in the issue (do not squash-merge #113) is a merge-time process note, not a code change — it cannot be addressed in a PR diff and is left for whoever merges #113.

## Testing
- `julia --project -e "using Pkg; Pkg.test()"` → green; the integration test skips by default with the new opt-in message.
- `ci.yml` validated as well-formed YAML; `cache-scratchspaces` confirmed as a valid input of `julia-actions/cache@v3`.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)