### PR TITLE
fix(measurement): promote frequency types and fix mixed-precision duration check

### DIFF
--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -19,7 +19,7 @@ using Polyester
 # UInt1856 variant because no mask is needed on shift/XOR.
 BitIntegers.@define_integers 1800
 
-using Unitful: upreferred, uconvert, Hz, dBHz, ms
+using Unitful: upreferred, uconvert, Hz, dBHz, ms, s
 import Base.zero, Base.length, Base.resize!, LinearAlgebra.dot
 
 export get_early,

--- a/src/measurement.jl
+++ b/src/measurement.jl
@@ -29,9 +29,18 @@ struct Measurement{S<:AbstractVecOrMat,F}
     intermediate_frequency::F
 end
 
-# Positional constructor with IF defaulting to 0.0Hz. Promotes the
-# numeric type so `sampling_frequency` and `intermediate_frequency` end
-# up the same concrete type (`F`).
+# Promotes the numeric type so `sampling_frequency` and
+# `intermediate_frequency` end up the same concrete type (`F`), e.g. an
+# integer-typed IF alongside a `Float64` sampling frequency.
+function Measurement(
+    samples::AbstractVecOrMat,
+    sampling_frequency,
+    intermediate_frequency,
+)
+    Measurement(samples, promote(sampling_frequency, intermediate_frequency)...)
+end
+
+# Positional constructor with IF defaulting to 0.0Hz.
 function Measurement(samples::AbstractVecOrMat, sampling_frequency)
     intermediate_frequency = zero(sampling_frequency)
     Measurement(samples, sampling_frequency, intermediate_frequency)

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -1038,19 +1038,23 @@ end
     )))
 end
 
-# Exact-equality duration check across all measurements. `num_samples /
-# sampling_frequency` must compare equal across every band — no tolerance.
+# Exact-equality duration check across all measurements — no tolerance.
+# Cross-multiply instead of dividing so that mixed-precision sampling
+# rates (e.g. Float32 vs Float64) with identical real durations compare
+# equal; the rates are promoted first so neither product rounds in a
+# narrower type than the comparison.
 @inline function _validate_equal_durations(measurements::Measurements)
     ms = Tuple(measurements)
     isempty(ms) && return nothing
     first_m = first(ms)
-    ref_duration = get_num_samples(first_m) / first_m.sampling_frequency
+    ref_num_samples = get_num_samples(first_m)
     for m in Base.tail(ms)
-        d = get_num_samples(m) / m.sampling_frequency
-        d == ref_duration && continue
+        ref_fs, fs = promote(first_m.sampling_frequency, m.sampling_frequency)
+        get_num_samples(m) * ref_fs == ref_num_samples * fs && continue
         throw(ArgumentError(string(
             "Measurement durations must be exactly equal across bands. ",
-            "Got ", d, " and ", ref_duration, ". ",
+            "Got ", uconvert(s, get_num_samples(m) / m.sampling_frequency),
+            " and ", uconvert(s, ref_num_samples / first_m.sampling_frequency), ". ",
             "Check `num_samples / sampling_frequency` for each band.",
         )))
     end

--- a/test/multi_band.jl
+++ b/test/multi_band.jl
@@ -56,7 +56,7 @@ end
     fs = 4e6Hz
     buf = _make_signal(GPSL1CA, 1, 200Hz, 100.0, 4000, fs)
     ts = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts; prn = 1, code_phase = 100.0, carrier_doppler = 180Hz)
+    ts = add_satellite!(ts; prn = 1, code_phase = 100.0, carrier_doppler = 180Hz)
     # Integer IF must promote inside the bare-buffer wrapper, not throw.
     new_ts = track(buf, ts, fs; intermediate_frequency = 0Hz)
     @test new_ts isa TrackState

--- a/test/multi_band.jl
+++ b/test/multi_band.jl
@@ -11,7 +11,8 @@ using Tracking:
     track, track!, add_satellite!,
     band_key, band_keys,
     get_samples, get_sampling_frequency, get_intermediate_frequency,
-    get_carrier_doppler, get_code_doppler, get_num_ants
+    get_carrier_doppler, get_code_doppler, get_num_ants,
+    _validate_equal_durations
 
 # Build a synthetic complex sample buffer for one PRN at one band, with a
 # given Doppler offset and starting code phase.
