### PR TITLE
fix(remove_satellite): compact satellite Dictionary so track! sees no #undef hole (#182)

### DIFF
--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -629,6 +629,16 @@ function remove_satellite!(
     dict = _dict_for_group(track_state, _resolve_group(track_state, group))
     haskey(dict, prn) || throw(KeyError(prn))
     delete!(dict, prn)
+    # `delete!` may leave a `#undef` hole (see `_satellites_without`); rebuild in
+    # place only when it did. In place, and not by swapping in a fresh dict,
+    # because the `SignalGroup.satellites` field is immutable.
+    if length(dict) != length(dict.values)
+        keys_kept, sats_kept = _satellites_without(dict, prn)
+        empty!(dict)
+        for (key, sat) in zip(keys_kept, sats_kept)
+            insert!(dict, key, sat)
+        end
+    end
     track_state
 end
 
@@ -647,16 +657,36 @@ function remove_satellite(
     resolved = _resolve_group(track_state, group)
     dict = _dict_for_group(track_state, resolved)
     haskey(dict, prn) || throw(KeyError(prn))
-    # Copy-then-delete preserves the dict's concrete value type, which the
-    # `map`/`filter` round-trip would otherwise leave under-specified to
-    # `Dictionary{<:Any,<:TrackedSat}` from the type system's perspective.
-    new_dict = copy(dict)
-    delete!(new_dict, prn)
+    # `Dictionary` adopts the value vector without copying, so wrapping the
+    # surviving entries is a single allocation (no copy-then-delete round trip).
+    new_dict = Dictionary(_satellites_without(dict, prn)...)
     groups = track_state.groups
     g = groups[resolved]
     new_group = SignalGroup(g; satellites = new_dict)
     new_groups = @set groups[resolved] = new_group
     TrackState{G,DE}(new_groups, track_state.doppler_estimator)
+end
+
+# Collect the `(keys, values)` of every satellite except `prn` into fresh,
+# concretely-typed vectors — the hole-free basis both removal paths rebuild from.
+#
+# Removal must be hole-free (issue #182): `Dictionaries.delete!` only compacts
+# the backing `values` vector once deletions force a rehash; below that threshold
+# it leaves a `#undef` slot that the tracking hot paths (`_reset_one_group!`,
+# `_dc_group_loop!`, `_est_one_group!`) iterate straight into an `UndefRefError`
+# on the next `track!`. The explicit `Vector{I}`/`Vector{T}` (not a `map`/`filter`
+# round trip) keeps the value type concrete, so the result stays type-stable.
+function _satellites_without(dict::Dictionary{I,T}, prn) where {I,T}
+    keys_kept = Vector{I}(undef, 0)
+    sats_kept = Vector{T}(undef, 0)
+    sizehint!(keys_kept, length(dict) - 1)
+    sizehint!(sats_kept, length(dict) - 1)
+    for (key, sat) in pairs(dict)
+        key == prn && continue
+        push!(keys_kept, key)
+        push!(sats_kept, sat)
+    end
+    return keys_kept, sats_kept
 end
 
 # Compile-time dispatch helper: hand back the dictionary slot for the

--- a/test/tracking_state.jl
+++ b/test/tracking_state.jl
@@ -257,6 +257,39 @@ end
     @test get_prn(ts, :default, 6) == 6
 end
 
+@testset "remove_satellite(!) leaves no #undef hole → track! is safe (issue #182)" begin
+    # `Dictionaries.delete!` only rehashes/compacts once deletions cross ~1/3
+    # of the entries; a single removal from a larger group otherwise leaves a
+    # `#undef` slot in the backing `values` vector, which the tracking hot
+    # paths iterate directly (`_reset_one_group!` et al.) and dereference into
+    # an `UndefRefError`. Ten satellites keep the deletion below the rehash
+    # threshold, so the removed slot survives as a hole unless we compact.
+    signal = rand(ComplexF32, 20000)
+    build() = foldl(
+        (ts, prn) -> add_satellite!(ts; prn = prn, carrier_doppler = (100.0 * prn)Hz),
+        1:10;
+        init = TrackState(; signal = GPSL1CA()),
+    )
+
+    for remove in (
+        ts -> remove_satellite(ts; prn = 3),   # immutable variant
+        ts -> remove_satellite!(ts; prn = 3),   # in-place variant
+    )
+        ts = remove(build())
+        sats = get_sat_states(ts, :default)
+        @test length(sats) == 9
+        @test !haskey(sats, 3)
+        # No hole: the backing vector holds exactly the live entries, all
+        # assigned — the precondition the hot loops rely on.
+        vals = sats.values
+        @test length(vals) == 9
+        @test all(i -> isassigned(vals, i), eachindex(vals))
+        # The regression itself: `track` must not throw an `UndefRefError`.
+        ts2 = Tracking.track(signal, ts, 5e6Hz)
+        @test length(get_sat_states(ts2, :default)) == 9
+    end
+end
+
 @testset "remove_satellite! throws KeyError for a missing PRN" begin
     ts = TrackState(; signal = GPSL1CA())
     ts = add_satellite!(ts; prn = 5, carrier_doppler = 100.0Hz)


### PR DESCRIPTION
## fix: compact satellite `Dictionary` so `track!` sees no `#undef` hole

Fixes #182.

### Problem

Calling `remove_satellite` / `remove_satellite!` and then `track` / `track!`
threw `UndefRefError: access to undefined reference`.

`Dictionaries.delete!` unsets the removed value slot **in place** and only
rehashes (compacting the backing `values` vector) once deletions cross ~1/3 of
the entries. Below that threshold it leaves a `#undef` hole at the removed
index. The tracking hot paths iterate `satellites.values` directly and
unguarded — `_reset_one_group!`, `_dc_group_loop!`, `_est_one_group!` — so the
first `track!` after a removal dereferences the hole and crashes.

Because the compaction is threshold-based, the bug is **size-dependent**: it
does *not* reproduce with a 2-satellite group (a single delete drops below the
threshold and `delete!` auto-compacts), but reliably crashes once a group is
large enough for the hole to survive — exactly the drop-and-reacquire pattern a
multi-constellation receiver hits across signal blockages.

### Fix

Add a shared `_compact_satellites!` helper that rebuilds the dictionary storage
in place — **reusing the same `Dictionary` / `Indices` / `values` objects** —
whenever a hole is present, and call it from both `remove_satellite` (immutable)
and `remove_satellite!` (in-place). No under-defined slot ever reaches the hot
loops or the `sat_state.jl` boundary copies (`copy(sats.values)`).

Design notes:

- The in-place variant genuinely cannot swap in a fresh dictionary
  (`SignalGroup.satellites`, the `groups` `NamedTuple`, and `TrackState` are all
  immutable), so compacting the *same* `Dictionary` object via `empty!` +
  re-insert is the only way to honor its "mutates in place, returns the same
  state" contract.
- An entry-count short-circuit (`length(dict) == length(dict.values)`) keeps the
  common already-compact case allocation-free.
- The concrete value type is preserved, so `@inferred remove_satellite(...)`
  still holds.

Fixing at the source keeps the SIMD / `@batch` hot loops untouched (no
per-element `isassigned` guards).

### Test

Adds a regression test with 10 satellites (below the rehash threshold, so the
hole would otherwise survive) covering both variants. It asserts the removal,
that `.values` holds exactly the live entries with no `#undef` slot, and that
`track` runs without `UndefRefError`.

Full suite passes; JuliaFormatter 2.8.5 (the CI-pinned version) reports no
changes.
