### PR TITLE
test(track): isolate E1B carrier residual & tighten tolerance to 1e-2 (#170)

### DIFF
--- a/test/track.jl
+++ b/test/track.jl
@@ -376,12 +376,16 @@ end
     @test mod(get_carrier_phase(track_state, :gps, 1), π) ≈ mod(comp_carrier_phase_gps, π) atol =
         2e-2
     @test get_code_phase(track_state, :gal, 1) ≈ comp_code_phase_gal atol = 5e-3
-    # Galileo E1B carrier phase: the embedded-LUT CBOC code is an Int8 integer
-    # approximation, and at the coarsest sample type (Int16) the extra quantisation
-    # leaves ~0.006 rad (~0.4°) of residual phase — excellent tracking, but just over
-    # the original 5e-3. Match the GPS carrier tolerance (2e-2); see GNSSSignals #90.
+    # Galileo E1B carrier phase: the GNSSSignals 3 embedded-LUT CBOC code is an Int8
+    # integer approximation of the true BOC(1,1)/BOC(6,1) subcarrier mix, which leaves
+    # ~0.006 rad (~0.4°) of residual phase — excellent tracking, but just over the
+    # original 5e-3. This residual comes from the code *model*, not the input sample
+    # type: it measures identically (to <1e-7 rad) for every `type` from Int16 through
+    # Float64, so Int16 sample quantisation contributes essentially nothing (~2e-8 rad).
+    # Bound at 1e-2 — comfortably above the deterministic ~0.006 rad residual, yet tight
+    # enough to catch a real tracking regression (see GNSSSignals #90).
     @test mod(get_carrier_phase(track_state, :gal, 1), π) ≈ mod(comp_carrier_phase_gal, π) atol =
-        2e-2
+        1e-2
 end
 
 @testset "Tracking with intermediate frequency of $intermediate_frequency" for intermediate_frequency in


### PR DESCRIPTION
## Summary

Resolves the #160 review finding #170: the Galileo E1B carrier-phase assertion in the *"Track multiple systems of type \$type"* testset was relaxed 4× (`5e-3` → `2e-2`), attributed to Int16 sample quantisation. The review asked to **isolate the cause or scope the relaxation**.

## What I found (isolation)

Measured the converged E1B carrier residual per sample type by replicating the testset:

| `type`  | E1B carrier residual (rad) |
|---------|----------------------------|
| Int16   | 0.006436110 |
| Int32   | 0.006436103 |
| Int64   | 0.006436089 |
| Float32 | 0.006436089 |
| Float64 | 0.006436089 |

The residual is **~0.00644 rad for every sample type**, differing by only **~2e-8 rad** between Int16 and Float64. So:

- The residual is entirely the **GNSSSignals 3 Int8-CBOC code-model approximation**, not input sample quantisation — Int16 rounding contributes ~0.0003% of it (~2e-8 rad).
- The original comment's attribution to "the coarsest sample type (Int16) … extra quantisation" was incorrect.
- Scoping the relaxation to only the coarse integer types (issue option b) is **not viable**: Float32/Float64 also exceed the old `5e-3`.

## What I changed

- Tightened the E1B carrier bound from `2e-2` to **`1e-2`** — ~1.55× above the deterministic ~0.006 rad residual (headroom for cross-platform FP variation) while catching real regressions the `2e-2` (3× headroom) bound would pass silently.
- Rewrote the code comment to record the isolated, sample-type-independent cause.

Test-only change; the full `test/track.jl` suite (all five sample types) passes with the tightened bound.

Sub-issue of tracking issue https://github.com/JuliaGNSS/Tracking.jl/issues/173. Stacked on #160 (`even-faster-tracking`).

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)