### PR TITLE
fix(int16): widen block-flush accumulator to Int64 before horizontal sum (#165)

### DIFF
--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -64,10 +64,15 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 # larger Int32-only amplitude (the old behaviour) overflowed the accumulator for
 # CBOC on the scalar/NEON path.
 #
+# Each SIMD LANE of the per-block Σ codeₓ·DI accumulator stays within Int32 on this
+# Int16-safe path, but the horizontal reduction ACROSS lanes at flush is the full
+# block total, which can exceed typemax(Int32); it is widened to Int64 first — see
+# `_wide64` (#165).
+#
 # For `max_meas ≥ 2^14` no amp ≥ 1 keeps the wipe within Int16, so we fall back to
 # full Int8 amplitude + Int32 wipe. That fallback voids the `|DI| ≤ typemax(Int16)`
-# premise (`|DI|` can reach `2·max_meas·127`), so the per-block Σ codeₓ·DI can wrap
-# the Int32 lane accumulators — see `_int16_safe_blk`, which shrinks the strip-mine
+# premise (`|DI|` can reach `2·max_meas·127`), so even a single lane's per-block
+# Σ codeₓ·DI can wrap Int32 — see `_int16_safe_blk`, which shrinks the strip-mine
 # block on the fallback path to keep that accumulate bounded (#167).
 const _INT16_MAX_MEAS = 1 << 11
 function _int16_choose_carrier(max_meas::Integer)
@@ -102,6 +107,13 @@ const _INT16_BLK = 8192
 @inline _wide32(v::SIMD.Vec{W,Int8}) where {W} = convert(SIMD.Vec{W,Int32}, v)
 @inline _wide32(v::SIMD.Vec{W,Int16}) where {W} = convert(SIMD.Vec{W,Int32}, v)
 @inline _wide16(v::SIMD.Vec{W,Int8}) where {W} = convert(SIMD.Vec{W,Int16}, v)
+# Widen the Int32 lane accumulator to Int64 BEFORE the block-flush horizontal `sum`.
+# The per-lane bound keeps each Int32 lane safe, but the reduction ACROSS lanes is the
+# full block total (up to ~2.7×typemax(Int32) for a strong, code-aligned, full-scale
+# CBOC capture at default settings), which wraps if summed in Int32 (#165). Widening
+# first makes the reduction and the running Int64 total exact. Cost is negligible: the
+# flush runs once per block.
+@inline _wide64(v::SIMD.Vec{W,Int32}) where {W} = convert(SIMD.Vec{W,Int64}, v)
 
 # vpmaddwd: Int16×Int16 → Int32 pairwise-add — the dot-product primitive for the
 # code accumulate Σ codeₓ·DI. Native 512-/256-bit intrinsics tiled to width W;
@@ -394,8 +406,8 @@ end
             offk = Symbol("off_$k")
             push!(blk_init.args, :($aI = zero(SIMD.Vec{$AW,Int32})))
             push!(blk_init.args, :($aQ = zero(SIMD.Vec{$AW,Int32})))
-            push!(flush.args, :($tI += Int64(sum($aI))))
-            push!(flush.args, :($tQ += Int64(sum($aQ))))
+            push!(flush.args, :($tI += sum(_wide64($aI))))
+            push!(flush.args, :($tQ += sum(_wide64($aQ))))
             if use_madd
                 push!(
                     chunk.args,
@@ -802,8 +814,8 @@ end
                 offk = Symbol("off_$(i)_$k")
                 push!(blk_init.args, :($aI = zero(SIMD.Vec{$AW,Int32})))
                 push!(blk_init.args, :($aQ = zero(SIMD.Vec{$AW,Int32})))
-                push!(flush.args, :($tI += Int64(sum($aI))))
-                push!(flush.args, :($tQ += Int64(sum($aQ))))
+                push!(flush.args, :($tI += sum(_wide64($aI))))
+                push!(flush.args, :($tQ += sum(_wide64($aQ))))
                 if use_madd
                     push!(
                         chunk.args,

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -389,6 +389,43 @@ end
               Int16ThreadedDownconvertAndCorrelator
     end
 
+    # Block-flush horizontal sum must not wrap in Int32 (#165). The per-lane Int32
+    # bound holds on the fast path, but the block-flush reduction ACROSS lanes is the
+    # full block total, which for a strong, code-aligned, full-scale CBOC capture at
+    # DEFAULT settings exceeds typemax(Int32). If that reduction happens in Int32 the
+    # prompt wraps and the E/P·L/P triangle is destroyed. Worst case from the issue:
+    # full-scale (|m| = max_meas on every sample) real signal carrying the E1B code
+    # sign, zero Doppler → Σ code·DI is same-sign across the whole 8192-sample block.
+    @testset "block-flush accumulator does not wrap in Int32 (#165)" begin
+        sig, fs = GalileoE1B(), 15e6Hz
+        nsamp = round(Int, (fs / 1Hz) * 1e-3)   # 15000 > 8192-sample block
+        cphase = 0.0
+        code = gen_code(nsamp, sig, 1, fs, get_code_frequency(sig), cphase)
+        cap = complex.(round.(Int16, 2048 .* sign.(real.(code))), zero(Int16))
+        meas = (l1 = BandMeasurement(cap, fs, 0.0Hz),)
+        corr(dc) = first(
+            get_sat_state(
+                downconvert_and_correlate(
+                    dc,
+                    meas,
+                    TrackState(sig, [TrackedSat(sig, 1, cphase, 0.0Hz)]),
+                ),
+                1,
+            ).signals,
+        ).correlator
+        cf = corr(CPUThreadedDownconvertAndCorrelator())
+        ci = corr(Int16ThreadedDownconvertAndCorrelator())
+        # The capture is strong enough that the integer prompt total exceeds
+        # typemax(Int32): this is exactly what wraps an Int32 block-flush reduction.
+        @test abs(get_prompt(ci)) > typemax(Int32)
+        # Amplitude-invariant E/P and L/P ratios still match the (overflow-free)
+        # Float32 backend — they would be garbage if the prompt had wrapped.
+        @test abs(get_early(ci)) / abs(get_prompt(ci)) ≈
+              abs(get_early(cf)) / abs(get_prompt(cf)) atol = 1e-2
+        @test abs(get_late(ci)) / abs(get_prompt(ci)) ≈
+              abs(get_late(cf)) / abs(get_prompt(cf)) atol = 1e-2
+    end
+
     @testset "full track converges (GPS L1 C/A)" begin
         sig, fs = GPSL1CA(), 5e6Hz
         cdopp, cphase = 300Hz, 230.0


### PR DESCRIPTION
## Summary

Fixes the highest-severity finding from the #160 review (tracked in #173): the Int16 backend's per-block flush reduced the correlator accumulator in **Int32** and could wrap **at default settings on every host**.

The flush emitted `tI += Int64(sum(aI))` with `aI :: SIMD.Vec{AW,Int32}`. SIMD.jl performs `sum(Vec{N,Int32})` **in Int32**, so the block total wrapped *before* the `Int64(...)` conversion. The amplitude choice bounds each Int32 *lane*, but the horizontal reduction *across* lanes is the full block total — up to ~2.7×`typemax(Int32)` for a strong, code-aligned, full-scale Galileo E1B (CBOC ±25) capture — silently corrupting E/P/L correlators and dropping lock, with no error.

## Fix

Widen the lane accumulator to `Int64` (`_wide64`) *before* the horizontal `sum` at both flush sites (single-signal kernel and multi-signal tile-share kernel). The flush runs once per 8192-sample block, so the cost is negligible. Also corrects the safety comment that claimed the per-lane bound protected "every path".

## Test

Adds a regression test that builds the worst-case full-scale, code-aligned E1B capture:
- **Without** the fix: the prompt wraps → E/P ≈ 11.8 vs the true ≈ 0.60 (3 assertions fail).
- **With** the fix: E/P·L/P ratios match the overflow-free Float32 backend, and the integer prompt exceeds `typemax(Int32)` (proving exact Int64 accumulation).

Full suite green locally.

Closes #165
Tracking issue: https://github.com/JuliaGNSS/Tracking.jl/issues/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)