### PR TITLE
fix(int16): require max_meas to size the carrier amplitude

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -789,6 +789,15 @@ if isdefined(Tracking, :Int16ThreadedDownconvertAndCorrelator)
         complex.(rand((-lim):(lim - one(Int16)), nsamp), rand((-lim):(lim - one(Int16)), nsamp))
     end
 
+    # Branch-portable Int16 backend construction. `max_meas` (the front end's
+    # full-scale) became a required positional argument; older Tracking took it
+    # only as a keyword with a default. AirspeedVelocity benches HEAD's suite
+    # against every rev, so dispatch on which signature the loaded Tracking has.
+    _make_int16_threaded_dc(max_meas) =
+        applicable(Tracking.Int16ThreadedDownconvertAndCorrelator, max_meas) ?
+        Tracking.Int16ThreadedDownconvertAndCorrelator(max_meas) :
+        Tracking.Int16ThreadedDownconvertAndCorrelator(; max_meas)
+
     # Self-explanatory scenario names (system · sat count · sampling rate). NO
     # "/" in a name — the benchmark-table script keys leaves by "/"-joined path,
     # so a slash would be read as an extra nesting level. Each scenario registers
@@ -807,7 +816,8 @@ if isdefined(Tracking, :Int16ThreadedDownconvertAndCorrelator)
         ts_i, _ = _make_steady_state_track_state(;
             systems, nsats_list, nsamp, prn_max, code_dop = 100.0)
         dc_f = _make_cpu_threaded_dc(sfreq)
-        dc_i = Tracking.Int16ThreadedDownconvertAndCorrelator()
+        # max_meas = 2^11 matches the ±2048 full-scale of `_int16_capture` above.
+        dc_i = _make_int16_threaded_dc(2^11)
         g = SUITE["track! Int16 vs Float32"][name]
         g["Float32"] = @benchmarkable Tracking.track!(
             $sig16, $ts_f, $sfreq; downconvert_and_correlator = $dc_f,

--- a/docs/src/track.md
+++ b/docs/src/track.md
@@ -84,7 +84,11 @@ buffers there is an opt-in integer backend,
 [`Int16ThreadedDownconvertAndCorrelator`](@ref) (and its single-threaded sibling
 [`Int16DownconvertAndCorrelator`](@ref)), which is typically ~1.3–2.9× faster.
 Select it explicitly via the `downconvert_and_correlator` keyword; it errors on a
-non-`Complex{Int16}` measurement.
+non-`Complex{Int16}` measurement. Its constructor takes one **required** positional
+argument, `max_meas` — your front end's full-scale (the largest `|real|`/`|imag|` a
+sample can take, e.g. `2^11` for a 12-bit ADC) — from which it sizes the carrier
+replica so the integer carrier wipe cannot overflow. There is no default: see
+[`Int16DownconvertAndCorrelator`](@ref) for why under-declaring it is catastrophic.
 
 ```@docs
 CPUDownconvertAndCorrelator

--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -55,14 +55,22 @@ end
 # (AVX2/AVX-512) only. Other backends use the exact Int32 multiply path.
 const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 
-# Maximum |measurement component| we size the carrier amplitude against: a 12-bit
-# ADC (|m| ≤ 2^11). Pick the LARGEST Int16-safe amplitude — the largest `amp` with
-# `2·max_meas·amp ≤ typemax(Int16)` — capped at the Int8 storage limit. Keeping the
-# wipe `DI = mᵣ·cos + mᵢ·sin` within Int16 enables the Int16 `vpmaddwd` fast path on
-# x86 and keeps `|DI| ≤ typemax(Int16)`. The wipe TYPE differs by backend (Int16 +
-# vpmaddwd on x86; exact Int32 elsewhere) but the AMPLITUDE is the same — using a
-# larger Int32-only amplitude (the old behaviour) overflowed the accumulator for
-# CBOC on the scalar/NEON path.
+# Choose the carrier-replica amplitude (and wipe arithmetic type) from `max_meas`,
+# the caller-declared largest `|real|`/`|imag|` of a measurement sample (e.g. 2^11
+# for a 12-bit ADC). Pick the LARGEST Int16-safe amplitude — the largest `amp` with
+# `2·max_meas·amp ≤ typemax(Int16)` — capped at the Int8 storage limit. The factor
+# of 2 is NOT slack: the carrier wipe is a COMPLEX multiply `DI = mᵣ·cos + mᵢ·sin`,
+# `DQ = mᵢ·cos − mᵣ·sin` — two products SUMMED per output — so `|DI| ≤ |mᵣ·cos| +
+# |mᵢ·sin| ≤ 2·max_meas·amp`; sizing against that keeps BOTH the intermediate
+# products and their sum within Int16. Keeping the wipe within Int16 enables the
+# Int16 `vpmaddwd` fast path on x86 and keeps `|DI| ≤ typemax(Int16)`. The wipe TYPE
+# differs by backend (Int16 + vpmaddwd on x86; exact Int32 elsewhere) but the
+# AMPLITUDE is the same — using a larger Int32-only amplitude (the old behaviour)
+# overflowed the accumulator for CBOC on the scalar/NEON path.
+#
+# `max_meas` is a required positional argument of both constructors (no default):
+# under-declaring it silently overflows the Int16 wipe and corrupts the correlation
+# catastrophically, so the caller must state their front end's full-scale.
 #
 # Three guards keep the per-block Σ codeₓ·DI within Int32 (the horizontal reduce is
 # widened to Int64, and two block-length caps bound the lanes themselves):
