### PR TITLE
fix(tracking): honor rebuilt estimator from add_satellite! handoff

### DIFF
--- a/docs/src/cn0_estimator.md
+++ b/docs/src/cn0_estimator.md
@@ -33,7 +33,7 @@ julia> track_state = TrackState(; signal = GPSL1CA());
 julia> sat = TrackedSat(GPSL1CA(), 1, 50.0, 1000.0Hz;
                         num_prompts_for_cn0_estimation = 200);
 
-julia> add_satellite!(track_state, :default, sat);
+julia> track_state = add_satellite!(track_state, :default, sat);
 
 julia> get_prn(track_state, 1)
 1
@@ -76,7 +76,7 @@ julia> function run_cn0_demo()
            code_freq = get_code_frequency(sys)
            rng = MersenneTwister(0)
            track_state = TrackState(; signal = GPSL1CA())
-           add_satellite!(track_state; prn, code_phase = 0.0, carrier_doppler = 0.0Hz)
+           track_state = add_satellite!(track_state; prn, code_phase = 0.0, carrier_doppler = 0.0Hz)
            for _ in 1:25
                clean = gen_code(num_samples, sys, prn, fs, code_freq, 0.0)
                noise = sigma .* randn(rng, ComplexF64, num_samples)

--- a/docs/src/correlator.md
+++ b/docs/src/correlator.md
@@ -176,7 +176,7 @@ julia> sat = TrackedSat(GPSL1CA(), 1, 50.0, 1000.0Hz;
                             preferred_early_late_to_prompt_code_shift = 0.1,
                         ));
 
-julia> add_satellite!(track_state, :default, sat);
+julia> track_state = add_satellite!(track_state, :default, sat);
 
 julia> get_correlator(track_state, :default, 1, 1).preferred_early_late_to_prompt_code_shift
 0.1

--- a/docs/src/custom_doppler_estimator.md
+++ b/docs/src/custom_doppler_estimator.md
@@ -144,7 +144,7 @@ julia> using Tracking: Hz
 
 julia> track_state = TrackState(; signal = GPSL1CA(), doppler_estimator = MyEstimator());
 
-julia> add_satellite!(track_state; prn = 1, code_phase = 0.0, carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, code_phase = 0.0, carrier_doppler = 1000.0Hz);
 
 julia> track_state = track(zeros(ComplexF64, 4000), track_state, 4e6Hz);
 

--- a/docs/src/custom_doppler_estimator.md
+++ b/docs/src/custom_doppler_estimator.md
@@ -30,13 +30,19 @@ per-sat fields directly and rewraps `doppler_estimator_state` unchanged.
    the Kalman state vector.
 
 3. **An [`init_estimator_state`](@ref) method** for your estimator.
-   Called once per satellite when a sat enters the track set
-   (acquisition → tracking handoff), it produces the initial per-sat
-   state for that sat:
+   It produces the initial per-sat state for a sat entering the track
+   set (acquisition → tracking handoff):
 
    ```julia
    Tracking.init_estimator_state(::MyEstimator, sat::TrackedSat) = MyPerSatState(...)
    ```
+
+   It must be **pure** (no observable side effects): besides seeding
+   real sats, it is also called on the throwaway PRN-0 template sat that
+   fixes a group's slot type at `TrackState` construction, as a type
+   probe when validating pre-built sats, and by
+   [`reset_loop_filters!`](@ref). Register sats into shared state in
+   `update_estimator_on_handoff` (below), never here.
 
 4. **(Optional) An [`update_estimator_on_handoff`](@ref) method**, if
    your estimator carries cross-satellite or cross-system shared state
@@ -60,6 +66,15 @@ per-sat fields directly and rewraps `doppler_estimator_state` unchanged.
    resizable containers (e.g. `Vector`, `Matrix`) you `push!`/`resize!`
    in place; if scalar fields need replacing, rebuild the estimator
    with `Setfield.@set` or a copying constructor.
+
+   **Use the return value of the handoff functions.** Every entry point
+   carries the estimator you return in the `TrackState` it gives back.
+   Since `TrackState` is immutable, even [`add_satellite!`](@ref) can
+   only honor a *rebuilt* estimator through its return value — write
+   `track_state = add_satellite!(track_state; ...)`, not a bare
+   `add_satellite!(track_state; ...)`, if your estimator rebuilds
+   itself on handoff. (For in-place estimators, including the
+   conventional ones, the returned `TrackState` is the input itself.)
 
 5. **An `estimate_dopplers_and_filter_prompt` method** dispatched on
    `TrackState{<:Any, <:MyEstimator}`. This is where the actual update

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,7 +57,7 @@ julia> using GNSSSignals: gen_code, get_code_frequency, get_code_center_frequenc
 
 julia> track_state = TrackState(; signal = GPSL1CA());
 
-julia> add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
 
 julia> sampling_frequency = 4e6Hz;
 

--- a/docs/src/loop_filter.md
+++ b/docs/src/loop_filter.md
@@ -75,7 +75,7 @@ julia> # Use non-assisted PLL with custom loop filter types
 
 julia> track_state = TrackState(; signal = GPSL1CA(), doppler_estimator);
 
