### PR TITLE
ci(bench): minimum-time table + Int16-vs-Float32 pairing (GNSSSignals-style)

### DIFF
--- a/.github/scripts/bench_table.jl
+++ b/.github/scripts/bench_table.jl
@@ -1,0 +1,165 @@
+# Build a PR-comment markdown table from benchpkg result JSONs, reporting the
+# *minimum* time per benchmark instead of AirspeedVelocity's median. The minimum
+# is robust to noisy-neighbour contention on shared CI runners (it captures the
+# least-disturbed sample), so it doesn't manufacture phantom regressions when the
+# head build happens to land on a busier runner window.
+#
+# The comment has two parts:
+#
+#   1. **Int16 vs Float32** — a head-to-head of the two `track!` backends. The
+#      integer backend is NEW on the PR (no base counterpart), so a plain
+#      base-vs-head diff can't show its speedup. Instead we pair each scenario's
+#      `Float32` and `Int16` leaves — registered side by side under
+#      `track! Int16 vs Float32/<scenario>/{Float32,Int16}` — into one row and
+#      report Float32 / Int16 (>1 ⇒ the integer backend is faster).
+#
+#   2. **Regression table** — every other benchmark, base rev vs PR head, the
+#      usual "did this PR get slower?" view.
+#
+# Usage:  julia bench_table.jl <input_dir> <pkg> <base_rev> <head_rev> [label]
+# The optional <label> (e.g. the runner OS) is appended to the headings so a
+# multi-platform matrix can post one distinct comment per platform.
+using JSON3
+
+input_dir, pkg, base_rev, head_rev = ARGS[1], ARGS[2], ARGS[3], ARGS[4]
+label = length(ARGS) >= 5 ? ARGS[5] : ""
+
+readrev(rev) = open(joinpath(input_dir, "results_$(pkg)@$(rev).json"), "r") do io
+    JSON3.read(io, Dict{String,Any})
+end
+
+# Recursively collect leaf trials (nodes carrying a "times" array) keyed by "a/b/c".
+function leaves!(acc, node, prefix = "")
+    if haskey(node, "times")
+        acc[prefix] = node
+    elseif haskey(node, "data")
+        for (k, v) in node["data"]
+            name = isempty(prefix) ? String(k) : prefix * "/" * String(k)
+            leaves!(acc, v, name)
+        end
+    end
+    acc
+end
+
+mintime(node) = minimum(Float64.(node["times"]))   # ns
+
+function fmt_time(ns)
+    unit, div = ns < 1e3 ? ("ns", 1.0) :
+                ns < 1e6 ? ("μs", 1e3) :
+                ns < 1e9 ? ("ms", 1e6) : ("s", 1e9)
+    string(round(ns / div; sigdigits = 3), " ", unit)
+end
+
+fmt_mem(node) = string(round(Int, node["allocs"]), " allocs: ", round(Int, node["memory"]), " B")
+
+# Ratio cell with a fast/slow marker. `faster_when` picks which direction is good:
+# for regressions base/head (>1 ⇒ PR faster); for Int16-vs-Float32 Float32/Int16
+# (>1 ⇒ Int16 faster). ✅ ≥ 5 % faster, ⚠️ ≥ 5 % slower.
+function fmt_ratio(r)
+    s = string(round(r; sigdigits = 3))
+    r >= 1.05 ? "$s ✅" : r <= 0.95 ? "$s ⚠️" : s
+end
+
+base = leaves!(Dict{String,Any}(), readrev(base_rev))
+head = leaves!(Dict{String,Any}(), readrev(head_rev))
+
+# The Int16-vs-Float32 backend head-to-head group (see benchmark/benchmarks.jl).
+const INT16_GROUP = "track! Int16 vs Float32"
+
+shortrev(rev) = length(rev) >= 16 && !occursin('/', rev) ? rev[1:8] * "…" : rev
+headlbl = shortrev(head_rev)
+baselbl = shortrev(base_rev)
+
+io = IOBuffer()
+suffix = isempty(label) ? "" : " — $label"
+println(io, "## Benchmark Results (minimum time)$suffix")
+println(io)
+println(io, "Reporting the **minimum** over all samples (robust to shared-runner ",
+            "contention), not the median.")
+println(io)
+
+# ── Section 1: Int16 vs Float32 backend head-to-head (PR head only) ──────────
+# Pair "<INT16_GROUP>/<scenario>/Float32" with ".../Int16" from the head rev.
+pairs = Dict{String,Dict{String,Any}}()   # scenario => Dict("Float32"=>node, "Int16"=>node)
+order = String[]                           # first-seen scenario order
+for k in sort(collect(keys(head)))
+    startswith(k, INT16_GROUP * "/") || continue
+    rest = k[lastindex(INT16_GROUP)+2:end]           # "<scenario>/<backend>"
+    slash = findlast('/', rest)
+    slash === nothing && continue
+    scenario = rest[1:prevind(rest, slash)]
+    backend = rest[nextind(rest, slash):end]
+    d = get!(pairs, scenario) do
+        push!(order, scenario)
+        Dict{String,Any}()
+    end
+    d[backend] = head[k]
+end
+
+if !isempty(order)
+    println(io, "### Int16 vs Float32 backend (`track!`, PR head)")
+    println(io)
+    println(io, "Ratio = Float32 / Int16: **>1 means the integer backend is faster**. ",
+                "✅ ≥ 5 % faster, ⚠️ ≥ 5 % slower.")
+    println(io)
+    println(io, "| Scenario | Float32 | Int16 | Float32 / Int16 |")
+    println(io, "|:--|--:|--:|--:|")
+    for scenario in order
+        d = pairs[scenario]
+        f = get(d, "Float32", nothing)
+        i = get(d, "Int16", nothing)
+        fcell = f === nothing ? "" : fmt_time(mintime(f))
+        icell = i === nothing ? "" : fmt_time(mintime(i))
+        rcell = (f !== nothing && i !== nothing) ? fmt_ratio(mintime(f) / mintime(i)) : ""
+        println(io, "| $scenario | $fcell | $icell | $rcell |")
+    end
+    println(io)
+end
+
+# ── Section 2: base-vs-head regression table for every other benchmark ───────
+# Stable ordering over the UNION of both revs' benchmarks (so rows new on the PR
+# still appear), excluding the Int16-vs-Float32 group (covered above). Sort
+# alphabetically, then push time_to_load last.
+isint16(n) = startswith(n, INT16_GROUP * "/")
+names = sort(collect(union(keys(base), keys(head))))
+filter!(n -> !isint16(n) && n != "time_to_load", names)
+(haskey(base, "time_to_load") || haskey(head, "time_to_load")) && push!(names, "time_to_load")
+
+println(io, "<details open><summary>Time benchmarks (base vs PR head)</summary>")
+println(io)
+println(io, "Ratio = $baselbl / $headlbl: **>1 means the PR is faster**. ✅ ≥ 5 % faster, ",
+            "⚠️ ≥ 5 % slower. A blank cell means the benchmark exists on only one revision ",
+            "(🆕 = new on the PR, 🗑 = removed).")
+println(io)
+println(io, "|  | $baselbl | $headlbl | $baselbl / $headlbl |")
+println(io, "|:--|--:|--:|--:|")
+for n in names
+    b = get(base, n, nothing); h = get(head, n, nothing)
+    bcell = b === nothing ? "" : fmt_time(mintime(b))
+    hcell = h === nothing ? "" : fmt_time(mintime(h))
+    if b !== nothing && h !== nothing
+        rcell = fmt_ratio(mintime(b) / mintime(h))
+    else
+        rcell = h === nothing ? "🗑" : "🆕"
+    end
+    println(io, "| $n | $bcell | $hcell | $rcell |")
+end
+println(io)
+println(io, "</details>")
+println(io)
+
+# --- memory table ---
+println(io, "<details><summary>Memory benchmarks (base vs PR head)</summary>")
+println(io)
+println(io, "|  | $baselbl | $headlbl |")
+println(io, "|:--|--:|--:|")
+for n in names
+    b = get(base, n, nothing); h = get(head, n, nothing)
+    bcell = b === nothing ? "" : fmt_mem(b)
+    hcell = h === nothing ? "" : fmt_mem(h)
+    println(io, "| $n | $bcell | $hcell |")
+end
+println(io)
+println(io, "</details>")
+
+print(String(take!(io)))

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,125 +1,102 @@
 name: Benchmark this PR