@@ -77,7 +85,6 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 #   * On the SinCosLUT `Portable` backend (`_INT16_W == 1`) a single Int32 lane sums
 #     a whole block, so `_int16_flush_len` shrinks the block by the SIMD width so no
 #     lane can wrap (#166); a no-op for W ≥ 16, so the hot path is unchanged.
-const _INT16_MAX_MEAS = 1 << 11
 function _int16_choose_carrier(max_meas::Integer)
     a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))
     a >= 1 || return (Int(typemax(Int8)), Int32)
@@ -252,16 +259,29 @@ static correlator path (EPL/VEPL and any `SVector`-shifts correlator). The
 runtime `AbstractVector`-shifts fallback additionally allocates the small
 `Vector` it returns each integration, but reuses the same thread-local scratch.
 
-The carrier-replica amplitude (and the wipe arithmetic type) are chosen from
-`max_meas`, the largest expected `|real|`/`|imag|` of a measurement sample —
-the largest amplitude that keeps the carrier wipe within `Int16` (so the wipe
-can't overflow and the on-x86 `vpmaddwd` fast path applies). Pass `max_meas`
-for your front end's full-scale (default `2^11`, a 12-bit ADC); under-declaring
-it risks overflow, over-declaring only coarsens the carrier. This backend is
-tuned for ≤12-bit sample buffers: for `max_meas ≥ 2^14` no `Int16`-safe carrier
-amplitude exists, so it falls back to the exact `Int32` wipe and automatically
-shrinks the strip-mine block to keep the correlation accumulators from
-overflowing (correct, but slower on that path).
+# Arguments
+
+`max_meas` (the first positional argument, **required — no default**) is the
+largest `|real|`/`|imag|` any measurement sample will take, i.e. your front end's
+full-scale (e.g. `2^11` for a 12-bit ADC). From it the constructor picks the
+LARGEST carrier-replica amplitude whose carrier wipe still fits `Int16`, and the
+wipe arithmetic type (`Int16` on the fast path, else `Int32`). The carrier
+wipe is a **complex** multiply `DI = mᵣ·cos + mᵢ·sin`, `DQ = mᵢ·cos − mᵣ·sin` —
+two products summed per output — so the amplitude is sized against
+`2·max_meas·amplitude ≤ typemax(Int16)`, bounding both the products and their sum.
+There is deliberately no default: **under-declaring `max_meas` silently overflows
+the `Int16` wipe and corrupts the correlation catastrophically**, so you must
+state it explicitly. Over-declaring is safe and only coarsens the carrier
+quantisation.
+
+!!! note "Performance: keep `max_meas < 2^14`"
+
+    For `max_meas ≥ 2^14` no `Int16`-safe carrier amplitude `≥ 1` exists, so the
+    backend falls back to an exact `Int32` carrier wipe — the on-x86 `vpmaddwd`
+    Int16 fast path no longer applies — and shrinks the strip-mine block to keep
+    the correlation accumulators from overflowing. This stays correct but is
+    measurably slower. This backend is tuned for ≤12-bit sample buffers; keep
+    `max_meas` below `2^14` to stay on the fast path.
 
 The `blk` keyword sets the strip-mine block length (samples). It must be `≥ 1`,
 validated at construction — `blk ≤ 0` would make the strip-mine loop never
@@ -327,8 +347,8 @@ function _int16_assert_engine_width(table::SinCosTable)
     return nothing
 end
 
-function Int16DownconvertAndCorrelator(;
-    max_meas::Integer = _INT16_MAX_MEAS,
+function Int16DownconvertAndCorrelator(
+    max_meas::Integer;
     steps::Integer = 64,
     blk::Integer = _INT16_BLK,
 )
@@ -343,8 +363,8 @@ function Int16DownconvertAndCorrelator(;
     )
 end
 
-function Int16ThreadedDownconvertAndCorrelator(;
-    max_meas::Integer = _INT16_MAX_MEAS,
+function Int16ThreadedDownconvertAndCorrelator(
+    max_meas::Integer;
     steps::Integer = 64,
     blk::Integer = _INT16_BLK,
 )

--- a/test/downconvert_and_correlate_int16.jl
+++ b/test/downconvert_and_correlate_int16.jl
@@ -64,6 +64,11 @@ function make_capture(sig, prn, fs, nsamp, cdopp, cphase; peak = 2000)
     complex.(round.(Int16, real.(s) .* peak), round.(Int16, imag.(s) .* peak))
 end
 
+# Declared full-scale for the plain-construction tests. `max_meas` is required (no
+# default) so every constructor call must state it; the captures above top out at
+# `peak = 2000 ≤ 2^11`, so `2^11` is the tightest `max_meas` that keeps them safe.
+const TEST_MAX_MEAS = 2^11
+
 band_key_for(sig) = get_band_id(sig)
 
 # M-antenna capture: a dense samples×M `Matrix` (same signal across antennas).
@@ -107,7 +112,7 @@ end
             100.0,
         )
         ci = correlate_once(
-            Int16ThreadedDownconvertAndCorrelator(),
+            Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS),
             sig,
             fs,
             nsamp,
@@ -147,7 +152,7 @@ end
             correlator = mk(),
         )
         ci = correlate_once(
-            Int16ThreadedDownconvertAndCorrelator(),
+            Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS),
             sig,
             fs,
             nsamp,
@@ -178,7 +183,7 @@ end
         run(dc) =
             first(get_sat_state(downconvert_and_correlate(dc, meas, mk()), 1).signals).correlator
         cf = run(CPUThreadedDownconvertAndCorrelator())
-        ci = run(Int16ThreadedDownconvertAndCorrelator())
+        ci = run(Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS))
         ef, pf, lf = get_early(cf), get_prompt(cf), get_late(cf)   # SVector{M,Complex}
         ei, pii, li = get_early(ci), get_prompt(ci), get_late(ci)
         @test length(pf) == M && length(pii) == M
