### PR TITLE
fix(sat_state): validate SignalGroup band/chip-rate and use lcm for code wrap

### DIFF
--- a/src/sat_state.jl
+++ b/src/sat_state.jl
@@ -194,8 +194,8 @@ estimates and bit buffers on their own boundaries. A user-supplied
 too — `signals[1]`'s privileged role is a convention of the conventional
 estimators, not a structural constraint of the type.
 
-The shared `code_phase` wraps at the longest code period across all signals
-including secondary code (see [`max_code_length`](@ref)).
+The shared `code_phase` wraps at the least common multiple of the signals'
+code periods including secondary code (see [`max_code_length`](@ref)).
 """
 struct TrackedSat{Signals<:Tuple{Vararg{TrackedSignal}},D}
     prn::Int
@@ -235,8 +235,15 @@ end
     end
 end
 
-@inline _max_code_length(::Tuple{}) = 0
-@inline _max_code_length(t::Tuple) = max(
+# Folded with `lcm` (identity 1 on the empty tuple), not `max`: per-signal
+# phases are re-derived as `mod(code_phase, _replica_code_wrap(...))`,
+# which is only correct when the shared wrap is an integer multiple of
+# *every* signal's replica wrap (issue #129). For all shipped signal
+# pairings the shorter wraps divide the longer ones, so the lcm equals
+# the max — but `max` would silently corrupt non-driver code phases for
+# a future pairing where it isn't a common multiple.
+@inline _max_code_length(::Tuple{}) = 1
+@inline _max_code_length(t::Tuple) = lcm(
     _post_sync_code_length(first(t)),
     _max_code_length(Base.tail(t)),
 )
@@ -245,10 +252,12 @@ end
 $(SIGNATURES)
 
 Upper bound on the shared `sat.code_phase` wrap period, in chips —
-the largest value `code_phase` ever takes once *every* signal on the
-sat has synced. For a sat tracking only GPS L1 C/A this is 1023 × 20 =
-20460 (one full data bit); for one tracking L1C-P this is 10230 × 1800
-≈ 18.4 M (one full secondary-code cycle).
+the least common multiple of the per-signal wrap periods once *every*
+signal on the sat has synced. For a sat tracking only GPS L1 C/A this is
+1023 × 20 = 20460 (one full data bit); for one tracking L1C-P this is
+10230 × 1800 ≈ 18.4 M (one full secondary-code cycle). For every shipped
+multi-signal pairing the shorter wraps divide the longer ones, so the
+lcm coincides with the longest signal's wrap.
 
 This is the *compile-time* bound. The actual runtime wrap shrinks to
 `get_code_length(signal) × 1` for any signal whose bit/secondary-code
@@ -274,8 +283,11 @@ the calling site for any concrete `signals` tuple type.
     end
 end
 
-@inline _current_code_wrap(::Tuple{}) = 0
-@inline _current_code_wrap(t::Tuple) = max(
+# `lcm`-folded for the same reason as `_max_code_length` above: the wrap
+# must be a common multiple of every signal's current wrap, not merely
+# the largest of them.
+@inline _current_code_wrap(::Tuple{}) = 1
+@inline _current_code_wrap(t::Tuple) = lcm(
     _current_code_length(first(t)),
     _current_code_wrap(Base.tail(t)),
 )
@@ -299,9 +311,13 @@ honors the current per-signal sync state. For each signal:
   we're in, so wrapping at the primary length is the most we can
   legitimately do.
 
-The shared wrap is the `max` across all signals, so the longest synced
-signal pins the wrap to its full sync period and shorter signals just
-ride along.
+The shared wrap is the least common multiple of the per-signal
+contributions, so it stays an integer multiple of every signal's own
+replica wrap — per-signal phases are re-derived as
+`mod(code_phase, replica_wrap)`, which a non-common-multiple wrap would
+silently corrupt (issue #129). For all shipped signal pairings the
+shorter wraps divide the longer ones, so the lcm coincides with the
+longest synced signal's wrap and shorter signals just ride along.
 """
 @inline current_code_wrap(signals::Tuple{Vararg{TrackedSignal}}) = _current_code_wrap(signals)
 
@@ -695,6 +711,44 @@ function SignalGroup(
     )
 end
 
