### PR TITLE
fix(int16): reject `steps` that changes the carrier engine width (#168)

### DIFF
--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -198,6 +198,34 @@ struct Int16ThreadedDownconvertAndCorrelator{TBL<:SinCosTable,TI} <:
     blk::Int
 end
 
+# The kernels stride the sample buffer by the compile-time constant `_INT16_W`
+# (the Int8 LUT SIMD width at the default `steps = 64`), but the carrier engine's
+# actual chunk width is set by the table's backend, which SinCosLUT selects from
+# `steps`. A `steps` that yields a different width desynchronises the carrier fill
+# from the kernel stride and silently corrupts the carrier replica (#168), so
+# reject it at construction. The width is checked against the engine the kernel
+# actually builds (`carrier_engine(table, …)`), so `steps` values that happen to
+# keep the same backend width (e.g. `steps = 128` on an AVX-512 host) are allowed.
+function _int16_assert_engine_width(table::SinCosTable)
+    W = SinCosLUT.carrier_width(carrier_engine(table, 0))
+    W == _INT16_W || throw(
+        ArgumentError(
+            string(
+                "Int16DownconvertAndCorrelator: the carrier table's SIMD engine ",
+                "width (",
+                W,
+                ") does not match the kernel stride `_INT16_W` (",
+                _INT16_W,
+                "). This happens when `steps` selects a different ",
+                "SinCosLUT backend than the default `steps = 64` on this host; a ",
+                "mismatched width would silently corrupt the carrier replica. ",
+                "Use `steps = 64`.",
+            ),
+        ),
+    )
+    return nothing
+end
+
 function Int16DownconvertAndCorrelator(;
     max_meas::Integer = _INT16_MAX_MEAS,
     steps::Integer = 64,
@@ -205,6 +233,7 @@ function Int16DownconvertAndCorrelator(;
 )
     amplitude, TI = _int16_choose_carrier(max_meas)
     table = SinCosTable(Int8; steps, amplitude)
+    _int16_assert_engine_width(table)
     Int16DownconvertAndCorrelator{typeof(table),TI}(
         Int16ScratchBuffers{TI}(),
         table,
@@ -219,6 +248,7 @@ function Int16ThreadedDownconvertAndCorrelator(;
 )
     amplitude, TI = _int16_choose_carrier(max_meas)
     table = SinCosTable(Int8; steps, amplitude)
+    _int16_assert_engine_width(table)
     Int16ThreadedDownconvertAndCorrelator{typeof(table),TI}(
         [Int16ScratchBuffers{TI}() for _ = 1:Threads.maxthreadid()],
         table,

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -335,6 +335,22 @@ end
         )
     end
 
+    @testset "rejects a `steps` that changes the engine width (#168)" begin
+        # The kernels stride by the compile-time `_INT16_W`; a `steps` whose
+        # SinCosLUT backend has a different SIMD width would silently corrupt the
+        # carrier. `steps = 48` is never a supported permute size → Portable
+        # (width 1), so on any non-portable host it mismatches and must be
+        # rejected at construction rather than producing garbage correlations.
+        if Tracking._INT16_W != 1
+            @test_throws ArgumentError Int16DownconvertAndCorrelator(steps = 48)
+            @test_throws ArgumentError Int16ThreadedDownconvertAndCorrelator(steps = 48)
+        end
+        # The default `steps = 64` always matches the kernel stride.
+        @test Int16DownconvertAndCorrelator(steps = 64) isa Int16DownconvertAndCorrelator
+        @test Int16ThreadedDownconvertAndCorrelator(steps = 64) isa
+              Int16ThreadedDownconvertAndCorrelator
+    end
+
     @testset "full track converges (GPS L1 C/A)" begin
         sig, fs = GPSL1CA(), 5e6Hz
         cdopp, cphase = 300Hz, 230.0


### PR DESCRIPTION
## Summary

Resolves the review finding #168 from #160: `Int16DownconvertAndCorrelator(steps ≠ 64)` could silently corrupt the carrier buffer.

The Int16 kernels stride the sample buffer by the compile-time constant `_INT16_W` (the Int8 LUT SIMD width at the default `steps = 64`), but the carrier engine's **actual** chunk width comes from the table's backend, which SinCosLUT selects from `steps`. The constructors accepted an arbitrary `steps` kwarg, so a value selecting a different backend (e.g. `steps = 32`, or `steps = 128` on an AVX2-only host) built an engine whose width diverged from the kernel stride — ~97% of the carrier buffer was filled with stale garbage, desynchronizing the phase. All calls were type-consistent, so it corrupted **silently**: near-zero/garbage correlations, no error.

## Fix

Validate at construction that the engine the kernel actually builds (`carrier_engine(table, …)`) has width `_INT16_W`, throwing an informative `ArgumentError` otherwise. Checking the *realized* width rather than `steps == 64` still allows `steps` values that keep the same backend width — e.g. `steps = 128` on an AVX-512 host (both give width 64).

## Test

Added a testset that asserts the constructor rejects a width-changing `steps` (`steps = 48` → Portable, width 1, on any non-portable host) and still accepts the default `steps = 64`. It fails without the fix (constructor silently succeeds) and passes with it. Full suite green.

Closes #168

Tracking issue: https://github.com/JuliaGNSS/Tracking.jl/issues/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)