### PR TITLE
fix(int16): bound Int32 accumulator on large-max_meas fallback (#167)

### DIFF
--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -58,19 +58,40 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 # Maximum |measurement component| we size the carrier amplitude against: a 12-bit
 # ADC (|m| ≤ 2^11). Pick the LARGEST Int16-safe amplitude — the largest `amp` with
 # `2·max_meas·amp ≤ typemax(Int16)` — capped at the Int8 storage limit. Keeping the
-# wipe `DI = mᵣ·cos + mᵢ·sin` within Int16 serves two purposes: it enables the Int16
-# `vpmaddwd` fast path on x86, AND it bounds the per-block Int32 correlation
-# accumulator on EVERY path, so the exact-Int32 accumulate cannot overflow even for
-# multi-level CBOC code (±25) over a full block. The wipe TYPE differs by backend
-# (Int16 + vpmaddwd on x86; exact Int32 elsewhere) but the AMPLITUDE is the same —
-# using a larger Int32-only amplitude (the old behaviour) overflowed the accumulator
-# for CBOC on the scalar/NEON path. (>14-bit `max_meas`, where no amp ≥ 1 is
-# Int16-safe, falls back to full Int8 amplitude + Int32 wipe.)
+# wipe `DI = mᵣ·cos + mᵢ·sin` within Int16 enables the Int16 `vpmaddwd` fast path on
+# x86 and keeps `|DI| ≤ typemax(Int16)`. The wipe TYPE differs by backend (Int16 +
+# vpmaddwd on x86; exact Int32 elsewhere) but the AMPLITUDE is the same — using a
+# larger Int32-only amplitude (the old behaviour) overflowed the accumulator for
+# CBOC on the scalar/NEON path.
+#
+# For `max_meas ≥ 2^14` no amp ≥ 1 keeps the wipe within Int16, so we fall back to
+# full Int8 amplitude + Int32 wipe. That fallback voids the `|DI| ≤ typemax(Int16)`
+# premise (`|DI|` can reach `2·max_meas·127`), so the per-block Σ codeₓ·DI can wrap
+# the Int32 lane accumulators — see `_int16_safe_blk`, which shrinks the strip-mine
+# block on the fallback path to keep that accumulate bounded (#167).
 const _INT16_MAX_MEAS = 1 << 11
 function _int16_choose_carrier(max_meas::Integer)
     a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))
     a >= 1 || return (Int(typemax(Int8)), Int32)
     (min(a, Int(typemax(Int8))), _INT16_HAS_MADDWD ? Int16 : Int32)
+end
+
+# Largest multi-level code sub-carrier magnitude the correlate accumulate must
+# tolerate (Galileo E1B CBOC ±25); used to bound the per-block Int32 accumulator.
+const _INT16_MAX_CODE = 25
+
+# Per-instance safe strip-mine block length. Each SIMD lane sums the per-sample
+# products `codeₓ·DI` (|code| ≤ `_INT16_MAX_CODE`, |DI| ≤ 2·max_meas·amp) over one
+# block into an Int32 accumulator before the per-block Int64 flush, and the flush
+# reduces those lanes in Int32. On the Int16-safe amplitude path this stays bounded
+# at the default block, so `blk` is returned unchanged; on the `max_meas ≥ 2^14`
+# fallback (amp = 127, Int32 wipe) the block is shrunk so the whole-block sum still
+# fits Int32 — trading throughput for correctness on that rare full-scale path (#167).
+function _int16_safe_blk(blk::Integer, max_meas::Integer, amp::Integer)
+    di_max = 2 * Int(max_meas) * Int(amp)                     # |DI| = |mᵣ·cos + mᵢ·sin|
+    di_max <= Int(typemax(Int16)) && return Int(blk)          # Int16-safe path: unchanged
+    safe = Int(typemax(Int32)) ÷ (_INT16_MAX_CODE * di_max)   # samples/block keeping Σ within Int32
+    min(Int(blk), max(1, safe))
 end
 
 # Default strip-mine block length (samples); multiple of every backend `W`,