@@ -192,9 +197,16 @@ end
     @testset "single-threaded and threaded backends agree" begin
         sig, fs = GPSL1CA(), 5e6Hz
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
-        c1 = correlate_once(Int16DownconvertAndCorrelator(), sig, fs, nsamp, 200Hz, 100.0)
+        c1 = correlate_once(
+            Int16DownconvertAndCorrelator(TEST_MAX_MEAS),
+            sig,
+            fs,
+            nsamp,
+            200Hz,
+            100.0,
+        )
         ct = correlate_once(
-            Int16ThreadedDownconvertAndCorrelator(),
+            Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS),
             sig,
             fs,
             nsamp,
@@ -226,7 +238,7 @@ end
             ).signals,
         ).correlator
         cf = corr(CPUThreadedDownconvertAndCorrelator())
-        ci = corr(Int16ThreadedDownconvertAndCorrelator(; max_meas = mm))
+        ci = corr(Int16ThreadedDownconvertAndCorrelator(mm))
         @test abs(get_early(ci)) / abs(get_prompt(ci)) ≈
               abs(get_early(cf)) / abs(get_prompt(cf)) atol = 1e-2
         @test abs(get_late(ci)) / abs(get_prompt(ci)) ≈
@@ -239,7 +251,7 @@ end
     @testset "Int32 wipe fallback (forced via large max_meas)" begin
         sig, fs = GPSL1CA(), 5e6Hz
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
-        dc32 = Int16ThreadedDownconvertAndCorrelator(; max_meas = 2^15)
+        dc32 = Int16ThreadedDownconvertAndCorrelator(2^15)
         @test dc32 isa Int16ThreadedDownconvertAndCorrelator{<:Any,Int32}   # Int32 wipe selected
         cf = correlate_once(
             CPUThreadedDownconvertAndCorrelator(),
@@ -280,7 +292,7 @@ end
             ).signals,
         ).correlator
         cf = corr(CPUThreadedDownconvertAndCorrelator())
-        ci = corr(Int16ThreadedDownconvertAndCorrelator(; max_meas = 2^15))
+        ci = corr(Int16ThreadedDownconvertAndCorrelator(2^15))
         @test abs(get_early(ci)) / abs(get_prompt(ci)) ≈
               abs(get_early(cf)) / abs(get_prompt(cf)) atol = 1e-2
         @test abs(get_late(ci)) / abs(get_prompt(ci)) ≈