+
+# Compares the PR head against the PR's *base* branch with AirspeedVelocity's `benchpkg`,
+# but reports the **minimum** time per benchmark instead of its built-in median table (the
+# minimum is far more robust to noisy-neighbour contention on shared GitHub runners, so it
+# doesn't manufacture phantom regressions when the head build lands on a busier window). The
+# custom table (`.github/scripts/bench_table.jl`) also pairs the Int16 and Float32 `track!`
+# backends into one Int16-vs-Float32 speedup row — the integer backend is new on the PR and
+# has no base counterpart, so a plain base-vs-head diff can't show its speedup.
+#
+# Runs on both x86 (Ubuntu) and ARM (Apple Silicon, macos-14) so the NEON code path gets
+# benchmarked on real Apple-Silicon hardware, not just the x86 AVX2/AVX-512 paths.
+#
+# Security: runs as pull_request_target so the comment-posting token has write access. The
+# repo is checked out at the *base* (trusted) ref — which provides bench_table.jl — and
+# benchpkg benchmarks the PR's own benchmark/benchmarks.jl via --bench-on=<head sha>.
+# GITHUB_TOKEN is blanked for every step that builds/executes benchmark code; only the
+# comment steps see the token.
+#
+# NOTE: for pull_request_target GitHub reads this workflow from the PR's BASE branch, so a
+# rewrite only takes effect for PRs whose base already contains it — it must be merged to
+# master (and to any feature branch used as a base) to apply there.
 on:
   pull_request_target:
-    branches: [ '**' ]
+
+# Key the concurrency group on the PR number: a new push to a PR cancels that PR's own
+# in-flight run, but PRs sharing a base branch don't cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
-  bench:
-    runs-on: ubuntu-latest
+  benchmark:
+    # Run on both x86 (Ubuntu) and ARM (Apple Silicon: macos-14 is M-series).
+    # fail-fast: false so a flake on one platform doesn't cancel the other's results.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.runner }}
     steps:
+      # Base (trusted) checkout — provides .github/scripts/bench_table.jl. The PR's own
+      # code is fetched separately by benchpkg via --url, not checked out here.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: julia-actions/setup-julia@v3
         env:
           GITHUB_TOKEN: ""
         with:
           version: '1'
-
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@v5
         env:
           GITHUB_TOKEN: ""
 
-      - name: Install AirspeedVelocity
+      - name: Install benchpkg + JSON3
         env:
           GITHUB_TOKEN: ""
         run: |
-          # Use fork with [sources] fix until upstream merges it
-          julia -e '
-            ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0
-            using Pkg
-            Pkg.add(url="https://github.com/zsoerenm/AirspeedVelocity.jl", rev="ss/fix-sources-resolution")
-            Pkg.build("AirspeedVelocity")
-          '
+          export JULIA_PKG_PRECOMPILE_AUTO=0
+          julia -e 'import Pkg; Pkg.add(name="AirspeedVelocity", version="0.6"); Pkg.add("JSON3")'
+          julia -e 'import Pkg; Pkg.build("AirspeedVelocity")'
+          echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
 
