### PR TITLE
fix(bit_buffer): apply lock polarity to pre-sync recovered bits

### DIFF
--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -730,11 +730,16 @@ function _buffer_find_bit(signal, prn::Integer, bit_buffer::BitBuffer{B}, num_co
         # Julia conservatively boxes the outer parameter even though this
         # closure path does not always run, leading to a per-call
         # Core.Box allocation.
+        # Apply the lock polarity to the buffered pre-sync bits as well, so
+        # they map symbol levels to bit values the same way as every
+        # post-sync bit (which is sign-flipped via `bit_buffer.polarity` in
+        # `buffer`). Otherwise a negative-polarity lock would invert only
+        # the post-sync part of the bit stream (issue #127).
         bit_sum = sum(0:num_code_blocks_that_form_a_bit-1) do code_block_index
             buffer_code_block_index =
                 (bit_index - 1) * num_code_blocks_that_form_a_bit + code_block_index
             ((code_block_buffer & (one(B) << buffer_code_block_index)) > 0) * 2 - 1
-        end
+        end * Int(sync.polarity)
         push!(bit_buffer.soft_bits, Float32(bit_sum))
         bits << 1 + (bit_sum > 0)
     end

--- a/test/bit_buffer.jl
+++ b/test/bit_buffer.jl
@@ -223,21 +223,45 @@ end
         @test next_bit_buffer.code_block_buffer_lengh == 1
     end
 
-    @testset "Find bit start and buffer the pre-sync bits" begin
+    @testset "Find bit start and buffer the pre-sync bits (negative polarity)" begin
         # Drive a clean data-1,1,0 stream (20 blocks each, +,+,-) through
         # `buffer()`. The soft detector locks at the true bit boundary
-        # (block 60) and the three completed bits are decoded with the most
-        # recent bit in the LSB: 0b110 = 6, with soft bits +, +, -.
+        # (block 60); the last completed bin is the "0", so the lock is at
+        # negative polarity. The three pre-sync bits are decoded with that
+        # polarity applied — the same sign-flip every post-sync bit gets — so
+        # they stay consistent across the sync boundary (issue #127): block
+        # signs +,+,- decode as bits 0,0,1 = 0b001 = 1, with soft bits -,-,+.
         found_at, bit_buffer =
             _feed_prompts([fill(1.0 + 0.0im, 40); fill(-1.0 + 0.0im, 20)])
         @test found_at == 60
         @test bit_buffer.found == true
+        @test bit_buffer.polarity == -1
         @test bit_buffer.length == 3
-        @test bit_buffer.buffer == 6
+        @test bit_buffer.buffer == 1
         @test bit_buffer.code_block_buffer_lengh == 60
         soft = get_soft_bits(bit_buffer)
         @test length(soft) == 3
-        @test soft[1] > 0 && soft[2] > 0 && soft[3] < 0
+        @test soft[1] < 0 && soft[2] < 0 && soft[3] > 0
+    end
+
+    @testset "Find bit start and buffer the pre-sync bits (positive polarity)" begin
+        # The whole-signal sign flip of the case above: data 0,0,1 (block
+        # signs -,-,+). The last completed bin is the "1", so the lock is at
+        # positive polarity. Because a global RF sign flip is exactly the
+        # ambiguity polarity resolves, the recovered hard bits and soft-bit
+        # signs are identical to the negative-polarity case (issue #127):
+        # buffer 0b001 = 1, soft -,-,+.
+        found_at, bit_buffer =
+            _feed_prompts([fill(-1.0 + 0.0im, 40); fill(1.0 + 0.0im, 20)])
+        @test found_at == 60
+        @test bit_buffer.found == true
+        @test bit_buffer.polarity == +1
+        @test bit_buffer.length == 3
+        @test bit_buffer.buffer == 1
+        @test bit_buffer.code_block_buffer_lengh == 60
+        soft = get_soft_bits(bit_buffer)
+        @test length(soft) == 3
+        @test soft[1] < 0 && soft[2] < 0 && soft[3] > 0
     end
 
     @testset "Buffer prompt when bit has been found" begin

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -23,34 +23,62 @@ using Tracking:
     code_frequency = get_code_frequency(gpsl1)
     carrier_doppler = 0.0Hz
 
-    track_state = TrackState(gpsl1, [TrackedSat(gpsl1, 1, 0, carrier_doppler)];)
+    # Run the same bit stream at both lock polarities: the bit-edge detector
+    # locks at block 40, where the newest 20 buffered blocks carry the second
+    # data bit — `1, 0, …` yields a negative-polarity lock, `0, 1, …` a
+    # positive one. The bits recovered from the pre-sync buffer and the bits
+    # decoded after sync must be consistent: equal to the transmitted bits up
+    # to a single *global* inversion across the whole stream (issue #127).
+    for data_bits in ([1, 0, 1, 1, 0, 0, 1], [0, 1, 0, 0, 1, 1, 0])
+        track_state = TrackState(gpsl1, [TrackedSat(gpsl1, 1, 0, carrier_doppler)];)
 
-    bits = vcat(ones(20), zeros(20), ones(1))
-    foreach(enumerate(bits)) do (index, bit)
-        code_phase = (index - 1) * num_samples * code_frequency / sampling_frequency
-        carrier_phase =
-            2π * (index - 1) * num_samples * carrier_doppler / sampling_frequency
-        signal =
-            (bit * 2 - 1) .*
-            cis.(
-                2π * (0:(num_samples-1)) * carrier_doppler / sampling_frequency .+
-                carrier_phase,
-            ) .*
-            gen_code(num_samples, gpsl1, 1, sampling_frequency, code_frequency, code_phase)
-        track_state = track(signal, track_state, sampling_frequency)
-        @test has_bit_or_secondary_code_been_found(track_state) == (index >= 40)
-        @test get_bits(track_state) == (index == 40 ? 2 : 0)
-        @test get_num_bits(track_state) == (index == 40 ? 2 : 0)
-        soft_bits = get_soft_bits(track_state)
-        # There is exactly one soft bit (Float32 accumulation) per hard bit
-        @test eltype(soft_bits) == Float32
-        @test length(soft_bits) == get_num_bits(track_state)
-        if index == 40
-            # The sign of each soft bit must match the respective hard bit
-            # (bits == 0b10, ordered oldest first: a "1" followed by a "0")
-            @test soft_bits[1] > 0
-            @test soft_bits[2] < 0
+        block_bits = repeat(data_bits, inner = 20)  # 20 code blocks per bit
+        decoded_bits = Bool[]
+        decoded_soft_bits = Float32[]
+        foreach(enumerate(block_bits)) do (index, bit)
+            code_phase = (index - 1) * num_samples * code_frequency / sampling_frequency
+            carrier_phase =
+                2π * (index - 1) * num_samples * carrier_doppler / sampling_frequency
+            signal =
+                (bit * 2 - 1) .*
+                cis.(
+                    2π * (0:(num_samples-1)) * carrier_doppler / sampling_frequency .+
+                    carrier_phase,
+                ) .*
+                gen_code(
+                    num_samples,
+                    gpsl1,
+                    1,
+                    sampling_frequency,
+                    code_frequency,
+                    code_phase,
+                )
+            track_state = track(signal, track_state, sampling_frequency)
+            @test has_bit_or_secondary_code_been_found(track_state) == (index >= 40)
+            # Sync at block 40 recovers the 2 buffered bits; afterwards one
+            # bit completes every 20 blocks.
+            expected_num_bits = index == 40 ? 2 : (index > 40 && index % 20 == 0 ? 1 : 0)
+            num_bits = get_num_bits(track_state)
+            @test num_bits == expected_num_bits
+            bits_word = get_bits(track_state)
+            for bit_index in num_bits:-1:1
+                push!(decoded_bits, (bits_word >> (bit_index - 1)) & 1 == 1)
+            end
+            soft_bits = get_soft_bits(track_state)
+            # There is exactly one soft bit (Float32 accumulation) per hard bit
+            @test eltype(soft_bits) == Float32
+            @test length(soft_bits) == num_bits
+            append!(decoded_soft_bits, soft_bits)
         end
+
+        @test length(decoded_bits) == length(data_bits)
+        # Pre-sync (first 2) and post-sync bits must agree on the symbol
+        # mapping: the decoded stream matches the transmitted one up to a
+        # global inversion, never a mixed one (issue #127).
+        @test decoded_bits == Bool.(data_bits) || decoded_bits == .!Bool.(data_bits)
+        # The sign of each soft bit must match the respective hard bit —
+        # including the soft bits recovered from the pre-sync buffer.
+        @test (decoded_soft_bits .> 0) == decoded_bits
     end
 end
 


### PR DESCRIPTION
## Summary

Fixes #127 — a v2 (#113) merge blocker.

At a negative-polarity lock (~50% of locks), `_buffer_find_bit` extracted the 2–3 historical bits (and their soft bits) **raw** from the code-block buffer, while every post-sync bit is sign-flipped by `polarity` in `buffer`. The same physical symbol level therefore mapped to opposite bit values across the sync boundary, corrupting the start of the bit stream for downstream decoders that tolerate only a *global* inversion.

## Fix

Multiply `bit_sum` by `Int(sync.polarity)` in the reduce closure of `_buffer_find_bit` (`sync` is already in scope), so the pre-sync recovered bits carry the same polarity as the post-sync ones.

## Tests

- Extended the L1 C/A bit-integration test past the sync boundary on **both** lock polarities and assert the decoded stream matches the transmitted bits up to a single *global* inversion (never a mixed one), with soft-bit signs matching the hard bits. The previous test stopped one block after sync, so it never observed the inconsistency.
- Updated the `bit_buffer` unit tests to pin the polarity-corrected extraction at both polarities (the prior test pinned the raw-extraction behavior).

The new integration assertion fails on `master` and passes with the fix. Full package test suite is green.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)