@@ -295,7 +307,7 @@ end
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
         fc = 200Hz * get_code_center_frequency_ratio(sig) + get_code_frequency(sig)
         shifts = collect(get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc))
-        dc = Int16ThreadedDownconvertAndCorrelator()
+        dc = Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS)
         cs = correlate_once(dc, sig, fs, nsamp, 200Hz, 100.0)                       # static EPL
         cd = correlate_once(
             dc,
@@ -334,7 +346,7 @@ end
         fc = 200Hz * get_code_center_frequency_ratio(sig) + get_code_frequency(sig)
         shifts_s = get_correlator_sample_shifts(EarlyPromptLateCorrelator(), fs, fc)  # SVector → @generated
         shifts_v = collect(shifts_s)                                                  # Vector → fallback
-        dc = Int16DownconvertAndCorrelator()
+        dc = Int16DownconvertAndCorrelator(TEST_MAX_MEAS)
         runN(shifts, cap, ns) = Tracking._int16_hybrid_blocked!(
             dc,
             cap,
@@ -373,7 +385,7 @@ end
         nsamp = round(Int, (fs / 1Hz) * 1e-3)
         cap = make_capture(sig, 1, fs, nsamp, 200Hz, 100.0)
         meas = (L1 = BandMeasurement(cap, fs, 0.0Hz),)
-        dc = Int16ThreadedDownconvertAndCorrelator()
+        dc = Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS)
         est = ConventionalAssistedPLLAndDLL()
         mksig() = TrackedSignal(
             sig;
@@ -418,15 +430,23 @@ end
         # Both integer backends run the sample-type check through the shared
         # `_check_sample_type` hook, so both must reject Float samples.
         @test_throws ArgumentError downconvert_and_correlate(
-            Int16DownconvertAndCorrelator(),
+            Int16DownconvertAndCorrelator(TEST_MAX_MEAS),
             meas,
             ts,
         )
         @test_throws ArgumentError downconvert_and_correlate(
-            Int16ThreadedDownconvertAndCorrelator(),
+            Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS),
             meas,
             ts,
         )
+    end
+
+    @testset "max_meas is a required positional argument (no default)" begin
+        # Under-declaring max_meas silently overflows the Int16 wipe, so it must
+        # NOT default: constructing without it is a MethodError, not a silent
+        # fall-back to some assumed full-scale.
+        @test_throws MethodError Int16DownconvertAndCorrelator()
+        @test_throws MethodError Int16ThreadedDownconvertAndCorrelator()
     end
 
     @testset "rejects a `steps` that changes the engine width (#168)" begin
@@ -436,12 +456,19 @@ end
         # (width 1), so on any non-portable host it mismatches and must be
         # rejected at construction rather than producing garbage correlations.
         if Tracking._INT16_W != 1
-            @test_throws ArgumentError Int16DownconvertAndCorrelator(steps = 48)
-            @test_throws ArgumentError Int16ThreadedDownconvertAndCorrelator(steps = 48)
+            @test_throws ArgumentError Int16DownconvertAndCorrelator(
+                TEST_MAX_MEAS;
+                steps = 48,
+            )
+            @test_throws ArgumentError Int16ThreadedDownconvertAndCorrelator(
+                TEST_MAX_MEAS;
+                steps = 48,
+            )
         end
         # The default `steps = 64` always matches the kernel stride.
-        @test Int16DownconvertAndCorrelator(steps = 64) isa Int16DownconvertAndCorrelator
-        @test Int16ThreadedDownconvertAndCorrelator(steps = 64) isa
+        @test Int16DownconvertAndCorrelator(TEST_MAX_MEAS; steps = 64) isa
+              Int16DownconvertAndCorrelator
+        @test Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS; steps = 64) isa
               Int16ThreadedDownconvertAndCorrelator
     end
 
@@ -469,7 +496,7 @@ end
                 1,
             ).signals,
         ).correlator
-        ci_dc = Int16ThreadedDownconvertAndCorrelator()
+        ci_dc = Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS)
         cf = corr(CPUThreadedDownconvertAndCorrelator())
         ci = corr(ci_dc)
         # The capture is strong enough that the raw Int64 block-flush total exceeds
@@ -515,26 +542,33 @@ end
         # never advance → track! hangs the calling thread(s) forever (with the
         # threaded backend, the Polyester workers). Reject it at construction.
         for bad in (0, -1, -8192)