@@ -174,7 +195,11 @@ The carrier-replica amplitude (and the wipe arithmetic type) are chosen from
 the largest amplitude that keeps the carrier wipe within `Int16` (so the wipe
 can't overflow and the on-x86 `vpmaddwd` fast path applies). Pass `max_meas`
 for your front end's full-scale (default `2^11`, a 12-bit ADC); under-declaring
-it risks overflow, over-declaring only coarsens the carrier.
+it risks overflow, over-declaring only coarsens the carrier. This backend is
+tuned for ≤12-bit sample buffers: for `max_meas ≥ 2^14` no `Int16`-safe carrier
+amplitude exists, so it falls back to the exact `Int32` wipe and automatically
+shrinks the strip-mine block to keep the correlation accumulators from
+overflowing (correct, but slower on that path).
 """
 struct Int16DownconvertAndCorrelator{TBL<:SinCosTable,TI} <:
        AbstractDownconvertAndCorrelator
@@ -208,7 +233,7 @@ function Int16DownconvertAndCorrelator(;
     Int16DownconvertAndCorrelator{typeof(table),TI}(
         Int16ScratchBuffers{TI}(),
         table,
-        Int(blk),
+        _int16_safe_blk(blk, max_meas, amplitude),
     )
 end
 
@@ -222,7 +247,7 @@ function Int16ThreadedDownconvertAndCorrelator(;
     Int16ThreadedDownconvertAndCorrelator{typeof(table),TI}(
         [Int16ScratchBuffers{TI}() for _ = 1:Threads.maxthreadid()],
         table,
-        Int(blk),
+        _int16_safe_blk(blk, max_meas, amplitude),
     )
 end
 

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -249,6 +249,37 @@ end
               abs(get_late(cf)) / abs(get_prompt(cf)) atol = 1e-2
     end
 
+    # #167: a full-scale 16-bit `max_meas` must not silently overflow the
+    # correlation accumulators. The large-`max_meas` fallback picks the exact
+    # Int32 wipe with amp = 127, so the `|DI| ≤ typemax(Int16)` invariant no
+    # longer holds; with near-full-scale samples and multi-level CBOC code (±25)
+    # the per-block Σ codeₓ·DI runs ~25× past typemax(Int32) unless the block
+    # length is shrunk to keep it bounded. Feed near-full-scale Galileo E1B and
+    # check the E/P/L ratios still match the Float32 backend (they are garbage if
+    # the Int32 accumulators wrapped).
+    @testset "full-scale max_meas = 2^15 does not overflow (#167)" begin
+        sig, fs = GalileoE1B(), 15e6Hz
+        nsamp = round(Int, (fs / 1Hz) * 1e-3)
+        cap = make_capture(sig, 1, fs, nsamp, 200Hz, 100.0; peak = 2^15 - 1)
+        meas = (l1 = BandMeasurement(cap, fs, 0.0Hz),)
+        corr(dc) = first(
+            get_sat_state(
+                downconvert_and_correlate(
+                    dc,
+                    meas,
+                    TrackState(sig, [TrackedSat(sig, 1, 100.0, 200Hz)]),
+                ),
+                1,
+            ).signals,
+        ).correlator
+        cf = corr(CPUThreadedDownconvertAndCorrelator())
+        ci = corr(Int16ThreadedDownconvertAndCorrelator(; max_meas = 2^15))
+        @test abs(get_early(ci)) / abs(get_prompt(ci)) ≈
+              abs(get_early(cf)) / abs(get_prompt(cf)) atol = 1e-2
+        @test abs(get_late(ci)) / abs(get_prompt(ci)) ≈
+              abs(get_late(cf)) / abs(get_prompt(cf)) atol = 1e-2
+    end
+
     # Dynamic (runtime Vector) tap count: a DynShiftsCorrelator with the same
     # shifts as EPL must produce the same accumulators through the Int16 backend's
     # AbstractVector-shifts fallback as the static @generated EPL kernel.


### PR DESCRIPTION
## Problem

Found in the review of #160. For `max_meas ≥ 2^14`, `_int16_choose_carrier` has no `Int16`-safe carrier amplitude, so it falls back to full Int8 amplitude (127) + exact-`Int32` wipe. That voids the `|DI| ≤ typemax(Int16)` premise the whole accumulator design rests on: `|DI|` can reach `2·max_meas·127 ≈ 8.3e6`, so the per-block `Σ codeₓ·DI` (|code| ≤ 25 for Galileo E1B CBOC) overflows the per-lane `Int32` accumulators — ~25× at `max_meas = 2^15`.

The result: `Int16DownconvertAndCorrelator(max_meas = 2^15)` — the natural call for a 16-bit front end, actively invited by the docstring — **silently** produced garbage correlation.

## Fix

Add `_int16_safe_blk`, which shrinks the strip-mine block length on the fallback path so the whole-block accumulate still fits `Int32`. The `Int16`-safe amplitude path (the default 12-bit-ADC case) is returned unchanged, so the common path keeps `blk = 8192` and its throughput; only the rare full-scale fallback trades speed for correctness.

Also fixed the stale "bounds the accumulator on EVERY path" comment and the docstring that invited passing a 16-bit full-scale `max_meas`.

## Test

Test-first: a new testset feeds near-full-scale Galileo E1B (CBOC ±25) at `max_meas = 2^15` and checks the E/P/L magnitude ratios match the Float32 backend. It fails without the fix (Int16 E/P = 1.007 vs Float32 0.577 — wrapped accumulators) and passes with it (0.577). Full suite green; default-path block length unchanged (no benchmark impact — benchmarks use the default `max_meas`).

Closes #167
Part of the review-findings tracking issue https://github.com/JuliaGNSS/Tracking.jl/issues/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)