@@ -37,6 +38,28 @@ end
     # Kwarg form with default intermediate_frequency = zero(sampling_frequency).
     m_kw_default = Measurement(buf; sampling_frequency = 4e6Hz)
     @test get_intermediate_frequency(m_kw_default) == 0.0Hz
+end
+
+@testset "Measurement promotes mixed frequency types" begin
+    buf = zeros(ComplexF64, 100)
+    # Integer-typed IF alongside a Float64 sampling frequency — the most
+    # natural spelling — must promote instead of throwing a MethodError.
+    m = @inferred Measurement(buf, 4e6Hz, 100Hz)
+    @test get_sampling_frequency(m) === 4e6Hz
+    @test get_intermediate_frequency(m) === 100.0Hz
+
+    m_kw = Measurement(buf; sampling_frequency = 4e6Hz, intermediate_frequency = 100Hz)
+    @test get_intermediate_frequency(m_kw) === 100.0Hz
+end
+
+@testset "track with integer-typed intermediate_frequency" begin
+    fs = 4e6Hz
+    buf = _make_signal(GPSL1CA, 1, 200Hz, 100.0, 4000, fs)
+    ts = TrackState(; signal = GPSL1CA())
+    add_satellite!(ts; prn = 1, code_phase = 100.0, carrier_doppler = 180Hz)
+    # Integer IF must promote inside the bare-buffer wrapper, not throw.
+    new_ts = track(buf, ts, fs; intermediate_frequency = 0Hz)
+    @test new_ts isa TrackState
 end
 
 @testset "band_key for L1 and L5" begin
@@ -191,6 +214,28 @@ end
     m_l1 = Measurement(zeros(ComplexF64, 4000),  4e6Hz)
     m_l5 = Measurement(zeros(ComplexF64, 25001), 25e6Hz)
     @test_throws ArgumentError track!((l1 = m_l1, l5 = m_l5), ts)
+end
+
+@testset "Equal durations across mixed Float32/Float64 sampling rates" begin
+    # Both bands span exactly 1 ms, but the L5 front-end reports its rate
+    # in Float32. Identical real durations must pass the check even though
+    # `4000 / 4e6Hz` (Float64) and `25000 / 25f6Hz` (Float32) are not
+    # `==` after division.
+    m_l1 = Measurement(zeros(ComplexF64, 4000),  4e6Hz)
+    m_l5 = Measurement(zeros(ComplexF64, 25000), 25f6Hz)
+    @test _validate_equal_durations((l1 = m_l1, l5 = m_l5)) === nothing
+
+    # A genuine one-sample mismatch must still throw, and the message
+    # should print durations in seconds, not Hz^-1.
+    m_bad = Measurement(zeros(ComplexF64, 25001), 25f6Hz)
+    err = try
+        _validate_equal_durations((l1 = m_l1, l5 = m_bad))
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    @test !occursin("Hz^-1", err.msg)
 end
 
 @testset "Antenna shape mismatch errors" begin


### PR DESCRIPTION
## Summary

Fixes two defects found in review of #113 (see #131).

### (a) `Measurement` did not promote frequency types
The struct `Measurement{S,F}` types both frequencies as `F` but only had the implicit inner constructor — no promotion existed despite the docstring claiming it. So the most natural spellings threw a raw `MethodError`:

- `Measurement(buf, 4e6Hz, 100Hz)` (integer-typed IF + Float64 sampling frequency)
- `track(buf, ts, 4e6Hz; intermediate_frequency = 100Hz)`

**Fix:** a promoting three-arg outer constructor that calls `promote(sampling_frequency, intermediate_frequency)`. When both already share a type, Julia's diagonal dispatch selects the inner constructor directly, so the common path is unchanged.

### (b) Duration check false-positived on mixed Float32/Float64 rates
`_validate_equal_durations` divided `num_samples / sampling_frequency` and compared exactly. Same-precision rates were fine, but mixed-precision rates with *identical real durations* failed — with the confusing message `Got 0.001 Hz^-1 and 0.001f0 Hz^-1` (two values that print equal).

**Fix:** cross-multiply with promoted rates (`get_num_samples(m) * ref_fs == ref_num_samples * fs`) — exact and cheaper than dividing — and print durations via `uconvert(s, …)` instead of `Hz^-1`.

## Tests
Added three testsets to `test/multi_band.jl` reproducing both bugs (confirmed failing before the fix, passing after). Full `Pkg.test()` suite is green.

Closes #131