-julia> add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
 ```
 
 ## Custom Loop Filters

--- a/docs/src/track.md
+++ b/docs/src/track.md
@@ -23,7 +23,7 @@ A typical receiver loop builds the `TrackState` once, hoists the correlator outs
 
 ```julia
 track_state = TrackState(; signal = GPSL1CA())
-add_satellite!(track_state; prn = 1, code_phase = 0.0, carrier_doppler = 1000.0Hz)
+track_state = add_satellite!(track_state; prn = 1, code_phase = 0.0, carrier_doppler = 1000.0Hz)
 # ... more sats ...
 
 dc = CPUThreadedDownconvertAndCorrelator()  # hoist outside the loop
@@ -57,9 +57,9 @@ julia> track_state = TrackState(;
            signals = (legacy_gps_l1 = (GPSL1CA(),), gps_l5 = (GPSL5I(),)),
        );
 
-julia> add_satellite!(track_state; prn = 1, group = :legacy_gps_l1, code_phase = 0.0, carrier_doppler = 0.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, group = :legacy_gps_l1, code_phase = 0.0, carrier_doppler = 0.0Hz);
 
-julia> add_satellite!(track_state; prn = 1, group = :gps_l5,        code_phase = 0.0, carrier_doppler = 0.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, group = :gps_l5,        code_phase = 0.0, carrier_doppler = 0.0Hz);
 
 julia> buf_l1 = zeros(ComplexF64, 4000);   # 1 ms at  4 MHz
 

