### PR TITLE
fix(int16): cap strip-mine block so single Int32 lane can't overflow (#166)

### DIFF
--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -64,16 +64,19 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 # larger Int32-only amplitude (the old behaviour) overflowed the accumulator for
 # CBOC on the scalar/NEON path.
 #
-# Each SIMD LANE of the per-block Σ codeₓ·DI accumulator stays within Int32 on this
-# Int16-safe path, but the horizontal reduction ACROSS lanes at flush is the full
-# block total, which can exceed typemax(Int32); it is widened to Int64 first — see
-# `_wide64` (#165).
-#
-# For `max_meas ≥ 2^14` no amp ≥ 1 keeps the wipe within Int16, so we fall back to
-# full Int8 amplitude + Int32 wipe. That fallback voids the `|DI| ≤ typemax(Int16)`
-# premise (`|DI|` can reach `2·max_meas·127`), so even a single lane's per-block
-# Σ codeₓ·DI can wrap Int32 — see `_int16_safe_blk`, which shrinks the strip-mine
-# block on the fallback path to keep that accumulate bounded (#167).
+# Three guards keep the per-block Σ codeₓ·DI within Int32 (the horizontal reduce is
+# widened to Int64, and two block-length caps bound the lanes themselves):
+#   * The horizontal reduction ACROSS lanes at flush is the full block total, which
+#     can exceed typemax(Int32) on this Int16-safe path even though each lane stays
+#     within Int32 — it is widened to Int64 first (see `_wide64`, #165).
+#   * For `max_meas ≥ 2^14` no amp ≥ 1 keeps the wipe within Int16, so we fall back
+#     to full Int8 amplitude + Int32 wipe. That voids the `|DI| ≤ typemax(Int16)`
+#     premise (`|DI|` can reach `2·max_meas·127`), so even a single lane's per-block
+#     Σ can wrap Int32; `_int16_safe_blk` shrinks the strip-mine block on that path
+#     to keep the whole-block sum bounded (#167).
+#   * On the SinCosLUT `Portable` backend (`_INT16_W == 1`) a single Int32 lane sums
+#     a whole block, so `_int16_flush_len` shrinks the block by the SIMD width so no
+#     lane can wrap (#166); a no-op for W ≥ 16, so the hot path is unchanged.
 const _INT16_MAX_MEAS = 1 << 11
 function _int16_choose_carrier(max_meas::Integer)
     a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))
@@ -102,6 +105,25 @@ end
 # Default strip-mine block length (samples); multiple of every backend `W`,
 # sized so the per-block L1 scratch (code + sin + cos) stays in L1.
 const _INT16_BLK = 8192
+
+# Strip-mine block length that keeps the per-block Int32 lane accumulator from
+# overflowing on narrow-SIMD hosts. Each Int32 lane sums the `code·DI` products of
+# its own samples before the per-block Int64 flush: `fld(L, W)` products on the
+# exact-Int32 path, twice that on the x86 `vpmaddwd` path (adjacent pairs are
+# pre-summed). With the Int16-safe amplitude the wipe `|DI| ≤ typemax(Int16)` and
+# the code peaks at CBOC ±25, so a lane sums at most `2·fld(L,W)·(_INT16_MAX_CODE·
+# max_wipe)`, which must stay within `typemax(Int32)`. Solving for L gives the cap
+# below. On wide-SIMD hosts (`W ≥ 16`) it exceeds the default block, so the block —
+# and thus the hot path — is unchanged; on the SinCosLUT `Portable` fallback
+# (`W == 1`: non-AVX2 x86, non-x86/aarch64 arches) it shrinks the block so a single
+# Int32 lane can no longer accumulate a whole block and wrap (issue #166). Composed
+# with `_int16_safe_blk` (which shrinks `dc.blk` on the amp = 127 path, #167) by
+# `min`, so both overflow axes are covered.
+function _int16_flush_len(W::Integer, max_wipe::Integer, blk::Integer)
+    max_product = _INT16_MAX_CODE * Int(max_wipe)
+    products_per_lane = Int(typemax(Int32)) ÷ (2 * max_product)   # 2× covers the vpmaddwd path
+    min(Int(blk), max(Int(W), products_per_lane * Int(W)))
+end
 
 # ── Widening / vpmaddwd helpers (ported from the GNSSSignals benchmark) ───────
 @inline _wide32(v::SIMD.Vec{W,Int8}) where {W} = convert(SIMD.Vec{W,Int32}, v)
@@ -500,7 +522,9 @@ end
         num_rows = size(signal, 1)
 
         bufs = _scratch_buffers(dc)
-        blk = dc.blk
+        # Cap the block so a single Int32 lane can't overflow before its per-block
+        # Int64 flush (issue #166: the `W == 1` Portable path). No-op for W ≥ 16.
+        blk = _int16_flush_len(W, typemax(Int16), dc.blk)
         ncar = (cld(blk, W) + 4) * W            # room for the 4-way carrier fill tail
         length(bufs.extb) < blk + span && resize!(bufs.extb, blk + span)
         length(bufs.csb) < ncar && resize!(bufs.csb, ncar)
