### PR TITLE
perf(int16): scratch-reusing dynamic-shifts fallback with per-block flush (#172)

### DIFF
--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -490,6 +490,55 @@ end
     end
 end
 
+# One block's correlate for the dynamic fallback: accumulate every antenna/tap
+# from the shared DI/DQ tile into the Int64 `tI`/`tQ` totals, flushing the
+# `Vec{W,Int32}` lane accumulator once per (block, antenna, tap). Split out as a
+# `Val{W}`-parameterized barrier — like `_int16_fill_carrier!` — so `W` and the
+# tile element type `TIw` are compile-time constants in the SIMD type positions
+# (a bare local `W` is not reliably const-folded into `SIMD.Vec{W,…}` on every
+# Julia version, which would box the accumulators and allocate per block).
+@inline function _int16_dyn_accumulate_block!(
+    tI::Vector{Int64},
+    tQ::Vector{Int64},
+    dib::Vector{TIw},
+    dqb::Vector{TIw},
+    extb::Vector{Int8},
+    sample_shifts::AbstractVector,
+    min_shift::Integer,
+    ::NumAnts{M},
+    len::Int,
+    ::Val{W},
+) where {TIw,M,W}
+    NC = length(sample_shifts)
+    @inbounds for j = 1:M
+        toff = (j - 1) * len
+        for k = 1:NC
+            offk = Int(sample_shifts[k]) - min_shift
+            idx = (j - 1) * NC + k
+            aI = zero(SIMD.Vec{W,Int32})
+            aQ = zero(SIMD.Vec{W,Int32})
+            n = 1
+            while n + W - 1 <= len
+                DI = _wide32(vload(SIMD.Vec{W,TIw}, dib, toff + n))
+                DQ = _wide32(vload(SIMD.Vec{W,TIw}, dqb, toff + n))
+                codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offk))
+                aI += codev * DI
+                aQ += codev * DQ
+                n += W
+            end
+            tI[idx] += Int64(sum(aI))
+            tQ[idx] += Int64(sum(aQ))
+            while n <= len
+                c = Int32(extb[n+offk])
+                tI[idx] += Int64(c * Int32(dib[toff+n]))
+                tQ[idx] += Int64(c * Int32(dqb[toff+n]))
+                n += 1
+            end
+        end
+    end
+    nothing
+end
+
 # Dynamic (runtime tap count) fallback: correlators whose sample shifts are a
 # runtime-sized `AbstractVector` (e.g. a `Vector`-accumulator correlator —
 # issue #126 (b)). `SVector` shifts are more specific and dispatch to the
@@ -584,32 +633,18 @@ function _int16_hybrid_blocked!(
             num_rows,
             p_sig,
         )
-        for j = 1:M
-            toff = (j - 1) * len
-            for k = 1:NC
-                offk = Int(sample_shifts[k]) - min_shift
-                idx = (j - 1) * NC + k
-                aI = zero(SIMD.Vec{W,Int32})
-                aQ = zero(SIMD.Vec{W,Int32})
-                n = 1
-                while n + W - 1 <= len
-                    DI = _wide32(vload(SIMD.Vec{W,eltype(dib)}, dib, toff + n))
-                    DQ = _wide32(vload(SIMD.Vec{W,eltype(dqb)}, dqb, toff + n))
-                    codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offk))
-                    aI += codev * DI
-                    aQ += codev * DQ
-                    n += W
-                end
-                tI[idx] += Int64(sum(aI))
-                tQ[idx] += Int64(sum(aQ))
-                while n <= len
-                    c = Int32(extb[n+offk])
-                    tI[idx] += Int64(c * Int32(dib[toff+n]))
-                    tQ[idx] += Int64(c * Int32(dqb[toff+n]))
-                    n += 1
-                end
-            end
-        end
+        _int16_dyn_accumulate_block!(
+            tI,
+            tQ,
+            dib,
+            dqb,
+            extb,
+            sample_shifts,
+            min_shift,
+            NumAnts{M}(),
+            len,
+            Val(_INT16_W),
+        )
         blk_off += len
     end
 