--- a/docs/src/tracking_state.md
+++ b/docs/src/tracking_state.md
@@ -57,7 +57,7 @@ track_state = TrackState(;
 # In your acquisition loop
 while running
     acqs = acquire(GPSL1CA(), latest_chunk, sampling_frequency, candidate_prns)
-    add_satellite!(track_state, filter(is_detected, acqs))   # routes each acq to the matching group
+    track_state = add_satellite!(track_state, filter(is_detected, acqs))   # routes each acq to the matching group
     track_state = track(latest_chunk, track_state, sampling_frequency)
 end
 ```
@@ -152,11 +152,11 @@ julia> using Tracking: Hz
 
 julia> track_state = TrackState(; signal = GPSL1CA());
 
-julia> add_satellite!(track_state; prn = 1,  code_phase = 50.0,  carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1,  code_phase = 50.0,  carrier_doppler = 1000.0Hz);
 
-julia> add_satellite!(track_state; prn = 5,  code_phase = 120.0, carrier_doppler = -500.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 5,  code_phase = 120.0, carrier_doppler = -500.0Hz);
 
-julia> add_satellite!(track_state; prn = 17, code_phase = 890.0, carrier_doppler = 2000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 17, code_phase = 890.0, carrier_doppler = 2000.0Hz);
 
 julia> get_carrier_doppler(track_state, 5)
 -500.0 Hz
@@ -181,9 +181,9 @@ julia> track_state = TrackState(;
            ),
        );
 
-julia> add_satellite!(track_state; prn = 1,  group = :gps,     code_phase = 50.0,  carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1,  group = :gps,     code_phase = 50.0,  carrier_doppler = 1000.0Hz);
 
-julia> add_satellite!(track_state; prn = 11, group = :galileo, code_phase = 200.0, carrier_doppler = -300.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 11, group = :galileo, code_phase = 200.0, carrier_doppler = -300.0Hz);
 
 julia> get_carrier_doppler(track_state, :gps, 1)
 1000.0 Hz
@@ -207,7 +207,7 @@ julia> track_state = TrackState(;
            ),
        );
 
-julia> add_satellite!(track_state;
+julia> track_state = add_satellite!(track_state;
            prn = 11, group = :modern_gps,
            code_phase = 0.0, carrier_doppler = 1234.0Hz,
        );
@@ -234,7 +234,7 @@ julia> track_state = TrackState(;
            num_ants = NumAnts(4),
        );
 
-julia> add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz);
 
 julia> get_num_ants(track_state, 1)
 4
@@ -274,11 +274,11 @@ When the [Acquisition.jl](https://github.com/JuliaGNSS/Acquisition.jl) extension
 using Acquisition  # loads the extension
 
 # Single acq
-add_satellite!(ts, acq)                       # auto-route
-add_satellite!(ts, acq; group = :legacy_gps)  # explicit group, asserts match
+ts = add_satellite!(ts, acq)                       # auto-route
+ts = add_satellite!(ts, acq; group = :legacy_gps)  # explicit group, asserts match
 
 # Vector of acqs (mixed constellations OK)
-add_satellite!(ts, filter(is_detected, acqs))
+ts = add_satellite!(ts, filter(is_detected, acqs))
 ```
 
 `acq.system` must match the **longest-primary-code** signal in the target group's tuple — its code phase is the only one that's unambiguous when the group tracks multiple signals on shared chips. Hand over an L1C-P acq (not L1 C/A) for a group tracking `(GPSL1C_P(), GPSL1C_D(), GPSL1CA())`.
@@ -292,11 +292,11 @@ julia> using Tracking: Hz
 
 julia> track_state = TrackState(; signal = GPSL1CA());
 
-julia> add_satellite!(track_state; prn = 1,  code_phase = 50.0,  carrier_doppler = 1000.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 1,  code_phase = 50.0,  carrier_doppler = 1000.0Hz);
 
-julia> add_satellite!(track_state; prn = 23, code_phase = 500.0, carrier_doppler = 1500.0Hz);
+julia> track_state = add_satellite!(track_state; prn = 23, code_phase = 500.0, carrier_doppler = 1500.0Hz);
 
-julia> remove_satellite!(track_state; prn = 1);
+julia> track_state = remove_satellite!(track_state; prn = 1);
 
 julia> haskey(get_sat_states(track_state, :default), 23)
 true
@@ -369,9 +369,9 @@ julia> track_state = TrackState(;
            signals = (legacy_gps_l1 = (GPSL1CA(),), gps_l5 = (GPSL5I(),)),
        );
 
-julia> add_satellite!(track_state; prn = 1, group = :legacy_gps_l1, code_phase = 0.0, carrier_doppler = 200Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, group = :legacy_gps_l1, code_phase = 0.0, carrier_doppler = 200Hz);
 
-julia> add_satellite!(track_state; prn = 1, group = :gps_l5, code_phase = 0.0, carrier_doppler = -150Hz);
+julia> track_state = add_satellite!(track_state; prn = 1, group = :gps_l5, code_phase = 0.0, carrier_doppler = -150Hz);
 
 julia> buf_l1 = make_signal(GPSL1CA(),  1, 200Hz,  4000,  4e6Hz);  # 1 ms at 4 MHz
 
@@ -492,7 +492,7 @@ julia> track_state = TrackState(;
            signals = (modern_gps = (GPSL1C_P(), GPSL1C_D(), GPSL1CA()),),
        );
 
-julia> add_satellite!(track_state; prn = 11, group = :modern_gps,
+julia> track_state = add_satellite!(track_state; prn = 11, group = :modern_gps,
                                    code_phase = 0.0, carrier_doppler = 1234.0Hz);
 
 julia> get_carrier_doppler(track_state, :modern_gps, 11)  # sat-level: same for all signals

--- a/ext/TrackingAcquisitionExt/TrackingAcquisitionExt.jl
+++ b/ext/TrackingAcquisitionExt/TrackingAcquisitionExt.jl
@@ -25,7 +25,6 @@ ts  = TrackState(acq)
 function Tracking.TrackState(acq::AcquisitionResults; kwargs...)
     ts = Tracking.TrackState(; signal = acq.system, kwargs...)
     Tracking.add_satellite!(ts, acq)
-    ts
 end
 
 """
@@ -80,13 +79,12 @@ function Tracking.TrackState(
             )))
         end
         ts = Tracking.TrackState(; signal = sig, kwargs...)
-        Tracking.add_satellite!(ts, acqs)
-        return ts
+        return Tracking.add_satellite!(ts, acqs)
     end
     ts = Tracking.TrackState(; signals, kwargs...)
     for acq in acqs
         group = _find_group_for_acq(ts, acq)
-        Tracking.add_satellite!(ts, acq; group)
+        ts = Tracking.add_satellite!(ts, acq; group)
     end
     ts
 end
@@ -175,7 +173,9 @@ default) each acq is routed to the matching group by signal type, so a
 mixed `Vector{AcquisitionResults}` from multiple constellations lands in
 the right place. Passing an explicit `group =` keyword applies that
 group to every entry (use the single-acq form per entry if your vector
-mixes groups). Returns `track_state`.
+mixes groups). Returns the track state carrying the estimator after all
+per-entry [`Tracking.update_estimator_on_handoff`](@ref) updates — keep
+using the return value.
 """
 function Tracking.add_satellite!(
     track_state::TrackState,
@@ -183,7 +183,7 @@ function Tracking.add_satellite!(
     group::Union{Symbol,Nothing} = nothing,
 )
     for acq in acqs
-        Tracking.add_satellite!(track_state, acq; group)
+        track_state = Tracking.add_satellite!(track_state, acq; group)
     end
     track_state
 end

--- a/src/sat_state.jl
+++ b/src/sat_state.jl
@@ -623,9 +623,18 @@ end
 $(SIGNATURES)
 
 Build the per-satellite Doppler-estimator state used by `estimator` for the
-given satellite. Called once per satellite when a new sat enters the track
-set. A custom doppler estimator must define this method for its
+given satellite. A custom doppler estimator must define this method for its
 [`AbstractDopplerEstimator`](@ref) subtype.
+
+This function must be **pure** (free of observable side effects): besides
+seeding each real satellite on entry, it is also called to build the
+throwaway PRN-0 template sat that fixes a group's dictionary slot type at
+[`TrackState`](@ref) construction, as a type probe when validating
+pre-built sats, and by [`reset_loop_filters!`](@ref) to re-seed existing
+satellites. Estimators with cross-satellite shared state must therefore
+not register satellites here — perform shared-state registration in
+[`update_estimator_on_handoff`](@ref), which is called exactly once per
+handoff with the real incoming satellites.
 """
 function init_estimator_state end
 
@@ -633,8 +642,9 @@ function init_estimator_state end
 $(SIGNATURES)
 
 Optionally update an estimator's cross-satellite or cross-system shared state
-when new satellites enter the track set. Called once per [`merge_sats`](@ref)
-call with the dictionary of incoming satellites, *after* per-sat seeding via
+when new satellites enter the track set. Called once per handoff entry point
+([`merge_sats`](@ref), [`add_satellite`](@ref), [`add_satellite!`](@ref))
+with the dictionary of incoming satellites, *after* per-sat seeding via
 [`init_estimator_state`](@ref).
 
 The default returns `estimator` unchanged, so estimators with no shared state
@@ -647,6 +657,13 @@ resizable container (e.g. `Vector`, `Matrix`) on an otherwise immutable
 estimator and `push!`/`resize!` it in place; rebuild the estimator with
 [`Setfield.@set`](https://jw3126.github.io/Setfield.jl/stable/) or a copying
 constructor when fields need replacing.
+
+Every entry point honors the return value: the `TrackState` it returns
+carries the returned estimator. `TrackState` is immutable, so even the
+in-place [`add_satellite!`](@ref) can only honor a *rebuilt* estimator
+through its return value — callers must keep using the returned
+`TrackState` rather than the one they passed in (for in-place estimators
+the two are identical).
 """
 update_estimator_on_handoff(estimator::AbstractDopplerEstimator, _new_sats) = estimator
 
@@ -765,6 +782,14 @@ The `satellites` dictionary is left empty — populate it via
 [`add_satellite!`](@ref) after the enclosing [`TrackState`](@ref) is
 built. The signal-tuple shape determines the dict's concrete value type,
 so the slot is type-stable.
+
+The `doppler_estimator` kwarg only shapes the dictionary's slot type
+(via the per-sat estimator-state type); the estimator that actually runs
+is the one configured on the enclosing `TrackState`. When the two
+disagree, `TrackState` rebuilds the empty slot to match its own
+estimator, so pass the same estimator instance to both — or simply leave
+this kwarg at its default and configure the estimator on `TrackState`
+alone.
 
 ```julia
 SignalGroup((GPSL1CA(),))                              # band L1(), 1 antenna

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -487,7 +487,14 @@ shortcut). For multi-group `TrackState`s, pass the group key explicitly.
 If a satellite with the same `prn` already exists in that group's
 dictionary, it is overwritten.
 
-Returns `track_state` unchanged (the dictionary is mutated in place).
+The satellite dictionary is mutated in place, but callers should keep
+using the *returned* `TrackState`: when the configured estimator's
+[`update_estimator_on_handoff`](@ref) returns a rebuilt estimator (rather
+than mutating in place), the rebuilt estimator is carried by the returned
+`TrackState` — `track_state.doppler_estimator` cannot be replaced in
+place because `TrackState` is immutable. For estimators that update in
+place (including the default conventional ones), the very same
+`track_state` comes back.
 
 ```julia
 track_state = TrackState(; signals = (modern_gps = (GPSL1C_P(), GPSL1C_D(), GPSL1CA()),))
@@ -527,24 +534,28 @@ escape hatch for power users who need non-default correlator or
 post-corr-filter types. The sat's type must match the group's slot type
 already fixed at [`TrackState`](@ref) construction; passing a sat of the
 wrong type errors at dispatch time.
+
+Like the keyword form, the returned `TrackState` carries the estimator
+returned by [`update_estimator_on_handoff`](@ref) — keep using the
+return value.
 """
 function add_satellite!(
-    track_state::TrackState,
+    track_state::TrackState{G,DE},
     group::Symbol,
     sat::TrackedSat,
-)
+) where {G<:SignalGroups,DE<:AbstractDopplerEstimator}
     _assert_sat_matches_slot_type(track_state, group, sat)
     insert_or_set!(_dict_for_group(track_state, group), sat.prn, sat)
-    # `update_estimator_on_handoff` is called for its side effect on
-    # estimators with cross-sat shared state (the default returns the
-    # estimator unchanged). The return value must have the same concrete
-    # type as the input — the TrackState is parameterized on the
-    # estimator type and `track_state.doppler_estimator` is immutable.
-    update_estimator_on_handoff(
+    new_estimator = update_estimator_on_handoff(
         track_state.doppler_estimator,
         dictionary((sat.prn => sat,)),
     )
-    track_state
+    # `TrackState` is immutable, so a rebuilt estimator can only be honored
+    # through the return value. Estimators that update in place return the
+    # identical object (the contract guarantees the concrete type either
+    # way), and then the input `track_state` is handed back unchanged.
+    new_estimator === track_state.doppler_estimator && return track_state
+    TrackState{G,DE}(track_state.groups, new_estimator)
 end
 
 # Verify that `sat` has exactly the concrete type the capability's

--- a/test/add_satellite.jl
+++ b/test/add_satellite.jl
@@ -65,7 +65,7 @@ end
         signals = (legacy = sg,),
         doppler_estimator = custom,
     )
-    add_satellite!(ts; prn = 1, group = :legacy, carrier_doppler = 0.0Hz)
+    ts = add_satellite!(ts; prn = 1, group = :legacy, carrier_doppler = 0.0Hz)
     de_state = get_sat_state(ts, :legacy, 1).doppler_estimator_state
     @test de_state.carrier_loop_filter_bandwidth == 22.0Hz
 end
@@ -96,7 +96,7 @@ end
 
 @testset "add_satellite! — single-group shortcut (no `group=`)" begin
     track_state = TrackState(; signal = GPSL1CA())
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 11,
         code_phase = 10.5,
         carrier_doppler = 1234.0Hz,
@@ -116,10 +116,10 @@ end
             galileo = (GalileoE1B(),),
         ),
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 5, group = :legacy, carrier_doppler = 500.0Hz,
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 11, group = :galileo, carrier_doppler = 2000.0Hz,
     )
     @test length(get_sat_states(track_state, :legacy)) == 1
@@ -130,10 +130,10 @@ end
 
 @testset "add_satellite! — overwrites on duplicate PRN" begin
     track_state = TrackState(; signal = GPSL1CA())
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 7, carrier_doppler = 100.0Hz,
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 7, carrier_doppler = 200.0Hz,
     )
     @test length(get_sat_states(track_state, :default)) == 1
@@ -156,7 +156,7 @@ end
     track_state = TrackState(; signal = GPSL1CA())
     sat = TrackedSat(GPSL1CA(), 9, 5.0, 300.0Hz;
         doppler_estimator = ConventionalAssistedPLLAndDLL())
-    add_satellite!(track_state, :default, sat)
+    track_state = add_satellite!(track_state, :default, sat)
     @test get_prn(track_state, :default, 9) == 9
     @test get_carrier_doppler(track_state, :default, 9) == 300.0Hz
 end
@@ -175,7 +175,7 @@ end
         code_loop_filter_bandwidth = 1.5Hz,
     )
     track_state = TrackState(; signal = GPSL1CA(), doppler_estimator = custom)
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 4, carrier_doppler = 0.0Hz,
     )
     de_state = get_sat_state(track_state, :default, 4).doppler_estimator_state
@@ -235,7 +235,7 @@ end
         _make_acq(GPSL1CA(), 2, 10.0, 200.0Hz),
         _make_acq(GPSL1CA(), 3, 20.0, 300.0Hz),
     ]
-    add_satellite!(ts, acqs)
+    ts = add_satellite!(ts, acqs)
     @test length(get_sat_states(ts, :default)) == 3
     @test get_carrier_doppler(ts, :default, 2) == 200.0Hz
 end
@@ -247,8 +247,8 @@ end
     ))
     gps_acq = _make_acq(GPSL1CA(), 11, 1.5, 50.0Hz)
     gal_acq = _make_acq(GalileoE1B(), 12, 2.5, 60.0Hz)
-    add_satellite!(ts, gps_acq; group = :gps)
-    add_satellite!(ts, gal_acq; group = :gal)
+    ts = add_satellite!(ts, gps_acq; group = :gps)
+    ts = add_satellite!(ts, gal_acq; group = :gal)
     @test get_prn(ts, :gps, 11) == 11
     @test get_prn(ts, :gal, 12) == 12
 end
@@ -261,8 +261,8 @@ end
     gps_acq = _make_acq(GPSL1CA(), 11, 1.5, 50.0Hz)
     gal_acq = _make_acq(GalileoE1B(), 12, 2.5, 60.0Hz)
     # No `group=`: each acq lands in the matching group automatically.
-    add_satellite!(ts, gps_acq)
-    add_satellite!(ts, gal_acq)
+    ts = add_satellite!(ts, gps_acq)
+    ts = add_satellite!(ts, gal_acq)
     @test get_prn(ts, :gps, 11) == 11
     @test get_prn(ts, :gal, 12) == 12
 end
@@ -277,7 +277,7 @@ end
         _make_acq(GalileoE1B(), 12, 2.5, 60.0Hz),
         _make_acq(GPSL1CA(),    13, 3.5, 70.0Hz),
     ]
-    add_satellite!(ts, acqs)  # no group= — routes per-entry
+    ts = add_satellite!(ts, acqs)  # no group= — routes per-entry
     @test get_prn(ts, :gps, 11) == 11
     @test get_prn(ts, :gps, 13) == 13
     @test get_prn(ts, :gal, 12) == 12
@@ -307,7 +307,7 @@ end
     @test_throws ArgumentError add_satellite!(ts, short_acq; group = :mix)
     # An L1C-P acquisition is accepted.
     long_acq = _make_acq(GPSL1C_P(), 7, 100.0, 50.0Hz)
-    add_satellite!(ts, long_acq; group = :mix)
+    ts = add_satellite!(ts, long_acq; group = :mix)
     @test get_prn(ts, :mix, 7) == 7
 end
 

--- a/test/cn0_estimation.jl
+++ b/test/cn0_estimation.jl
@@ -132,7 +132,7 @@ end
     # forwarding paths. With an unseeded CN0 estimator the value is
     # 0 dB-Hz — we only assert the methods dispatch and run.
     ts = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts; prn = 1, carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, carrier_doppler = 0Hz)
     @test estimate_cn0(ts, :default, 1) == 0.0dBHz
     @test estimate_cn0(ts, 1) == 0.0dBHz
 end

--- a/test/flexiband_integration_test.jl
+++ b/test/flexiband_integration_test.jl
@@ -272,13 +272,13 @@ else
             ),
         )
         for a in acq_l1
-            add_satellite!(track_state, a; group = :gps_l1)
+            track_state = add_satellite!(track_state, a; group = :gps_l1)
         end
         for a in acq_e1
-            add_satellite!(track_state, a; group = :galileo)
+            track_state = add_satellite!(track_state, a; group = :galileo)
         end
         for a in acq_l5
-            add_satellite!(track_state, a; group = :gps_l5)
+            track_state = add_satellite!(track_state, a; group = :gps_l5)
         end
 
         track!(

--- a/test/multi_band.jl
+++ b/test/multi_band.jl
@@ -55,14 +55,14 @@ end
 
     # Immutable variant.
     ts_imm = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts_imm; prn, code_phase = start_code_phase,
+    ts_imm = add_satellite!(ts_imm; prn, code_phase = start_code_phase,
                    carrier_doppler = carrier_doppler - 20Hz)
     new_ts = track(measurement, ts_imm)
     @test abs(get_carrier_doppler(new_ts, :default, prn) - carrier_doppler) < 50Hz
 
     # In-place variant.
     ts_inp = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts_inp; prn, code_phase = start_code_phase,
+    ts_inp = add_satellite!(ts_inp; prn, code_phase = start_code_phase,
                    carrier_doppler = carrier_doppler - 20Hz)
     track!(measurement, ts_inp)
     @test abs(get_carrier_doppler(ts_inp, :default, prn) - carrier_doppler) < 50Hz
@@ -110,7 +110,7 @@ end
     start_code_phase = 100.0
 
     track_state = TrackState(; signal = GPSL1CA())
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn, code_phase = start_code_phase,
         carrier_doppler = carrier_doppler - 20Hz,
     )
@@ -148,11 +148,11 @@ end
         legacy_gps_l1 = (GPSL1CA(),),
         gps_l5        = (GPSL5I(),),
     ))
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = prn_l1, group = :legacy_gps_l1,
         code_phase = cp_l1, carrier_doppler = cd_l1 - 20Hz,
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = prn_l5, group = :gps_l5,
         code_phase = cp_l5, carrier_doppler = cd_l5 - 20.0Hz,
     )
@@ -183,8 +183,8 @@ end
         legacy_gps_l1 = (GPSL1CA(),),
         gps_l5        = (GPSL5I(),),
     ))
-    add_satellite!(ts; prn = 1, group = :legacy_gps_l1, carrier_doppler = 0Hz)
-    add_satellite!(ts; prn = 1, group = :gps_l5,        carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, group = :legacy_gps_l1, carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, group = :gps_l5,        carrier_doppler = 0Hz)
 
     # L1 has 4000 samples @ 4 MHz = 1.000 ms; L5 has 25001 samples @ 25 MHz
     # ≈ 1.00004 ms. Off by one sample at L5's rate — must reject.
@@ -195,7 +195,7 @@ end
 
 @testset "Antenna shape mismatch errors" begin
     ts = TrackState(; signal = GPSL1CA(), num_ants = NumAnts(2))
-    add_satellite!(ts; prn = 1, carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, carrier_doppler = 0Hz)
     # 2-antenna group expects a Matrix with 2 columns; pass a Vector.
     m = Measurement(zeros(ComplexF64, 4000), 4e6Hz)
     @test_throws ArgumentError track!((l1 = m,), ts)
@@ -208,8 +208,8 @@ end
         legacy_gps_l1 = SignalGroup((GPSL1CA(),); num_ants = NumAnts(2)),
         gps_l5        = SignalGroup((GPSL5I(),);  num_ants = NumAnts(1)),
     ))
-    add_satellite!(ts; prn = 1, group = :legacy_gps_l1, carrier_doppler = 0Hz)
-    add_satellite!(ts; prn = 1, group = :gps_l5,        carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, group = :legacy_gps_l1, carrier_doppler = 0Hz)
+    ts = add_satellite!(ts; prn = 1, group = :gps_l5,        carrier_doppler = 0Hz)
 
     @test get_num_ants(ts, :legacy_gps_l1, 1) == 2
     @test get_num_ants(ts, :gps_l5, 1) == 1

--- a/test/multi_signal.jl
+++ b/test/multi_signal.jl
@@ -152,13 +152,13 @@ end
 
     # Single-signal reference.
     ref_state = TrackState(; signal = gpsl1)
-    add_satellite!(ref_state; prn, code_phase = start_code_phase, carrier_doppler)
+    ref_state = add_satellite!(ref_state; prn, code_phase = start_code_phase, carrier_doppler)
     ref_state = track(signal_buf, ref_state, sampling_frequency)
     ref_sat = get_sat_state(ref_state, prn)
 
     # Two-signal sat, both GPSL1CA with identical config.
     multi_state = TrackState(; signals = (default = (gpsl1, gpsl1),))
-    add_satellite!(multi_state; prn, code_phase = start_code_phase, carrier_doppler)
+    multi_state = add_satellite!(multi_state; prn, code_phase = start_code_phase, carrier_doppler)
     multi_state = track(signal_buf, multi_state, sampling_frequency)
     multi_sat = get_sat_state(multi_state, prn)
 
@@ -185,7 +185,7 @@ end
     track_state = TrackState(;
         signals = (modern_gps = (GPSL1C_P(), GPSL1C_D(), GPSL1CA()),),
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn = 11, group = :modern_gps,
         code_phase = 0.0, carrier_doppler = 1234.0Hz,
     )

--- a/test/track.jl
+++ b/test/track.jl
@@ -672,7 +672,7 @@ end
     start_carrier_phase = π / 2
 
     track_state = @inferred TrackState(; signal)
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn,
         code_phase = start_code_phase,
         carrier_doppler = carrier_doppler - 5Hz,
@@ -749,7 +749,7 @@ end
     # 0.2-chip seed offset — a realistic acquisition handoff error that puts the
     # DLL discriminator onto the BOC autocorrelation slope. Uses the group's
     # default correlator, so reverting the default spacing breaks this test.
-    add_satellite!(track_state; prn, code_phase = 0.2, carrier_doppler = 0.0Hz)
+    track_state = add_satellite!(track_state; prn, code_phase = 0.2, carrier_doppler = 0.0Hz)
 
     build(code_phase) =
         gen_code(period, signal, prn, sampling_frequency, code_frequency, code_phase) .*
@@ -781,7 +781,7 @@ end
     track_state = TrackState(;
         signals = (modern_gps = (GPSL1C_P(), GPSL1C_D(), GPSL1CA()),),
     )
-    add_satellite!(track_state;
+    track_state = add_satellite!(track_state;
         prn, group = :modern_gps,
         code_phase = 0.0,
         carrier_doppler = carrier_doppler - init_offset,
@@ -876,7 +876,7 @@ end
         gen_code(total_samples, signal, prn, sampling_frequency, code_frequency, 0.0)
 
     track_state = TrackState(; signal)
-    add_satellite!(track_state; prn, code_phase = 0.0, carrier_doppler = carrier_doppler - 20Hz)
+    track_state = add_satellite!(track_state; prn, code_phase = 0.0, carrier_doppler = carrier_doppler - 20Hz)
 
     track!((@view long_signal[1:chunk]), track_state, sampling_frequency)
     prompts = ComplexF64[]

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -476,6 +476,51 @@ end
     @test merged_default.doppler_estimator === default_estimator
 end
 
+@testset "add_satellite! honors a rebuilt estimator on handoff" begin
+    import Tracking
+    using Tracking: AbstractDopplerEstimator
+
+    # Spec-conforming estimator that *rebuilds itself* on handoff — same
+    # concrete type, replaced field — the style the
+    # `update_estimator_on_handoff` docstring explicitly sanctions.
+    struct RebuildingEstimator <: AbstractDopplerEstimator
+        num_registered::Int
+    end
+
+    struct SatRebuildingState end
+
+    Tracking.init_estimator_state(::RebuildingEstimator, ::TrackedSat) =
+        SatRebuildingState()
+
+    Tracking.update_estimator_on_handoff(est::RebuildingEstimator, new_sats) =
+        RebuildingEstimator(est.num_registered + length(new_sats))
+
+    # Keyword form: the returned TrackState carries the rebuilt estimator.
+    ts = TrackState(; signal = GPSL1CA(), doppler_estimator = RebuildingEstimator(0))
+    ts2 = add_satellite!(ts; prn = 1, carrier_doppler = 100.0Hz)
+    @test ts2.doppler_estimator.num_registered == 1
+    # The dictionary mutation is still in place — shared with the input.
+    @test length(get_sat_states(ts, :default)) == 1
+    @test get_sat_states(ts2, :default) === get_sat_states(ts, :default)
+
+    # Escape-hatch overload behaves the same.
+    sat = get_sat_state(ts2, :default, 1)
+    sat2 = TrackedSat(
+        sat.prn + 1, sat.code_phase, sat.code_doppler,
+        sat.carrier_phase, sat.carrier_doppler,
+        sat.signal_start_sample, sat.signals, sat.doppler_estimator_state,
+    )
+    ts3 = add_satellite!(ts2, :default, sat2)
+    @test ts3.doppler_estimator.num_registered == 2
+    @test length(get_sat_states(ts3, :default)) == 2
+
+    # Estimators that update in place (or don't override the hook) keep
+    # the in-place contract: the identical TrackState comes back.
+    conventional_ts = TrackState(; signal = GPSL1CA())
+    ret = add_satellite!(conventional_ts; prn = 5, carrier_doppler = 100.0Hz)
+    @test ret === conventional_ts
+end
+
 # Type stability matters because every accessor is on the path between
 # user code and the hot tracking loop. A widened return type here can
 # silently propagate into a dynamic dispatch in the caller; `@inferred`

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -196,10 +196,10 @@ end
     # values vector — leaving the original claiming keys it has no values for
     # (UndefRefError or silent garbage on access).
     ts = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts; prn = 1, carrier_doppler = 100.0Hz)
+    ts = add_satellite!(ts; prn = 1, carrier_doppler = 100.0Hz)
 
     ts2 = Tracking.reset_start_sample_and_bit_buffer(ts)
-    add_satellite!(ts2; prn = 2, carrier_doppler = 200.0Hz)
+    ts2 = add_satellite!(ts2; prn = 2, carrier_doppler = 200.0Hz)
 
     # The original must be untouched: still exactly one satellite.
     @test length(get_sat_states(ts, :default)) == 1
@@ -209,7 +209,7 @@ end
     @test length(get_sat_states(ts2, :default)) == 2
 
     # Removal on the copy must not shrink the original's key set either.
-    remove_satellite!(ts2; prn = 1)
+    ts2 = remove_satellite!(ts2; prn = 1)
     @test length(get_sat_states(ts, :default)) == 1
     @test get_prn(ts, :default, 1) == 1
 end
@@ -226,7 +226,7 @@ end
     signal = rand(ComplexF64, 5000)
 
     ts2 = Tracking.track(signal, ts, sampling_frequency)
-    add_satellite!(ts2; prn = 2, carrier_doppler = 200.0Hz)
+    ts2 = add_satellite!(ts2; prn = 2, carrier_doppler = 200.0Hz)
 
     # Input keeps exactly its one satellite; output has two.
     @test length(get_sat_states(ts, :default)) == 1
@@ -237,8 +237,8 @@ end
 
 @testset "remove_satellite! kwarg form mutates in place" begin
     ts = TrackState(; signal = GPSL1CA())
-    add_satellite!(ts; prn = 5, carrier_doppler = 100.0Hz)
-    add_satellite!(ts; prn = 6, carrier_doppler = 200.0Hz)
+    ts = add_satellite!(ts; prn = 5, carrier_doppler = 100.0Hz)
+    ts = add_satellite!(ts; prn = 6, carrier_doppler = 200.0Hz)
     @test length(get_sat_states(ts, :default)) == 2
 
     ret = remove_satellite!(ts; prn = 5)
@@ -528,7 +528,7 @@ end
 # the actual return.
 @testset "Accessor type stability — single-group, single-signal" begin
     track_state = TrackState(; signal = GPSL1CA())
-    add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz)
+    track_state = add_satellite!(track_state; prn = 1, code_phase = 50.0, carrier_doppler = 1000.0Hz)
 
     @inferred get_prn(track_state, 1)
     @inferred get_num_ants(track_state, 1)


### PR DESCRIPTION
## Summary

Fixes #130. `add_satellite!` invoked `update_estimator_on_handoff` purely for its side effect and threw the result away (`src/tracking_state.jl`). Since the extension-point docstring explicitly sanctions estimators that *return a rebuilt estimator* (via `Setfield.@set` or a copying constructor), a spec-conforming estimator silently lost its handoff update depending on which API entry the user picked — `merge_sats` and the immutable `add_satellite` stored the returned estimator, but `add_satellite!` did not.

This adopts **option 1** from the issue: `add_satellite!` now returns a (possibly new) `TrackState` carrying the returned estimator. The satellite dictionary is still mutated in place and stays shared with the input; when the estimator updates in place (including the default `ConventionalPLLAndDLL` / `ConventionalAssistedPLLAndDLL`), `update_estimator_on_handoff` returns the identical object and the very same `track_state` is handed back — so existing callers that ignore the return value are unaffected.

## Changes

- **`src/tracking_state.jl`** — the escape-hatch `add_satellite!(track_state, group, sat)` returns `TrackState{G,DE}` carrying the estimator from `update_estimator_on_handoff`; the keyword form forwards through it. Identity short-circuit keeps the in-place contract for in-place estimators.
- **`ext/TrackingAcquisitionExt`** — threaded the return value through `TrackState(acq)`, `TrackState(acqs)`, and the batch `add_satellite!(ts, acqs)`, which had the same discard bug.
- **Docs / docstrings** — addressed the related contract gaps the issue flags:
  - `init_estimator_state` is documented as **pure** (it's also used for the PRN-0 template sat, the type probe in `_assert_doppler_estimator_types_match`, and `reset_loop_filters!`); shared-state registration belongs in `update_estimator_on_handoff`.
  - `SignalGroup`'s `doppler_estimator` kwarg only shapes the dictionary slot type; the `TrackState`'s estimator is what actually runs.
  - `update_estimator_on_handoff` and `add_satellite!` docstrings now state that every entry point honors the return value and callers must keep using the returned `TrackState`.

## Testing

- Added a regression test (`test/tracking_state.jl`) with a `RebuildingEstimator` that returns a new estimator of the same concrete type on handoff. It fails on the old code (`0 == 1`) and passes now, covering both the keyword and escape-hatch `add_satellite!` forms plus the in-place identity contract.
- Full suite green via `julia --project -e "using Pkg; Pkg.test()"` (including the Flexiband multi-band integration test).

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)