### PR TITLE
fix(bit_buffer): decode post-sync data bits at 1-block integration (#125)

### DIFF
--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -376,10 +376,15 @@ function _buffer_find_bit(signal, prn::Integer, bit_buffer::BitBuffer{B}, num_co
         # Secondary-code signals (GPS L5I, GPS L1C-P): the buffered pre-sync
         # prompt signs are modulated by the secondary code, not the navigation
         # data, so there are no data bits to recover from them. Data-bit
-        # decoding starts fresh post-sync — the integration cadence then aligns
-        # each integration to the secondary-code (data-bit) boundary, so no
-        # accumulator seeding is needed here. We only record the recovered
-        # `secondary_phase` / `polarity`, which anchor the shared `code_phase`.
+        # decoding starts fresh post-sync. The rotation search locks at *any*
+        # secondary chip, so the upcoming integration starts `sync.phase` blocks
+        # into the current data bit — not at its boundary. Seed the accumulator
+        # block count with `sync.phase` so the first emitted bit completes
+        # exactly `num_code_blocks_that_form_a_bit − sync.phase` blocks later, on
+        # the data-bit boundary, instead of `num_code_blocks_that_form_a_bit`
+        # blocks after the lock instant (issue #125). For pilots
+        # (`num_code_blocks_that_form_a_bit == 0`) the post-sync `buffer` path
+        # returns early and never consults this seed, so it is harmless there.
         return BitBuffer{B}(
             code_block_buffer,
             code_block_buffer_lengh,
@@ -389,7 +394,7 @@ function _buffer_find_bit(signal, prn::Integer, bit_buffer::BitBuffer{B}, num_co
             zero(UInt128),
             0,
             complex(0.0, 0.0),
-            0,
+            sync.phase,
             bit_buffer.soft_bits,
         )
     end

--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -324,7 +324,16 @@ end
     prompt = get_prompt(filtered_correlator)
     push!(tracked_signal.filtered_prompts, prompt)
     cn0_estimator = update(get_cn0_estimator(tracked_signal), prompt)
-    bit_buffer = buffer(signal, sat.prn, tracked_signal.bit_buffer, integrated_code_blocks, prompt)
+    # The bit accumulator is credited with the blocks actually integrated, not
+    # the intended `integrated_code_blocks`: post-sync the first integration is
+    # truncated to land on the data-bit boundary (issue #125).
+    bit_block_count = calc_num_code_blocks_for_bit_buffer(
+        signal,
+        tracked_signal.integrated_samples,
+        sampling_frequency,
+        has_bit_or_secondary_code_been_found(tracked_signal.bit_buffer),
+    )
+    bit_buffer = buffer(signal, sat.prn, tracked_signal.bit_buffer, bit_block_count, prompt)
     integration_time = tracked_signal.integrated_samples / sampling_frequency
 
     # The configured bandwidths are referenced to a one-primary-code-period
@@ -413,18 +422,21 @@ end
         return tracked_signal
     end
     signal = tracked_signal.signal
-    integrated_code_blocks = calc_num_code_blocks_to_integrate(
-        signal,
-        tracked_signal.preferred_num_code_blocks_to_integrate,
-        has_bit_or_secondary_code_been_found(tracked_signal.bit_buffer),
-    )
     normalized_correlator = normalize(tracked_signal.correlator, tracked_signal.integrated_samples)
     post_corr_filter = update(tracked_signal.post_corr_filter, get_prompt(normalized_correlator))
     filtered_correlator = apply(post_corr_filter, normalized_correlator)
     prompt = get_prompt(filtered_correlator)
     push!(tracked_signal.filtered_prompts, prompt)
     cn0_estimator = update(get_cn0_estimator(tracked_signal), prompt)
-    bit_buffer = buffer(signal, prn, tracked_signal.bit_buffer, integrated_code_blocks, prompt)
+    # Credit the accumulator with the blocks actually integrated (truncated on
+    # the first post-sync integration), not the intended count (issue #125).
+    bit_block_count = calc_num_code_blocks_for_bit_buffer(
+        signal,
+        tracked_signal.integrated_samples,
+        sampling_frequency,
+        has_bit_or_secondary_code_been_found(tracked_signal.bit_buffer),
+    )
+    bit_buffer = buffer(signal, prn, tracked_signal.bit_buffer, bit_block_count, prompt)
     TrackedSignal(
         tracked_signal;
         integrated_samples = 0,

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -416,21 +416,26 @@ end
     (first(t) == chosen, _flag_completed(Base.tail(t), chosen)...)
 
 # Code-phase wrap to use when generating a signal's code replica / sizing its
-# integration window over `num_blocks` primary blocks. For a MULTI-block
-# (`num_blocks > 1`) coherent integration past sync, the wrap must preserve the
-# secondary-/overlay-code phase: otherwise `gen_code!` bakes the secondary code
-# starting at chip 0 and the N blocks sum against a misaligned overlay (the
-# coherent sum cancels), and the boundary calc would start the N-block window
-# off the secondary phase and straddle the data-symbol boundary. A SINGLE-block
-# integration (`num_blocks == 1`) deliberately keeps the primary wrap so the
-# replica stays primary-only — the per-block secondary sign is then handled by
-# the bit buffer, exactly as before sync; this keeps the N=1 path bit-identical
-# and avoids double-removing the secondary. Before sync only the primary phase
-# is known. (Signals without a baked secondary code — e.g. GPS L1 C/A — are
-# unaffected: the primary repeats every `get_code_length` chips, secondary
-# length 1.)
+# integration window. Past sync the wrap is the full secondary-/bit-period
+# length so that `gen_code!` bakes the secondary code at the correct chip for
+# the current primary-code period: the replica's start phase carries the
+# secondary-period offset, so the secondary sign is wiped per block right in
+# the replica. This holds at ANY integration length — including the default
+# `num_blocks == 1`. The previous code kept the N=1 replica primary-only and
+# left the per-block secondary sign for the bit buffer to handle, but the
+# post-sync bit decoder never did that wipe, so a `data × Σ(secondary signs)`
+# collapse cost ~14 dB of decision margin at the default 1-block integration
+# (issue #125). Wiping in the replica matches what `master` did via
+# `update_code_phase` and is correct for multi-block windows too (otherwise the
+# N blocks sum against a misaligned overlay and the coherent sum cancels).
+# The boundary calc is unaffected at N=1: `calc_num_chips_to_integrate` re-mods
+# the phase by the primary length, so the wider wrap yields the same per-block
+# boundary. Before sync only the primary phase is known, so the wrap stays at
+# the primary length. (Signals without a baked secondary code — e.g. GPS L1
+# C/A — are unaffected: the primary repeats every `get_code_length` chips,
+# secondary length 1.) `num_blocks` is retained for call-site symmetry.
 @inline _replica_code_wrap(tsig::TrackedSignal, num_blocks::Integer) =
-    (num_blocks > 1 && has_bit_or_secondary_code_been_found(tsig)) ?
+    has_bit_or_secondary_code_been_found(tsig) ?
     _post_sync_code_length(tsig) : get_code_length(tsig.signal)
 
 # Single-signal path: gen one code replica + run the in-register fused

--- a/src/sample_parameters.jl
+++ b/src/sample_parameters.jl
@@ -26,6 +26,41 @@ end
 """
 $(SIGNATURES)
 
+Number of primary code blocks to credit the bit-buffer accumulator with for a
+just-completed integration.
+
+Pre-sync this is always 1: the bit/secondary-code search shifts exactly one
+prompt sign into its window per call, and a non-block-aligned start can make
+the first integration a *fractional* block — reporting anything but 1 would
+trip the single-block invariant in `_buffer_find_bit`.
+
+Post-sync it is the number of whole blocks the integration actually covered,
+recovered from its sample count. Integrations then end on a secondary-/data-bit
+boundary so this divides cleanly (the `round` absorbs the sub-chip Doppler
+residual in `code_frequency`). This can differ from the *intended* count
+returned by [`calc_num_code_blocks_to_integrate`](@ref): the first post-sync
+integration is truncated to `secondary_code_length − secondary_phase` blocks so
+it lands on the data-bit boundary, even though the preferred length is the full
+bit period. Crediting the accumulator with the intended length would misalign
+the decoded bits (issue #125).
+"""
+@inline function calc_num_code_blocks_for_bit_buffer(
+    signal::AbstractGNSSSignal,
+    integrated_samples::Integer,
+    sampling_frequency,
+    secondary_code_or_bit_found::Bool,
+)
+    secondary_code_or_bit_found || return 1
+    round(
+        Int,
+        integrated_samples * get_code_frequency(signal) /
+        (get_code_length(signal) * sampling_frequency),
+    )
+end
+
+"""
+$(SIGNATURES)
+
 Calculates the number of chips to integrate.
 """
 function calc_num_chips_to_integrate(

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -13,7 +13,8 @@ using Tracking:
     get_bits,
     get_num_bits,
     get_soft_bits,
-    has_bit_or_secondary_code_been_found
+    has_bit_or_secondary_code_been_found,
+    set_preferred_num_code_blocks_to_integrate!
 
 @testset "Bit detection integration test" begin
     gpsl1 = GPSL1CA()
@@ -139,8 +140,108 @@ end
         track_state = TrackState(gpsl5, [TrackedSat(gpsl5, prn, start_phase, 0.0Hz)])
         track_state = track(signal, track_state, sampling_frequency)
         @test has_bit_or_secondary_code_been_found(track_state)
-        @test get_code_phase(track_state) ==
-              (k % secondary_code_length) * primary_code_length + 0.5 * primary_code_length
+        # Post-sync the replica bakes the NH chip per block (issue #125), so the
+        # loop sees a sign-consistent prompt and code Doppler nudges by floating-
+        # point noise over the continuous 60-block run; the converged code phase
+        # lands on chip `k mod 10` + the leftover half block up to a sub-microchip
+        # residual (~5e-7 of 10230 chips). Same tolerance as the L1C-P run below.
+        @test get_code_phase(track_state) ≈
+              (k % secondary_code_length) * primary_code_length + 0.5 * primary_code_length atol = 1e-4
+    end
+end
+
+# GPS L5I post-sync data-bit decoding (issue #125).
+#
+# The NH10 rotation search locks at *any* secondary chip, so the post-sync bit
+# decoder must (a) wipe the NH code from each prompt — at the default 1-block
+# integration the replica covers a single primary period and has to bake the
+# correct NH chip, otherwise a 10-block "bit" sum collapses to
+# `data x Σ(NH signs)` and loses ~14 dB of decision margin — and (b) start its
+# accumulation grid at the recovered secondary phase rather than at the lock
+# instant, so bits are emitted on the NH10 / data-bit boundary. This decodes a
+# known bit sequence through boundary and non-boundary locks at both the default
+# 1-block and a 10-block coherent integration.
+#
+# Note on polarity: locking onto a periodic secondary code carries an inherent
+# ±1 data-polarity ambiguity (the rotation search cannot tell a data "1" period
+# from a "0" period — both match the NH pattern in one orientation), resolved
+# downstream by the nav-message preamble. The fix's job is a *clean, aligned,
+# uncancelled* decode, so the sequence is checked up to a single global
+# inversion, with the per-bit coherent magnitude asserted near the full NH10
+# length (≈10, vs ≈2 if the NH code were left in).
+@testset "GPS L5I post-sync data-bit decoding (issue #125)" begin
+    gpsl5 = GPSL5I()
+    prn = 1
+    sampling_frequency = 25e6Hz
+    code_frequency = get_code_frequency(gpsl5)
+    primary_code_length = get_code_length(gpsl5)              # 10230 chips
+    secondary_code_length = get_secondary_code_length(gpsl5)  # 10 (NH10)
+    num_samples = round(Int, 25e6 / 1000)                     # 1 ms = one primary block
+
+    # One data bit per NH10 period (10 primary blocks). The first two bits are
+    # equal so the rotation search locks cleanly on a 10-block window that may
+    # straddle their boundary.
+    data_bits = [1, 1, 0, 1, 0, 0, 1, 1, 0, 1]
+
+    @testset "preferred = $preferred_blocks, start chip $start_secondary_chip" for
+            preferred_blocks in (1, 10), start_secondary_chip in (0, 3, 9)
+        # One continuous signal: `gen_code` bakes the NH chip per block via the
+        # advancing code phase, and each 1 ms block is scaled by its data bit.
+        # Fed in a single `track` call so the inner loop owns all block-boundary
+        # bookkeeping — robust to the sub-sample code-Doppler the loop develops,
+        # which would otherwise straddle fixed per-call chunks and drop bits.
+        total_blocks = secondary_code_length * length(data_bits) - start_secondary_chip
+        signal = ComplexF32.(
+            gen_code(
+                total_blocks * num_samples,
+                gpsl5,
+                prn,
+                sampling_frequency,
+                code_frequency,
+                start_secondary_chip * primary_code_length,
+            ),
+        )
+        for b in 0:(total_blocks-1)
+            abs_block = start_secondary_chip + b
+            data_bit = data_bits[div(abs_block, secondary_code_length)+1]
+            block_range = (b*num_samples+1):((b+1)*num_samples)
+            @views signal[block_range] .*= ComplexF32(2 * data_bit - 1)
+        end
+
+        track_state = TrackState(
+            gpsl5,
+            [TrackedSat(gpsl5, prn, start_secondary_chip * primary_code_length, 0.0Hz)],
+        )
+        set_preferred_num_code_blocks_to_integrate!(track_state, prn, preferred_blocks)
+        track_state = track(signal, track_state, sampling_frequency)
+
+        @test has_bit_or_secondary_code_been_found(track_state)
+
+        # The pre-sync rotation search consumes the first NH10 period (the lead
+        # of the lock data bit); decoding then begins with the remainder of that
+        # same data bit (`data_bits[2]`) and proceeds bit-by-bit. The trailing
+        # data bit may be left mid-integration, so compare the bits that
+        # completed.
+        soft_bits = get_soft_bits(track_state)
+        decoded_bits = [Int(s > 0) for s in soft_bits]
+        n_decoded = length(decoded_bits)
+        expected = data_bits[2:(1+n_decoded)]
+
+        # At least every full data bit but the last must have decoded.
+        @test n_decoded >= length(data_bits) - 2
+        # Clean, boundary-aligned decode — up to the global polarity ambiguity.
+        @test decoded_bits == expected || decoded_bits == 1 .- expected
+        # Soft-bit signs are internally consistent with the hard bits.
+        @test all((soft_bits .> 0) .== (decoded_bits .== 1))
+        # The NH code is wiped: every *full* post-sync bit (all but a possibly
+        # truncated first one, when the lock lands mid data bit) sums coherently.
+        # A full bit spans `secondary_code_length` primary blocks; the soft bit
+        # sums one unit-magnitude prompt per `preferred_blocks`-block integration,
+        # so its magnitude is ≈ `secondary_code_length / preferred_blocks`. Left
+        # in, the NH signs would nearly cancel (≈2 for NH10 at 1-block), so this
+        # half-of-nominal floor is the load-bearing assertion of the fix.
+        full_bit_magnitude = secondary_code_length / preferred_blocks
+        @test all(>(0.5 * full_bit_magnitude), abs.(soft_bits[2:end]))
     end
 end
 


### PR DESCRIPTION
## Summary

Fixes GPS L5I (and any secondary-code signal) post-sync data-bit decoding at the default `preferred_num_code_blocks_to_integrate = 1`. Two compounding bugs, plus a related accounting bug, are addressed.

Closes #125.

### (a) NH code is now wiped at N=1
The N=1 post-sync replica was deliberately kept primary-only, so each 1 ms prompt still carried its NH chip sign and a 10-block "bit" sum collapsed to `data × Σ(NH signs)` — about 14 dB of decision-margin loss even when perfectly aligned. `_replica_code_wrap` now returns the full secondary-/bit-period wrap whenever sync has been found, at **any** integration length, so `gen_code!` bakes the correct NH chip for each primary-code period and the secondary sign is wiped right in the replica (matching what `master` did via `update_code_phase`). The per-block integration boundary is unchanged at N=1 — `calc_num_chips_to_integrate` re-mods the phase by the primary length.

### (b) Accumulation grid now honors `secondary_phase`
The rotation search locks at *any* secondary chip, so the upcoming integration starts `phase` blocks into the current data bit, not at its boundary. `_buffer_find_bit` now seeds `prompt_accumulator_integrated_code_blocks = sync.phase`, so the first bit is emitted exactly on the NH10 / data-bit boundary instead of `num_code_blocks_that_form_a_bit` blocks after the lock instant.

### Related: actual vs intended block count
The first post-sync integration is truncated to `secondary_code_length − phase` blocks so it lands on the data-bit boundary, but `buffer` was credited the *intended* count from `calc_num_code_blocks_to_integrate`, misaligning every subsequent bit. The new `calc_num_code_blocks_for_bit_buffer` recovers the **actual** whole-block count from the integration's sample count post-sync (and reports 1 pre-sync, where a non-block-aligned start can otherwise yield a fractional first block and trip the single-block invariant).

## Test

Adds a behavioral test (`test/bit_integration_test.jl`) that decodes a known data-bit sequence through **boundary and non-boundary** NH10 locks at both **1-block and 10-block** coherent integration. It feeds one continuous signal in a single `track` call (so the inner loop owns block-boundary bookkeeping, robust to the sub-sample code-Doppler the loop develops) and asserts:
- the decoded sequence matches the data up to the inherent secondary-code polarity ambiguity (a single global inversion),
- soft- and hard-bit signs are internally consistent,
- the per-bit coherent magnitude is near its full value (≈ `secondary_code_length / preferred_blocks`) rather than the ≈2 the NH signs would leave — the load-bearing check for the NH wipe.

Confirmed the test fails without the NH-wipe fix (only the `preferred = 1` cases, as expected — `preferred = 10` already wiped NH for multi-block windows) and passes with it. The existing sub-block-start phase assertion is relaxed from `==` to `≈ atol=1e-4` for the sub-microchip code-phase residual the corrected loop now develops (same tolerance the L1C-P run already uses).

The full package test suite is green.