-            @test_throws ArgumentError Int16DownconvertAndCorrelator(; blk = bad)
-            @test_throws ArgumentError Int16ThreadedDownconvertAndCorrelator(; blk = bad)
+            @test_throws ArgumentError Int16DownconvertAndCorrelator(
+                TEST_MAX_MEAS;
+                blk = bad,
+            )
+            @test_throws ArgumentError Int16ThreadedDownconvertAndCorrelator(
+                TEST_MAX_MEAS;
+                blk = bad,
+            )
         end
 
         # A positive blk is accepted and stored verbatim (default and custom).
-        @test Int16DownconvertAndCorrelator().blk == 8192
-        @test Int16ThreadedDownconvertAndCorrelator().blk == 8192
-        @test Int16DownconvertAndCorrelator(; blk = 4096).blk == 4096
+        @test Int16DownconvertAndCorrelator(TEST_MAX_MEAS).blk == 8192
+        @test Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS).blk == 8192
+        @test Int16DownconvertAndCorrelator(TEST_MAX_MEAS; blk = 4096).blk == 4096
 
         # A large blk is NOT rejected: the per-lane Int32 overflow it once risked
         # is bounded at run time by `_int16_flush_len` (#166) and `_int16_safe_blk`
         # (#167), which cap the effective block. So construction succeeds and the
         # correlators stay correct — the E/P·L/P triangle matches the default-blk
         # result (it would be garbage if a lane had wrapped).
-        @test Int16DownconvertAndCorrelator(; blk = 200_000).blk == 200_000
-        @test Int16ThreadedDownconvertAndCorrelator(; blk = 200_000).blk == 200_000
+        @test Int16DownconvertAndCorrelator(TEST_MAX_MEAS; blk = 200_000).blk == 200_000
+        @test Int16ThreadedDownconvertAndCorrelator(TEST_MAX_MEAS; blk = 200_000).blk ==
+              200_000
         let sig = GalileoE1B(), fs = 15e6Hz
             nsamp = round(Int, (fs / 1Hz) * 1e-3)
             cbig = correlate_once(
-                Int16DownconvertAndCorrelator(; blk = 200_000),
+                Int16DownconvertAndCorrelator(TEST_MAX_MEAS; blk = 200_000),
                 sig,
                 fs,
                 nsamp,
@@ -542,7 +576,7 @@ end
                 100.0,
             )
             cdef = correlate_once(
-                Int16DownconvertAndCorrelator(),
+                Int16DownconvertAndCorrelator(TEST_MAX_MEAS),
                 sig,
                 fs,
                 nsamp,
@@ -566,7 +600,9 @@ end
             cap,
             ts,
             fs;
-            downconvert_and_correlator = Int16ThreadedDownconvertAndCorrelator(),
+            downconvert_and_correlator = Int16ThreadedDownconvertAndCorrelator(
+                TEST_MAX_MEAS,
+            ),
         )
         # Converges back toward the true Doppler from the 20 Hz initial offset.
         @test get_carrier_doppler(get_sat_state(ts, 1)) ≈ cdopp atol = 10Hz


### PR DESCRIPTION
## Summary

The `Int16DownconvertAndCorrelator` / `Int16ThreadedDownconvertAndCorrelator` constructors previously defaulted `max_meas` to `2^11`. That silently assumed a front-end full-scale the caller may not have — a front end with a larger range overflows the **complex** carrier wipe `DI = mᵣ·cos + mᵢ·sin`, `DQ = mᵢ·cos − mᵣ·sin` into `Int16` and corrupts the correlation with no error.

This makes `max_meas` (the front end's full-scale — largest `|real|`/`|imag|` per sample) a **required positional argument** with no default. From it the carrier-replica amplitude and wipe arithmetic type are chosen so the wipe cannot overflow `Int16`, sized against `2·max_meas·amplitude ≤ typemax(Int16)` — the factor of 2 covers the two products summed per output of the complex multiply. Constructing without `max_meas` is now a `MethodError` rather than a silent, unsafe fall-back.

## Details

- Removed the `max_meas = 2^11` default (and the now-unused `_INT16_MAX_MEAS` const); `max_meas` is the first positional arg of both constructors.
- Docstrings gain an Arguments section, an explanation that the factor-of-2 bound is the complex-wipe term, and a **performance note**: `max_meas ≥ 2^14` has no Int16-safe carrier amplitude, so it drops to the slower exact-`Int32` wipe (no on-x86 `vpmaddwd` fast path) and shrinks the strip-mine block.
- `docs/src/track.md` documents the required argument.
- `benchmark/benchmarks.jl` passes `max_meas = 2^11` (matches its ±2048 capture).

## Testing

- `test/downconvert_and_correlate_int16.jl`: all constructions pass `max_meas`; added a test asserting `max_meas` is required (no default). **114/114 pass** locally.
- Files pass `JuliaFormatter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)