+# Constructor invariants for a group's signal tuple (issue #129):
+# (a) every signal lives on the group's RF band — the whole group is
+#     downconverted against the single measurement that `band` routes to,
+#     so a signal on another band would silently correlate against the
+#     wrong samples (and `_validate_measurements` would never ask for its
+#     band's buffer); and
+# (b) every signal shares one chip rate — the shared `code_phase` advances
+#     at `signals[1]`'s code frequency (see `update` in
+#     downconvert_and_correlate.jl), so a signal with a different chip
+#     rate would silently mistrack.
+# Bands compare by `band_key` (not instance) so a user-defined band that
+# aliases an existing measurement key still validates.
+function _validate_signal_group(signals::Tuple{Vararg{AbstractGNSSSignal}}, band)
+    driver = first(signals)
+    foreach(signals) do s
+        if band_key(get_band(s)) !== band_key(band)
+            throw(ArgumentError(string(
+                "All signals in a SignalGroup must be on the same RF band: `",
+                nameof(typeof(s)), "` is on band `:", band_key(get_band(s)),
+                "` but the group is on band `:", band_key(band),
+                "`. Put signals on different bands into separate groups, e.g. ",
+                "`signals = (l1 = (GPSL1CA(),), l5 = (GPSL5I(),))`.",
+            )))
+        end
+        if get_code_frequency(s) != get_code_frequency(driver)
+            throw(ArgumentError(string(
+                "All signals in a SignalGroup must share one chip rate: the ",
+                "shared code phase advances at the first signal's code ",
+                "frequency (`", nameof(typeof(driver)), "`: ",
+                get_code_frequency(driver), "), but `", nameof(typeof(s)),
+                "` has ", get_code_frequency(s),
+                ". Track it in its own group instead.",
+            )))
+        end
+    end
+    nothing
+end
+
 """
 $(SIGNATURES)
 
@@ -702,6 +756,10 @@ User-facing outer constructor: build a fresh `SignalGroup` from a signal
 tuple with band and antenna count as kwargs. `band` defaults to
 `get_band(first(signals))` (so users only override for the rare case of
 naming a band differently); `num_ants` defaults to `NumAnts(1)`.
+
+All signals must live on `band` and share one chip rate — signals on other
+bands or with other chip rates belong in their own group (the constructor
+throws an `ArgumentError` otherwise).
 
 The `satellites` dictionary is left empty — populate it via
 [`add_satellite!`](@ref) after the enclosing [`TrackState`](@ref) is
@@ -725,6 +783,7 @@ function SignalGroup(
                 default_code_loop_filter_bandwidth(first(signals)),
         ),
 )
+    _validate_signal_group(signals, band)
     # Build a template TrackedSat so the dict's value type is concrete.
     # Reuses the existing helper from tracking_state.jl, which is fine
     # because doppler_estimator only affects per-sat state type, not the

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -115,9 +115,10 @@ end
     doppler_estimator::AbstractDopplerEstimator,
     num_ants::NumAnts,
 )
+    band = get_band(first(sig_tuple))
+    _validate_signal_group(sig_tuple, band)
     template = _make_template_tracked_sat(sig_tuple, doppler_estimator, num_ants)
     sats = Dictionary{Int, typeof(template)}(Int[], typeof(template)[])
-    band = get_band(first(sig_tuple))
     SignalGroup(band, sats, sig_tuple, num_ants)
 end
 

--- a/test/sat_state.jl
+++ b/test/sat_state.jl
@@ -3,7 +3,8 @@ module SatStateTest
 using Test: @test, @testset, @inferred
 using Unitful: Hz
 using Dictionaries: dictionary
-using GNSSSignals: GPSL1CA, get_code_center_frequency_ratio
+using GNSSSignals:
+    GNSSSignals, AbstractGNSSSignal, GPSL1CA, get_code_center_frequency_ratio
 using Acquisition: Acquisition, AcquisitionResults
 import Tracking
 using Tracking:
@@ -127,11 +128,12 @@ end
     synced_signals = (synced_sig,)
     @test @inferred(Tracking.current_code_wrap(synced_signals)) == 20460
 
-    # `_max_code_length` recursion terminator on an empty tuple. Not
-    # reachable via TrackedSat itself (signals tuple is always non-empty),
-    # but exercised here so the base case counts as covered.
-    @test Tracking._max_code_length(()) == 0
-    @test Tracking._current_code_wrap(()) == 0
+    # `_max_code_length` recursion terminator on an empty tuple — 1, the
+    # lcm identity. Not reachable via TrackedSat itself (signals tuple is
+    # always non-empty), but exercised here so the base case counts as
+    # covered.
+    @test Tracking._max_code_length(()) == 1
+    @test Tracking._current_code_wrap(()) == 1
 
     @testset "_post_sync_code_length per signal" begin
         # Worst-case wrap contributions across all supported signals.
@@ -143,6 +145,58 @@ end
         @test Tracking._post_sync_code_length(Tracking.TrackedSignal(GPSL1C_D())) == 10230 * 1
         @test Tracking._post_sync_code_length(Tracking.TrackedSignal(GPSL1C_P())) == 10230 * 1800
     end
+end
+
+# Pilot-style signal (data frequency 0) with arbitrary primary / secondary
+# code lengths. All real signal pairings have wrap periods that divide each
+# other, so the lcm-vs-max distinction in the shared code wrap (issue #129)
+# is only observable with fabricated lengths. Pre-sync the signal
+# contributes `code_length`; post-sync `code_length × secondary_code_length`.
+struct FakeWrapSignal <: AbstractGNSSSignal{Matrix{Int16}}
+    code_length::Int
+    secondary_code_length::Int
+end
+GNSSSignals.get_code_length(s::FakeWrapSignal) = s.code_length
+GNSSSignals.get_secondary_code_length(s::FakeWrapSignal) = s.secondary_code_length
+GNSSSignals.get_data_frequency(::FakeWrapSignal) = 0Hz
+
+@testset "shared code wrap is a common multiple, not a max (issue #129)" begin
+    # The per-signal code phase is re-derived as
+    # `mod(code_phase, _replica_code_wrap(signal))`, which is only correct
+    # when the shared wrap is an integer multiple of *every* signal's
+    # replica wrap — `max` is not a common multiple in general.
+    base = Tracking.TrackedSignal(GPSL1CA())
+    synced_buffer(::Tracking.BitBuffer{B}) where {B} = Tracking.BitBuffer{B}(
+        zero(B), 0, true, 0, Int8(+1), zero(UInt128), 0, complex(0.0, 0.0), 0, Float32[],
+        Tracking.PhaseAccumulators(),
+    )
+    fake_tracked_signal(code_length, secondary_length, found) = Tracking.TrackedSignal(
+        FakeWrapSignal(code_length, secondary_length),
+        base.integrated_samples,
+        base.is_integration_completed,
+        base.correlator,
+        base.last_fully_integrated_correlator,
+        base.last_fully_integrated_filtered_prompt,
+        base.cn0_estimator,
+        found ? synced_buffer(base.bit_buffer) : base.bit_buffer,
+        base.post_corr_filter,
+        base.filtered_prompts,
+        base.preferred_num_code_blocks_to_integrate,
+    )
+
+    # Pre-sync wraps 4 and 6: the shared wrap must be 12 (max would give 6,
+    # under which a phase of e.g. 5 re-derives as 1 for the 4-chip signal —
+    # but so does a phase of 9, silently corrupting the 4-chip signal).
+    s4 = fake_tracked_signal(4, 5, false)
+    s6 = fake_tracked_signal(6, 1, false)
+    @test @inferred(Tracking.current_code_wrap((s4, s6))) == 12
+
+    # Once the 4-chip signal syncs, its wrap widens to 4 × 5 = 20 → lcm 60.
+    s4_synced = fake_tracked_signal(4, 5, true)
+    @test @inferred(Tracking.current_code_wrap((s4_synced, s6))) == 60
+
+    # The compile-time bound covers the all-synced worst case: lcm(20, 6).
+    @test @inferred(max_code_length((s4, s6))) == 60
 end
 
 end

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -2,7 +2,8 @@ module TrackingStateTest
 
 using Test: @test, @testset, @inferred, @test_throws
 using Unitful: Hz
-using GNSSSignals: GPSL1CA, GPSL5I, GPSL1C_P, GalileoE1B
+using GNSSSignals:
+    GNSSSignals, AbstractGNSSSignal, GPSL1CA, GPSL1C_D, GPSL1C_P, GPSL5I, GalileoE1B
 using Dictionaries: Dictionary, dictionary
 import Tracking
 using Tracking:
@@ -42,7 +43,39 @@ using Tracking:
     reset_loop_filters!,
     get_doppler_estimator_state,
     ConventionalAssistedPLLAndDLL,
-    ConventionalPLLAndDLL
+    ConventionalPLLAndDLL,
+    SignalGroup
+
+# No real GNSS signal pair mixes chip rates on a single band, so fake one to
+# exercise the SignalGroup chip-rate invariant (issue #129): L1 band like
+# GPS L1 C/A, but at double the chip rate. Only `get_band` and
+# `get_code_frequency` are needed — validation throws before the group
+# touches any other part of the signal API.
+struct FakeDoubleRateL1Signal <: AbstractGNSSSignal{Matrix{Int16}} end
+GNSSSignals.get_band(::FakeDoubleRateL1Signal) = GNSSSignals.L1()
+GNSSSignals.get_code_frequency(::FakeDoubleRateL1Signal) = 2_046_000Hz
+
+@testset "SignalGroup rejects mixed bands and mixed chip rates (issue #129)" begin
+    # (a) Band homogeneity: every signal in a group is downconverted against
+    # the single band measurement the group's `band` routes to, so an L5
+    # signal in an L1 group would silently correlate against L1 samples.
+    @test_throws ArgumentError SignalGroup((GPSL1CA(), GPSL5I()))
+    @test_throws ArgumentError TrackState(; signals = (mix = (GPSL1CA(), GPSL5I()),))
+    # An explicit `band` override that contradicts the signals is just as wrong.
+    @test_throws ArgumentError SignalGroup((GPSL1CA(),); band = GNSSSignals.L5())
+
+    # (b) Shared chip rate: the shared `code_phase` advances at `signals[1]`'s
+    # code frequency, so a signal with a different chip rate silently mistracks.
+    @test_throws ArgumentError SignalGroup((GPSL1CA(), FakeDoubleRateL1Signal()))
+    @test_throws ArgumentError TrackState(;
+        signals = (l1 = (GPSL1CA(), FakeDoubleRateL1Signal()),),
+    )
+
+    # Valid same-band, same-chip-rate combinations still construct.
+    @test SignalGroup((GPSL1C_P(), GPSL1C_D(), GPSL1CA())) isa SignalGroup
+    ts = TrackState(; signals = (l1 = (GPSL1C_P(), GPSL1C_D(), GPSL1CA()), l5 = (GPSL5I(),)))
+    @test ts isa TrackState
+end
 
 @testset "Tracking state" begin
     sampling_frequency = 5e6Hz


### PR DESCRIPTION
Closes #129.

Three unenforced invariants on a `SignalGroup`'s signal tuple, all cheap constructor checks:

**(a) Band homogeneity.** The whole group is downconverted against the single measurement its `band` routes to, but the constructor only inferred `band` from `signals[1]` and never checked the rest. `TrackState(; signals = (mix = (GPSL1CA(), GPSL5I()),))` was accepted silently — the L5 signal then correlated against L1 samples and `_validate_measurements` never asked for an L5 buffer.

**(b) Shared chip rate.** The shared `code_phase` advances at `signals[1]`'s code frequency (`update` in `downconvert_and_correlate.jl`), while `_gen_all_code_replicas` generates each replica at its own `get_code_frequency`. A mixed-rate group silently mistracked signals 2..N.

**(c) Wrap modulus.** `current_code_wrap` / `max_code_length` took the `max` of per-signal wraps, but per-signal phases are re-derived as `mod(code_phase, replica_wrap)` — only correct when the shared wrap is an integer *multiple* of every signal's replica wrap. All shipped pairings (L1CA/L1C-D/L1C-P, L5I/L5Q, E1B/E1C) divide cleanly so `max` happened to work, but a future pairing where `max` isn't a common multiple would corrupt non-driver code phases silently.

## Changes

- Add `_validate_signal_group(signals, band)` in `src/sat_state.jl`, called from the `SignalGroup` outer constructor and from `_normalize_group_entry` in `src/tracking_state.jl`. It throws a descriptive `ArgumentError` when any signal's band key differs from the group's, or when any signal's code frequency differs from the driver's.
- Fold `_max_code_length` and `_current_code_wrap` with `lcm` (identity `1` on the empty tuple) instead of `max`, so the shared wrap is always a common multiple of every signal's replica wrap. For all shipped pairings the lcm coincides with the previous `max`, so runtime behavior is unchanged today.
- Docstrings on `TrackedSat`, `max_code_length`, and `current_code_wrap` updated to describe the lcm semantics.

## Tests

- `test/tracking_state.jl`: new testset rejecting mixed-band tuples (via both `SignalGroup` and `TrackState`), a contradictory explicit `band` override, and mixed-chip-rate tuples (using a fabricated double-rate L1 signal, since no real pair mixes chip rates on one band); plus positive cases confirming valid combinations still construct.
- `test/sat_state.jl`: new testset exercising the lcm-vs-max distinction with fabricated 4/6-chip signals where `lcm ≠ max`, pre- and post-sync; empty-tuple terminators updated to `1`.

Full suite green, including the Flexiband multi-band integration test.