-      - name: Run benchmarks
+      - name: Run benchmarks (base vs PR head, using the PR's benchmark suite)
         env:
           GITHUB_TOKEN: ""
-          JULIA_NUM_THREADS: auto
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          export PATH="$HOME/.julia/bin:$PATH"
-          mkdir results
-          if [ "$BASE_REF" = "master" ]; then
-            REVS="master,$HEAD_SHA"
-          else
-            REVS="master,$BASE_REF,$HEAD_SHA"
-          fi
+          mkdir -p results
           benchpkg Tracking \
-            --rev=$REVS \
             --url=${{ github.event.repository.clone_url }} \
-            --bench-on=$HEAD_SHA \
+            --rev=${{ github.event.pull_request.base.sha }},${{ github.event.pull_request.head.sha }} \
+            --bench-on=${{ github.event.pull_request.head.sha }} \
+            --add=GNSSSignals,Unitful,StaticArrays \
             --output-dir=results/ \
-            --add=GNSSSignals,Unitful,StaticArrays
+            --tune
 
-      - name: Create comment body
+      - name: Build minimum-time comparison table
         env:
           GITHUB_TOKEN: ""
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          export PATH="$HOME/.julia/bin:$PATH"
-          echo "## Benchmark Results" > body.md
-          echo "" >> body.md
-          if [ "$BASE_REF" = "master" ]; then
-            for m in time memory; do
-              {
-                echo "<details><summary>${m^} benchmarks</summary>"
-                echo ""
-                benchpkgtable Tracking \
-                  --input-dir=results/ \
-                  --rev=master,$HEAD_SHA \
-                  --mode=$m \
-                  --ratio
-                echo ""
-                echo "</details>"
-                echo ""
-              } >> body.md
-            done
-          else
-            for m in time memory; do
-              {
-                echo "<details><summary>${m^} benchmarks (vs base branch)</summary>"
-                echo ""
-                benchpkgtable Tracking \
-                  --input-dir=results/ \
-                  --rev=$BASE_REF,$HEAD_SHA \
-                  --mode=$m \
-                  --ratio
-                echo ""
-                echo "</details>"
-                echo ""
-              } >> body.md
-            done
-            for m in time memory; do
-              {
-                echo "<details><summary>${m^} benchmarks (vs master)</summary>"
-                echo ""
-                benchpkgtable Tracking \
-                  --input-dir=results/ \
-                  --rev=master,$HEAD_SHA \
-                  --mode=$m \
-                  --ratio
-                echo ""
-                echo "</details>"
-                echo ""
-              } >> body.md
-            done
-          fi
+          julia .github/scripts/bench_table.jl results Tracking \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            "${{ matrix.runner }}" > body.md
+          cat body.md
 
-      - name: Find comment
+      - name: Find existing benchmark comment
         uses: peter-evans/find-comment@v4
         id: find
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: "Benchmark Results"
+          body-includes: "Benchmark Results (minimum time) — ${{ matrix.runner }}"
 
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v5


### PR DESCRIPTION
Rewrites the PR benchmark workflow to mirror [GNSSSignals' `Benchmarks.yml`](https://github.com/JuliaGNSS/GNSSSignals.jl/blob/v3.0.0/.github/workflows/Benchmarks.yml):

- **Minimum time** per benchmark (robust to shared-runner contention) via a custom `.github/scripts/bench_table.jl`, instead of `benchpkgtable`'s median.
- **x86 + ARM matrix** (`ubuntu-latest`, `macos-14`) so the NEON path is measured on real Apple Silicon.
- **Dedicated "Int16 vs Float32" table**: the integer backend is new on #160 and has no base counterpart, so a plain base-vs-head diff can't show its speedup. The script pairs each scenario's `Float32`/`Int16` leaves into one row with the `Float32/Int16` ratio (>1 = integer backend faster). All other benchmarks keep the usual base-vs-head regression table.

### Why this must go to master directly
`pull_request_target` reads the workflow **and its scripts** (via the base checkout) from the PR's **base** branch. So this only takes effect for #160's benchmark comment once it's on `master`.

### Example rendered table
> ### Int16 vs Float32 backend (`track!`, PR head)
> | Scenario | Float32 | Int16 | Float32 / Int16 |
> |:--|--:|--:|--:|
> | GPS L1CA, 8 sats @ 5 MHz | 3.0 μs | 1.5 μs | 2.0 ✅ |
> | Galileo E1B, 4 sats @ 25 MHz | 9.0 μs | 6.8 μs | 1.32 ✅ |

Pairs with PR #160, which renames the benchmark scenarios (`benchmark/benchmarks.jl`) to the self-explanatory, slash-free names this table keys on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)