--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -80,6 +80,7 @@ const _INT16_BLK = 8192
 # ── Widening / vpmaddwd helpers (ported from the GNSSSignals benchmark) ───────
 @inline _wide32(v::SIMD.Vec{W,Int8}) where {W} = convert(SIMD.Vec{W,Int32}, v)
 @inline _wide32(v::SIMD.Vec{W,Int16}) where {W} = convert(SIMD.Vec{W,Int32}, v)
+@inline _wide32(v::SIMD.Vec{W,Int32}) where {W} = v   # already widened (Int32 wipe tile)
 @inline _wide16(v::SIMD.Vec{W,Int8}) where {W} = convert(SIMD.Vec{W,Int16}, v)
 
 # vpmaddwd: Int16×Int16 → Int32 pairwise-add — the dot-product primitive for the
@@ -156,9 +157,14 @@ struct Int16ScratchBuffers{TI}
     # signals (one downconvert per sat, not per signal). Wipe element type `TI`.
     dib::Vector{TI}
     dqb::Vector{TI}
+    # Int64 tap totals (`M·NC`, flattened) for the runtime `AbstractVector`-shifts
+    # fallback, hoisted here so that path allocates only its result vector (not
+    # fresh totals) per integration. Unused by the `@generated` static path.
+    tsumI::Vector{Int64}
+    tsumQ::Vector{Int64}
 end
 Int16ScratchBuffers{TI}() where {TI} =