@@ -962,7 +986,9 @@ end
         maxspan_v = $maxspan
 
         bufs = _scratch_buffers(dc)
-        blk = dc.blk
+        # Cap the block so a single Int32 lane can't overflow before its per-block
+        # Int64 flush (issue #166: the `W == 1` Portable path). No-op for W ≥ 16.
+        blk = _int16_flush_len(W, typemax(Int16), dc.blk)
         ncar = (cld(blk, W) + 4) * W
         length(bufs.extb) < blk + maxspan_v && resize!(bufs.extb, blk + maxspan_v)
         length(bufs.csb) < ncar && resize!(bufs.csb, ncar)

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -475,6 +475,31 @@ end
               abs(get_late(cf)) / abs(get_prompt(cf)) atol = 1e-2
     end
 
+    # Per-block Int32 lane-accumulator overflow guard (issue #166). On the
+    # SinCosLUT `Portable` backend (`_INT16_W == 1`: non-AVX2 x86, non-x86/aarch64
+    # arches) a single Int32 lane would otherwise accumulate a whole strip-mine
+    # block of `code·DI` products before the per-block Int64 flush and wrap on a
+    # strong CBOC (±25) capture. `_int16_flush_len` caps the block so no lane can
+    # exceed `typemax(Int32)` at any host SIMD width.
+    @testset "flush cadence bounds the Int32 accumulator (issue #166)" begin
+        max_code = 25                       # Galileo E1B CBOC sub-carrier peak
+        max_wipe = Int(typemax(Int16))      # Int16-safe wipe bound (|DI| ≤ typemax(Int16))
+        max_product = max_code * max_wipe
+        blk = Tracking._INT16_BLK
+        for W in (1, 16, 32, 64)
+            L = Tracking._int16_flush_len(W, max_wipe, blk)
+            @test 0 < L <= blk
+            # A lane sums fld(L, W) products (exact-Int32) or 2·fld(L, W) (vpmaddwd);
+            # the 2× worst case must still fit in Int32.
+            @test 2 * cld(L, W) * max_product <= typemax(Int32)
+        end
+        # The Portable (W == 1) path must flush before a full default block …
+        @test Tracking._int16_flush_len(1, max_wipe, blk) < blk
+        # … while wide-SIMD hosts are unaffected (no benchmark impact).
+        @test Tracking._int16_flush_len(16, max_wipe, blk) == blk
+        @test Tracking._int16_flush_len(32, max_wipe, blk) == blk
+    end
+
     @testset "full track converges (GPS L1 C/A)" begin
         sig, fs = GPSL1CA(), 5e6Hz
         cdopp, cphase = 300Hz, 230.0


### PR DESCRIPTION
## Problem

On SinCosLUT's `Portable` backend — `_INT16_W == 1`, selected on any x86-64 **without AVX2** and unconditionally on any arch other than x86/aarch64 (RISC-V, POWER, …) — the two `@generated` Int16 kernels (`_int16_hybrid_blocked!` and `_int16_hybrid_blocked_multi!`) accumulate a whole strip-mine block of `code·DI` products into a single `Vec{1,Int32}` lane before the per-block `Int64` flush.

At default `max_meas = 2^11` (amp = 7, `|DI| ≤ 28672`) a strong near-full-scale Galileo E1B (CBOC ±25) capture overflows that lane:

```
8192 · 25 · 28672 = 5,872,025,600 > typemax(Int32) = 2,147,483,647
```

→ silent wraparound, corrupted correlators, no error or warning. Verified: CONFIRMED.

## Fix

The Int16-safe amplitude bounds each *product* (`|DI| ≤ typemax(Int16)`) but not the *number* of products a lane sums before the flush, which is `blk / W`. That is safe for `W ≥ 16` at the default block but not for `W == 1`.

`_int16_flush_len(W, max_wipe, blk)` caps the effective strip-mine block so no Int32 lane can exceed `typemax(Int32)` at any host SIMD width — accounting for the 2× products/lane on the x86 `vpmaddwd` path. It is a **no-op for `W ≥ 16`** (the SIMD hot path and its scratch sizing are byte-for-byte unchanged, so no benchmark impact) and shrinks the `Portable` block to a safe length (8192 → 1310 at default settings).

The dynamic `AbstractVector`-shifts fallback already flushes to `Int64` every chunk, so it was never affected and is left untouched. Results are bit-identical across block lengths (verified).

The amp = 127 fallback for `max_meas ≥ 2^14` voids the `|DI| ≤ typemax(Int16)` premise on a different axis and is tracked separately by #167; it is out of scope here.

## Test

Adds a unit test pinning the overflow invariant (`2·⌈L/W⌉ · 25 · typemax(Int16) ≤ typemax(Int32)`) for `W ∈ {1, 16, 32, 64}`, asserting the `W == 1` block shrinks below the default while wide-SIMD widths are unchanged. The test fails without the fix (the cap does not exist) and passes with it. Full suite green.

Stacked on #160 (`even-faster-tracking`), which introduces this backend.

Closes #166
Tracking issue: https://github.com/JuliaGNSS/Tracking.jl/issues/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)