-    Int16ScratchBuffers{TI}(Int8[], Int8[], Int8[], TI[], TI[])
+    Int16ScratchBuffers{TI}(Int8[], Int8[], Int8[], TI[], TI[], Int64[], Int64[])
 
 """
 $(SIGNATURES)
@@ -167,7 +173,10 @@ Integer (`Complex{Int16}`) hybrid-blocked CPU downconvert + correlate backend
 (single-threaded). Opt-in alternative to [`CPUDownconvertAndCorrelator`] for
 `Complex{Int16}` sample buffers; errors on any other sample element type.
 Construct **once outside** the `track!` loop and pass it via the
-`downconvert_and_correlator` keyword for an allocation-free steady state.
+`downconvert_and_correlator` keyword for an allocation-free steady state on the
+static correlator path (EPL/VEPL and any `SVector`-shifts correlator). The
+runtime `AbstractVector`-shifts fallback additionally allocates the small
+`Vector` it returns each integration, but reuses the same thread-local scratch.
 
 The carrier-replica amplitude (and the wipe arithmetic type) are chosen from
 `max_meas`, the largest expected `|real|`/`|imag|` of a measurement sample —
@@ -483,12 +492,17 @@ end
 
 # Dynamic (runtime tap count) fallback: correlators whose sample shifts are a
 # runtime-sized `AbstractVector` (e.g. a `Vector`-accumulator correlator —
-# issue #126 (b)). Mirrors the Float32 backend's `AbstractVector`-shifts path.
-# Loops over taps/antennas at runtime and uses the exact Int32 wipe + per-chunk
-# horizontal sum, so it is not the hot path but stays correct for any tap count;
-# returns `Vector{ComplexF64}` (M=1) or `Vector{SVector{M,ComplexF64}}` (M>1).
-# `SVector` shifts are more specific and dispatch to the `@generated` method
-# above, so EPL/VEPL keep the fast unrolled kernel.
+# issue #126 (b)). `SVector` shifts are more specific and dispatch to the
+# `@generated` method above, so EPL/VEPL keep the fast unrolled kernel; this
+# path stays correct for any runtime tap count. It mirrors that kernel's
+# structure so it is not gratuitously slow: per block it fills the shared DI/DQ
+# tile once (`_int16_fill_ditile!`), then for each antenna/tap accumulates into a
+# register `Vec{W,Int32}` lane accumulator flushed into Int64 totals once per
+# block — no per-chunk horizontal reduction. The totals live in the thread-local
+# scratch, so the only per-call allocation is the returned result vector:
+# `Vector{ComplexF64}` (M=1) or `Vector{SVector{M,ComplexF64}}` (M>1). The exact
+# Int32 accumulate (widening the `TI` tile) is used regardless of backend — the
+# `vpmaddwd` fast path is reserved for the `@generated` hot path.
 function _int16_hybrid_blocked!(
     dc::_Int16DC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -509,18 +523,30 @@ function _int16_hybrid_blocked!(
     min_shift = minimum(sample_shifts)
     max_shift = maximum(sample_shifts)
     span = max_shift - min_shift
-    offs = [Int(sample_shifts[k]) - min_shift for k = 1:NC]   # extb read offsets
     num_rows = size(signal, 1)
 
     bufs = _scratch_buffers(dc)
     blk = dc.blk
     ncar = (cld(blk, W) + 4) * W
+    ntile = blk * M
     length(bufs.extb) < blk + span && resize!(bufs.extb, blk + span)
     length(bufs.csb) < ncar && resize!(bufs.csb, ncar)
     length(bufs.ccb) < ncar && resize!(bufs.ccb, ncar)
+    length(bufs.dib) < ntile && resize!(bufs.dib, ntile)
+    length(bufs.dqb) < ntile && resize!(bufs.dqb, ntile)
+    length(bufs.tsumI) < M * NC && resize!(bufs.tsumI, M * NC)
+    length(bufs.tsumQ) < M * NC && resize!(bufs.tsumQ, M * NC)
     extb = bufs.extb
     csb = bufs.csb
     ccb = bufs.ccb
+    dib = bufs.dib
+    dqb = bufs.dqb
+    tI = bufs.tsumI
+    tQ = bufs.tsumQ
+    @inbounds for i = 1:(M*NC)
+        tI[i] = zero(Int64)
+        tQ[i] = zero(Int64)
+    end
 
     carrier_freq = Float64(upreferred(carrier_frequency / Hz))
     sampling_freq = Float64(upreferred(sampling_frequency / Hz))
@@ -530,8 +556,6 @@ function _int16_hybrid_blocked!(
     cps = Float64(upreferred(code_frequency / Hz)) / sampling_freq
     code_phase0 = Float64(code_phase)
 
-    tI = zeros(Int64, M, NC)
-    tQ = zeros(Int64, M, NC)
     p_sig = Ptr{Int16}(pointer(signal))
 
     blk_off = 0
@@ -548,48 +572,53 @@ function _int16_hybrid_blocked!(
         )
         _int16_fill_carrier!(csb, ccb, reng, blk_off, len, phase0, Val(W))
         base = signal_start_sample + blk_off
+        _int16_fill_ditile!(
+            dib,
+            dqb,
+            signal,
+            NumAnts{M}(),
+            csb,
+            ccb,
+            base,
+            len,
+            num_rows,
+            p_sig,
+        )
         for j = 1:M
-            colbase = (j - 1) * num_rows
-            n = 1
-            while n + W - 1 <= len
-                byte_off = (colbase + base + n - 2) * 2 * sizeof(Int16)
-                mr, mi = _deinterleave_load(SIMD.Vec{W,Int32}, p_sig, byte_off)
-                cc = _wide32(vload(SIMD.Vec{W,Int8}, ccb, n))
-                sn = _wide32(vload(SIMD.Vec{W,Int8}, csb, n))
-                DI = mr * cc + mi * sn
-                DQ = mi * cc - mr * sn
-                for k = 1:NC
-                    codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offs[k]))
-                    tI[j, k] += Int64(sum(codev * DI))
-                    tQ[j, k] += Int64(sum(codev * DQ))
+            toff = (j - 1) * len
+            for k = 1:NC
+                offk = Int(sample_shifts[k]) - min_shift
+                idx = (j - 1) * NC + k
+                aI = zero(SIMD.Vec{W,Int32})
+                aQ = zero(SIMD.Vec{W,Int32})
+                n = 1
+                while n + W - 1 <= len
+                    DI = _wide32(vload(SIMD.Vec{W,eltype(dib)}, dib, toff + n))
+                    DQ = _wide32(vload(SIMD.Vec{W,eltype(dqb)}, dqb, toff + n))
+                    codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offk))
+                    aI += codev * DI
+                    aQ += codev * DQ
+                    n += W
                 end
-                n += W
-            end
-            while n <= len
-                sig = signal[base+n-1, j]
-                mr_s = Int32(real(sig));
-                mi_s = Int32(imag(sig))
-                cc_s = Int32(ccb[n]);
-                sn_s = Int32(csb[n])
-                di = mr_s * cc_s + mi_s * sn_s
-                dq = mi_s * cc_s - mr_s * sn_s
-                for k = 1:NC
-                    c = Int32(extb[n+offs[k]])
-                    tI[j, k] += Int64(c * di)
-                    tQ[j, k] += Int64(c * dq)
+                tI[idx] += Int64(sum(aI))
+                tQ[idx] += Int64(sum(aQ))
+                while n <= len
+                    c = Int32(extb[n+offk])
+                    tI[idx] += Int64(c * Int32(dib[toff+n]))
+                    tQ[idx] += Int64(c * Int32(dqb[toff+n]))
+                    n += 1
                 end
-                n += 1
             end
         end
         blk_off += len
     end
 
     if M == 1
-        return [complex(Float64(tI[1, k]), Float64(tQ[1, k])) for k = 1:NC]
+        return [complex(Float64(tI[k]), Float64(tQ[k])) for k = 1:NC]
     else
         return [
             SVector{M,ComplexF64}(
-                ntuple(j -> complex(Float64(tI[j, k]), Float64(tQ[j, k])), M),
+                ntuple(j -> complex(Float64(tI[(j-1)*NC+k]), Float64(tQ[(j-1)*NC+k])), M),
             ) for k = 1:NC
         ]
     end

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -280,18 +280,21 @@ end
 
     # The AbstractVector-shifts fallback hoists its offsets/totals into the
     # thread-local scratch and flushes per block, so in steady state it allocates
-    # only the small result `Vector` it returns — not fresh per-integration totals
-    # (which previously added an `M×NC` `tI`/`tQ` matrix pair + offset vector per
-    # ~1 ms integration). Assert the backend call allocates no more than a couple
-    # of small result vectors (the pre-fix path allocated ~3.4× more).
+    # only the length-NC result `Vector` it returns — not fresh per-integration
+    # totals (the pre-fix path also built an `M×NC` `tI`/`tQ` matrix pair + an
+    # offset vector, i.e. four arrays per ~1 ms integration). The two structural
+    # claims we assert (both platform-independent, `minimum` over repeats to strip
+    # GC-sampling noise): the per-call allocation is small (just the result
+    # vector, not the pre-fix four-array scratch) and does NOT grow with
+    # integration length (no per-block allocation — the bug that a bare-`W`,
+    # non-`Val` kernel would reintroduce by boxing the SIMD accumulators).
     @testset "dynamic Vector-shifts fallback is scratch-reusing (bounded allocs)" begin
         sig, fs = GPSL1CA(), 5e6Hz
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
         fc = 200Hz * get_code_center_frequency_ratio(sig) + get_code_frequency(sig)
         shifts = collect(get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc))
         dc = Int16DownconvertAndCorrelator()
-        cap = make_capture(sig, 1, fs, nsamp, 200Hz, 100.0)
-        call() = Tracking._int16_hybrid_blocked!(
+        runN(cap, ns) = Tracking._int16_hybrid_blocked!(
             dc,
             cap,
             NumAnts(1),
@@ -304,33 +307,24 @@ end
             200Hz + 0.0Hz,
             fs,
             1,
-            nsamp,
+            ns,
         )
-        call()                                  # warm up (grow scratch once)
-        call()
-        # Result is a Vector{ComplexF64} of length 3 (~112 B here); the only
-        # steady-state allocation. Independent of integration length, so a 10×
-        # longer capture allocates the same amount.
-        allocs = @allocated call()
-        @test allocs <= 256
-        cap10 = make_capture(sig, 1, fs, 10 * nsamp, 200Hz, 100.0)
-        call10() = Tracking._int16_hybrid_blocked!(
-            dc,
-            cap10,
-            NumAnts(1),
-            sig,
-            1,
-            shifts,
-            100.0,
-            0.6,
-            fc,
-            200Hz + 0.0Hz,
-            fs,
-            1,
-            10 * nsamp,
-        )
-        call10()
-        @test (@allocated call10()) == allocs
+        # min over repeats: @allocated is GC-sampling-noisy per call, but the
+        # structural allocation is the stable floor.
+        function minalloc(mult)
+            ns = mult * nsamp
+            cap = make_capture(sig, 1, fs, ns, 200Hz, 100.0)
+            runN(cap, ns)
+            runN(cap, ns)                       # warm up (grow scratch once)
+            minimum(@allocated(runN(cap, ns)) for _ = 1:8)
+        end
+        a1 = minalloc(1)                        # 1 strip-mine block
+        a13 = minalloc(20)                      # ~13 strip-mine blocks
+        # Only the result vector allocates — well under the pre-fix four-array
+        # scratch (which measured ~576 B for a single block on CI).
+        @test a1 <= 256
+        # No per-block allocation: 13× the blocks allocates the same amount.
+        @test a13 == a1
     end
 
     # Multi-signal-per-sat tile-share: a sat carrying N identical GPS L1 C/A

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -279,22 +279,25 @@ end
     end
 
     # The AbstractVector-shifts fallback hoists its offsets/totals into the
-    # thread-local scratch and flushes per block, so in steady state it allocates
-    # only the length-NC result `Vector` it returns — not fresh per-integration
-    # totals (the pre-fix path also built an `M×NC` `tI`/`tQ` matrix pair + an
-    # offset vector, i.e. four arrays per ~1 ms integration). The two structural
-    # claims we assert (both platform-independent, `minimum` over repeats to strip
-    # GC-sampling noise): the per-call allocation is small (just the result
-    # vector, not the pre-fix four-array scratch) and does NOT grow with
-    # integration length (no per-block allocation — the bug that a bare-`W`,
-    # non-`Val` kernel would reintroduce by boxing the SIMD accumulators).
-    @testset "dynamic Vector-shifts fallback is scratch-reusing (bounded allocs)" begin
+    # thread-local scratch and flushes per block, so its only per-call allocation
+    # is the length-NC result `Vector` it returns — the pre-fix path also built an
+    # `M×NC` `tI`/`tQ` matrix pair + an offset vector (four arrays per ~1 ms
+    # integration). We measure the fallback (`Vector` shifts) *against* the static
+    # `@generated` path (`SVector` shifts): both call `gen_code!`/`fill_carrier!`
+    # the same number of times per block, so the difference cancels that shared,
+    # per-block cost (which itself allocates on some Julia versions) and isolates
+    # the fallback's own per-call scratch. After the fix that gap is just the
+    # result vector (~48 B, and constant in block count); the pre-fix four-array
+    # scratch made it ~6× larger (~288 B). `minimum` over repeats strips
+    # GC-sampling noise.
+    @testset "dynamic Vector-shifts fallback adds no per-call scratch vs static path" begin
         sig, fs = GPSL1CA(), 5e6Hz
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
         fc = 200Hz * get_code_center_frequency_ratio(sig) + get_code_frequency(sig)
-        shifts = collect(get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc))
+        shifts_s = get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc)  # SVector → @generated
+        shifts_v = collect(shifts_s)                                                  # Vector → fallback
         dc = Int16DownconvertAndCorrelator()
-        runN(cap, ns) = Tracking._int16_hybrid_blocked!(
+        runN(shifts, cap, ns) = Tracking._int16_hybrid_blocked!(
             dc,
             cap,
             NumAnts(1),
@@ -309,22 +312,19 @@ end
             1,
             ns,
         )
-        # min over repeats: @allocated is GC-sampling-noisy per call, but the
-        # structural allocation is the stable floor.
-        function minalloc(mult)
+        function minalloc(shifts, mult)
             ns = mult * nsamp
             cap = make_capture(sig, 1, fs, ns, 200Hz, 100.0)
-            runN(cap, ns)
-            runN(cap, ns)                       # warm up (grow scratch once)
-            minimum(@allocated(runN(cap, ns)) for _ = 1:8)
+            runN(shifts, cap, ns)
+            runN(shifts, cap, ns)               # warm up (grow scratch once)
+            minimum(@allocated(runN(shifts, cap, ns)) for _ = 1:8)
         end
-        a1 = minalloc(1)                        # 1 strip-mine block
-        a13 = minalloc(20)                      # ~13 strip-mine blocks
-        # Only the result vector allocates — well under the pre-fix four-array
-        # scratch (which measured ~576 B for a single block on CI).
-        @test a1 <= 256
-        # No per-block allocation: 13× the blocks allocates the same amount.
-        @test a13 == a1
+        # 1 vs ~13 strip-mine blocks: the fallback's over-allocation vs the static
+        # path must be small AND must not grow with the number of blocks.
+        for mult in (1, 13)
+            gap = minalloc(shifts_v, mult) - minalloc(shifts_s, mult)
+            @test gap <= 128
+        end
     end
 
     # Multi-signal-per-sat tile-share: a sat carrying N identical GPS L1 C/A

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -278,6 +278,61 @@ end
         end
     end
 
+    # The AbstractVector-shifts fallback hoists its offsets/totals into the
+    # thread-local scratch and flushes per block, so in steady state it allocates
+    # only the small result `Vector` it returns — not fresh per-integration totals
+    # (which previously added an `M×NC` `tI`/`tQ` matrix pair + offset vector per
+    # ~1 ms integration). Assert the backend call allocates no more than a couple
+    # of small result vectors (the pre-fix path allocated ~3.4× more).
+    @testset "dynamic Vector-shifts fallback is scratch-reusing (bounded allocs)" begin
+        sig, fs = GPSL1CA(), 5e6Hz
+        nsamp = round(Int, (fs / 1Hz) * 1e-3)
+        fc = 200Hz * get_code_center_frequency_ratio(sig) + get_code_frequency(sig)
+        shifts = collect(get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc))
+        dc = Int16DownconvertAndCorrelator()
+        cap = make_capture(sig, 1, fs, nsamp, 200Hz, 100.0)
+        call() = Tracking._int16_hybrid_blocked!(
+            dc,
+            cap,
+            NumAnts(1),
+            sig,
+            1,
+            shifts,
+            100.0,
+            0.6,
+            fc,
+            200Hz + 0.0Hz,
+            fs,
+            1,
+            nsamp,
+        )
+        call()                                  # warm up (grow scratch once)
+        call()
+        # Result is a Vector{ComplexF64} of length 3 (~112 B here); the only
+        # steady-state allocation. Independent of integration length, so a 10×
+        # longer capture allocates the same amount.
+        allocs = @allocated call()
+        @test allocs <= 256
+        cap10 = make_capture(sig, 1, fs, 10 * nsamp, 200Hz, 100.0)
+        call10() = Tracking._int16_hybrid_blocked!(
+            dc,
+            cap10,
+            NumAnts(1),
+            sig,
+            1,
+            shifts,
+            100.0,
+            0.6,
+            fc,
+            200Hz + 0.0Hz,
+            fs,
+            1,
+            10 * nsamp,
+        )
+        call10()
+        @test (@allocated call10()) == allocs
+    end
+
     # Multi-signal-per-sat tile-share: a sat carrying N identical GPS L1 C/A
     # signals shares one carrier downconvert. Each signal's correlator must equal
     # the single-signal result (same code/carrier; only the downconvert is shared).


### PR DESCRIPTION
Resolves the review finding in #172 (sub-issue of the #160 review tracking issue #173).

## Problem

The Int16 backend's `AbstractVector`-shifts fallback (`_int16_hybrid_blocked!`, single-signal dynamic tap count) had two efficiency issues flagged in the #160 review:

1. **Per-chunk horizontal reduction + heap read-modify-write** — a full `sum(codev * DI)` of a `Vec{W,Int32}` (I and Q, per tap) for *every* W-sample chunk, plus a `Matrix` load/store, where the `@generated` kernel does one vector add per tap and flushes once per block (~an order of magnitude more accumulate work).
2. **Per-call allocations** — fresh `offs`, `tI`/`tQ` matrices every integration (~1 ms per satellite), i.e. GC pressure for any user with a `Vector`-shifts correlator.
3. The `Int16DownconvertAndCorrelator` docstring's unscoped "allocation-free steady state" claim was contradicted by this path.

## Fix

Mirror the `@generated` kernel's structure in the fallback:

- Fill the shared DI/DQ tile once per block via the existing `_int16_fill_ditile!` (reusing the `dib`/`dqb` scratch), then accumulate each antenna/tap into a **register `Vec{W,Int32}` lane accumulator flushed into Int64 totals once per block** — no per-chunk horizontal reduction.
- Hoist the Int64 tap totals into the thread-local `Int16ScratchBuffers` (`tsumI`/`tsumQ`), and compute tap offsets inline, so the only per-call allocation is the small result `Vector` it must return (backend-level **~384 B → ~112 B** per call here, independent of integration length).
- Add an `_wide32(::Vec{W,Int32})` identity so the tile load works for both the Int16 and Int32 wipe backends (the fallback keeps the exact-Int32 accumulate; `vpmaddwd` stays reserved for the hot path).
- Scope the docstring's allocation-free claim to the static (`SVector`-shifts) path.

Results are bit-for-bit identical to before (verified against the static EPL kernel in the existing test).

## Tests

Added `dynamic Vector-shifts fallback is scratch-reusing (bounded allocs)` — asserts the backend call allocates only the result vector (≤ 256 B, constant across a 10× longer capture). It **fails on the pre-fix code** (384 B) and passes after. Full suite green.

Tracking issue: https://github.com/JuliaGNSS/Tracking.jl/issues/173

Closes #172

## Follow-ups (from CI)

- Julia 1.10/1.11 CI surfaced that `gen_code!` allocates ~500 B per strip-mine block on those versions — a pre-existing GNSSSignals codegen cost that the static `@generated` kernel incurs identically, and out of scope here. Localized on Julia 1.10.9: `_int16_fill_carrier!`, `_int16_fill_ditile!` and the new accumulate barrier each allocate 0.
- Moved the per-block correlate into a `Val{W}`-parameterized barrier (`_int16_dyn_accumulate_block!`, mirroring `_int16_fill_carrier!`) so `W` and the tile type const-fold into the `SIMD.Vec{W,…}` positions on every Julia version.
- Reworked the allocation test to compare the fallback against the static path (both call `gen_code!` identically per block, so the difference cancels that shared per-block cost and isolates the fallback's own per-call scratch): after the fix the gap is just the result vector (~48 B, constant in block count) vs the pre-fix offs + tI/tQ matrices (~300 B). Verified failing-first on the pre-fix source and passing after, on both Julia 1.10 and 1.12.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
