### PR TITLE
perf: aarch64 (NEON) speedups for Int16 and OneBit correlate backends

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -986,3 +986,42 @@ if isdefined(Tracking, :OneBitThreadedDownconvertAndCorrelator) &&
         )
     end
 end
+
+# ── Int16 / OneBit `track!` in the base-vs-head regression table ───────────────
+# The `track! Int16 vs Float32` group above is rendered head-only (a Float32-relative
+# table), so it can't reveal an Int16/OneBit *kernel* speedup against the base branch.
+# Register a few `track!` benchmarks with those backends under the plain `track` group
+# instead: `bench_table.jl` diffs every non-`track! Int16 vs Float32` leaf base-vs-head,
+# so these land in the regression table next to the Float32 `track!` rows and a backend
+# speedup shows directly. Unlike a new *table* group, this needs no `bench_table.jl`
+# change — the base ref's script (which the workflow runs) already diffs this group. Same
+# rebuild-state-per-eval pattern as the head-to-head group (random samples drift `track!`
+# to a NaN doppler otherwise).
+if isdefined(Tracking, :Int16DownconvertAndCorrelator) && isdefined(Tracking, :track!)
+    for (key, systems, nsats_list, sfreq, nsamp, prn_max, onebit) in (
+        ("2. L1 8sat/5K", (GPSL1CA(),), [8], 5e6Hz, 5000, 32, true),
+        ("3. E1B 4sat/25K", (GalileoE1B(),), [4], 25e6Hz, 25000, 50, false),
+    )
+        sig16 = _int16_capture(nsamp)
+        dc_i = _make_int16_dc(2^11)   # max_meas = 2^11 matches _int16_capture's ±2048
+        SUITE["track"]["$key – track! Int16"] = @benchmarkable(
+            Tracking.track!($sig16, ts, $sfreq; downconvert_and_correlator = $dc_i),
+            setup = (ts = first(_make_steady_state_track_state(;
+                systems = $systems, nsats_list = $nsats_list, nsamp = $nsamp,
+                prn_max = $prn_max, code_dop = 100.0,
+            ))),
+            evals = 1,
+        )
+        if onebit && isdefined(Tracking, :OneBitDownconvertAndCorrelator)
+            dc_b = Tracking.OneBitDownconvertAndCorrelator()
+            SUITE["track"]["$key – track! OneBit"] = @benchmarkable(
+                Tracking.track!($sig16, ts, $sfreq; downconvert_and_correlator = $dc_b),
+                setup = (ts = first(_make_steady_state_track_state(;
+                    systems = $systems, nsats_list = $nsats_list, nsamp = $nsamp,
+                    prn_max = $prn_max, code_dop = 100.0,
+                ))),
+                evals = 1,
+            )
+        end
+    end
+end

--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -55,6 +55,18 @@ end
 # (AVX2/AVX-512) only. Other backends use the exact Int32 multiply path.
 const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 
+# Whether to run the carrier wipe in Int16 (vs. exact Int32). An Int16 wipe halves
+# both the wipe's SIMD op count (8 Int16 lanes per 128-bit register vs. 4 Int32)
+# and the DI/DQ memory traffic, and it lets the code accumulate `Σ codeₓ·DI` use a
+# widening multiply-accumulate: x86 gets the pairwise `vpmaddwd`, and aarch64 gets
+# NEON `SMLAL`/`SMLAL2` — LLVM auto-selects the latter from a `sext(i16)·sext(i16)`
+# accumulate (verified in @code_native), so no intrinsic is needed there. Both need
+# `2·max_meas·amp ≤ typemax(Int16)` (the `a ≥ 1` case in `_int16_choose_carrier`) to
+# keep the wipe from overflowing Int16. On other arches / narrow-SIMD hosts the
+# Int16 wipe would gain nothing (no widening-MAC lowering), so keep the exact Int32
+# path there.
+const _INT16_WIDE_WIPE = _INT16_HAS_MADDWD || Sys.ARCH === :aarch64
+
 # Choose the carrier-replica amplitude (and wipe arithmetic type) from `max_meas`,
 # the caller-declared largest `|real|`/`|imag|` of a measurement sample (e.g. 2^11
 # for a 12-bit ADC). Pick the LARGEST Int16-safe amplitude — the largest `amp` with
@@ -63,10 +75,11 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 # `DQ = mᵢ·cos − mᵣ·sin` — two products SUMMED per output — so `|DI| ≤ |mᵣ·cos| +
 # |mᵢ·sin| ≤ 2·max_meas·amp`; sizing against that keeps BOTH the intermediate
 # products and their sum within Int16. Keeping the wipe within Int16 enables the
-# Int16 `vpmaddwd` fast path on x86 and keeps `|DI| ≤ typemax(Int16)`. The wipe TYPE
-# differs by backend (Int16 + vpmaddwd on x86; exact Int32 elsewhere) but the
-# AMPLITUDE is the same — using a larger Int32-only amplitude (the old behaviour)
-# overflowed the accumulator for CBOC on the scalar/NEON path.
+# widening-MAC fast path (`vpmaddwd` on x86, `SMLAL` on aarch64; see
+# `_INT16_WIDE_WIPE`) and keeps `|DI| ≤ typemax(Int16)`. The wipe TYPE differs by
+# backend (Int16 on the wide-wipe arches; exact Int32 elsewhere) but the AMPLITUDE
+# is the same — using a larger Int32-only amplitude (the old behaviour) overflowed
+# the accumulator for CBOC on the scalar path.
 #
 # `max_meas` is a required positional argument of both constructors (no default):
 # under-declaring it silently overflows the Int16 wipe and corrupts the correlation
@@ -88,7 +101,7 @@ const _INT16_HAS_MADDWD = Sys.ARCH in (:x86_64, :i686) && _INT16_W in (32, 64)
 function _int16_choose_carrier(max_meas::Integer)
     a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))
     a >= 1 || return (Int(typemax(Int8)), Int32)
-    (min(a, Int(typemax(Int8))), _INT16_HAS_MADDWD ? Int16 : Int32)
+    (min(a, Int(typemax(Int8))), _INT16_WIDE_WIPE ? Int16 : Int32)
 end
 
 # Largest multi-level code sub-carrier magnitude the correlate accumulate must
@@ -460,6 +473,10 @@ end
     W = _INT16_W
     TI = dc.parameters[2]              # carrier-wipe element type, per backend instance
     use_madd = _INT16_HAS_MADDWD && TI === Int16
+    # aarch64 Int16-wipe accumulate: widen code+DI to Int32 and MAC — LLVM lowers
+    # the `sext(i16)·sext(i16)` accumulate to NEON `SMLAL`/`SMLAL2` (no pairwise
+    # pre-sum, so `AW = W`, unlike x86's `vpmaddwd`).
+    use_smlal = TI === Int16 && !use_madd
     AW = use_madd ? W ÷ 2 : W          # vpmaddwd pre-sums adjacent pairs → W÷2
     MT = TI === Int16 ? Int16 : Int32  # meas/wipe SIMD element type
     cc_load =
@@ -501,6 +518,15 @@ end
                         codew = _wide16(vload(SIMD.Vec{$W,Int8}, extb, n + $offk))
                         $aI += _maddacc(codew, DI)
                         $aQ += _maddacc(codew, DQ)
+                    end,
+                )
+            elseif use_smlal
+                push!(
+                    chunk.args,
+                    quote
+                        codew = _wide16(vload(SIMD.Vec{$W,Int8}, extb, n + $offk))
+                        $aI += _wide32(codew) * _wide32(DI)
+                        $aQ += _wide32(codew) * _wide32(DQ)
                     end,
                 )
             else
@@ -671,9 +697,16 @@ end
             aQ = zero(SIMD.Vec{W,Int32})
             n = 1
             while n + W - 1 <= len
+                # When the tile is Int16 (wide-wipe arches) widen code through Int16
+                # so the `sext(i16)·sext(i16)` MAC lowers to NEON SMLAL; the `TIw`
+                # branch is a compile-time constant. Int32 tiles keep the exact path.
+                if TIw === Int16
+                    codev = _wide32(_wide16(vload(SIMD.Vec{W,Int8}, extb, n + offk)))
+                else
+                    codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offk))
+                end
                 DI = _wide32(vload(SIMD.Vec{W,TIw}, dib, toff + n))
                 DQ = _wide32(vload(SIMD.Vec{W,TIw}, dqb, toff + n))
-                codev = _wide32(vload(SIMD.Vec{W,Int8}, extb, n + offk))
                 aI += codev * DI
                 aQ += codev * DQ
                 n += W
@@ -910,6 +943,7 @@ end
     W = _INT16_W
     TI = dc.parameters[2]              # carrier-wipe element type, per backend instance
     use_madd = _INT16_HAS_MADDWD && TI === Int16
+    use_smlal = TI === Int16 && !use_madd   # aarch64 widening MAC (SMLAL); see the single-signal kernel
     AW = use_madd ? W ÷ 2 : W
     N = length(all_shifts.parameters)
     NCs = [length(all_shifts.parameters[i]) for i = 1:N]
@@ -982,6 +1016,15 @@ end
                             codew = _wide16(vload(SIMD.Vec{$W,Int8}, extb, n + $offk))
                             $aI += _maddacc(codew, DI)
                             $aQ += _maddacc(codew, DQ)
+                        end,
+                    )
+                elseif use_smlal
+                    push!(
+                        chunk.args,
+                        quote
+                            codew = _wide16(vload(SIMD.Vec{$W,Int8}, extb, n + $offk))
+                            $aI += _wide32(codew) * _wide32(DI)
+                            $aQ += _wide32(codew) * _wide32(DQ)
                         end,
                     )
                 else

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -39,28 +39,100 @@ const _ONEBIT_BLK = 8192
 const _OB_VW = 8
 
 # ── sign-mask helpers: pack the sign bit of 64 lanes into a UInt64 (bit j ⇔ lane j < 0) ──
-@inline _ob_mm(v::SIMD.Vec{64,Int8}) = Base.llvmcall(
-    (
-        """
+# Two lowerings of the same operation, chosen by arch. The portable form (`icmp slt` +
+# `bitcast <64 x i1> to i64`) is optimal on x86 (→ `vpmovmskb` / `vpmov{b,w}2m`), but on
+# aarch64 LLVM emits a per-16-lane `cmlt` + `and` + `addv` + GPR-move sequence whose serial
+# `addv`→GPR moves dominate. The aarch64 form isolates each lane's sign bit with the
+# `{1,2,…,128}` bitmask and reduces with a 4-deep `addp` (vpaddq) tree — one GPR move total,
+# no `addv` — measured ≈2.4× (Int8) / ≈1.9× (Int16) faster on Cortex-A78. Both bit-identical:
+# bit j is set ⇔ lane j is negative. The Int16 form does one extra `sext <64 x i1> to <64 x i8>`
+# so it can share the byte-wise `addp` tree.
+@static if Sys.ARCH === :aarch64
+    # `%s` (a <64 x i8>, byte j = 0xFF ⇔ lane j negative) → u64 bitmask: isolate each lane's
+    # bit with the {1,2,…,128} mask, then a 4-deep `addp` (vpaddq) tree. The Int16 form adds
+    # one `sext <64 x i1> to <64 x i8>` so it shares the byte-wise tree.
+    @inline _ob_mm(v::SIMD.Vec{64,Int8}) = Base.llvmcall(
+        (
+            """
+declare <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8>, <16 x i8>)
+define i64 @entry(<64 x i8> %v) #0 {
+  %c = icmp slt <64 x i8> %v, zeroinitializer
+  %s = sext <64 x i1> %c to <64 x i8>
+  %v0 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 0,i32 1,i32 2,i32 3,i32 4,i32 5,i32 6,i32 7,i32 8,i32 9,i32 10,i32 11,i32 12,i32 13,i32 14,i32 15>
+  %v1 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 16,i32 17,i32 18,i32 19,i32 20,i32 21,i32 22,i32 23,i32 24,i32 25,i32 26,i32 27,i32 28,i32 29,i32 30,i32 31>
+  %v2 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 32,i32 33,i32 34,i32 35,i32 36,i32 37,i32 38,i32 39,i32 40,i32 41,i32 42,i32 43,i32 44,i32 45,i32 46,i32 47>
+  %v3 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 48,i32 49,i32 50,i32 51,i32 52,i32 53,i32 54,i32 55,i32 56,i32 57,i32 58,i32 59,i32 60,i32 61,i32 62,i32 63>
+  %bm0 = and <16 x i8> %v0, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm1 = and <16 x i8> %v1, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm2 = and <16 x i8> %v2, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm3 = and <16 x i8> %v3, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %p0 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %bm0, <16 x i8> %bm1)
+  %p1 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %bm2, <16 x i8> %bm3)
+  %p2 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %p0, <16 x i8> %p1)
+  %p3 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %p2, <16 x i8> %p2)
+  %r = bitcast <16 x i8> %p3 to <2 x i64>
+  %lo = extractelement <2 x i64> %r, i32 0
+  ret i64 %lo }
+attributes #0 = { alwaysinline }""",
+            "entry",
+        ),
+        UInt64,
+        Tuple{NTuple{64,Base.VecElement{Int8}}},
+        v.data,
+    )
+    @inline _ob_mm(v::SIMD.Vec{64,Int16}) = Base.llvmcall(
+        (
+            """
+declare <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8>, <16 x i8>)
+define i64 @entry(<64 x i16> %v) #0 {
+  %c = icmp slt <64 x i16> %v, zeroinitializer
+  %s = sext <64 x i1> %c to <64 x i8>
+  %v0 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 0,i32 1,i32 2,i32 3,i32 4,i32 5,i32 6,i32 7,i32 8,i32 9,i32 10,i32 11,i32 12,i32 13,i32 14,i32 15>
+  %v1 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 16,i32 17,i32 18,i32 19,i32 20,i32 21,i32 22,i32 23,i32 24,i32 25,i32 26,i32 27,i32 28,i32 29,i32 30,i32 31>
+  %v2 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 32,i32 33,i32 34,i32 35,i32 36,i32 37,i32 38,i32 39,i32 40,i32 41,i32 42,i32 43,i32 44,i32 45,i32 46,i32 47>
+  %v3 = shufflevector <64 x i8> %s, <64 x i8> undef, <16 x i32> <i32 48,i32 49,i32 50,i32 51,i32 52,i32 53,i32 54,i32 55,i32 56,i32 57,i32 58,i32 59,i32 60,i32 61,i32 62,i32 63>
+  %bm0 = and <16 x i8> %v0, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm1 = and <16 x i8> %v1, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm2 = and <16 x i8> %v2, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %bm3 = and <16 x i8> %v3, <i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128,i8 1,i8 2,i8 4,i8 8,i8 16,i8 32,i8 64,i8 -128>
+  %p0 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %bm0, <16 x i8> %bm1)
+  %p1 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %bm2, <16 x i8> %bm3)
+  %p2 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %p0, <16 x i8> %p1)
+  %p3 = call <16 x i8> @llvm.aarch64.neon.addp.v16i8(<16 x i8> %p2, <16 x i8> %p2)
+  %r = bitcast <16 x i8> %p3 to <2 x i64>
+  %lo = extractelement <2 x i64> %r, i32 0
+  ret i64 %lo }
+attributes #0 = { alwaysinline }""",
+            "entry",
+        ),
+        UInt64,
+        Tuple{NTuple{64,Base.VecElement{Int16}}},
+        v.data,
+    )
+else
+    @inline _ob_mm(v::SIMD.Vec{64,Int8}) = Base.llvmcall(
+        (
+            """
 define i64 @entry(<64 x i8> %v) #0 { %c = icmp slt <64 x i8> %v, zeroinitializer
   %m = bitcast <64 x i1> %c to i64 ret i64 %m } attributes #0={alwaysinline}""",
-        "entry",
-    ),
-    UInt64,
-    Tuple{NTuple{64,Base.VecElement{Int8}}},
-    v.data,
-)
-@inline _ob_mm(v::SIMD.Vec{64,Int16}) = Base.llvmcall(
-    (
-        """
+            "entry",
+        ),
+        UInt64,
+        Tuple{NTuple{64,Base.VecElement{Int8}}},
+        v.data,
+    )
+    @inline _ob_mm(v::SIMD.Vec{64,Int16}) = Base.llvmcall(
+        (
+            """
 define i64 @entry(<64 x i16> %v) #0 { %c = icmp slt <64 x i16> %v, zeroinitializer
   %m = bitcast <64 x i1> %c to i64 ret i64 %m } attributes #0={alwaysinline}""",
-        "entry",
-    ),
-    UInt64,
-    Tuple{NTuple{64,Base.VecElement{Int16}}},
-    v.data,
-)
+            "entry",
+        ),
+        UInt64,
+        Tuple{NTuple{64,Base.VecElement{Int16}}},
+        v.data,
+    )
+end
 @inline _ob_masklast(w::UInt64, r::Int) = r == 0 ? w : w & ((UInt64(1) << r) - UInt64(1))
 
 # Pack tap code sign plane: bit for output sample n = sign(extb[byteoff+n]). `extb` is


### PR DESCRIPTION
Two ARM/NEON performance improvements for the bit-wise/integer correlate backends, developed and benchmarked on a Jetson Orin (Cortex-A78AE, aarch64) and validated on the CI Apple-Silicon runner (macos-14). Both are **bit-identical** to the previous output and leave x86 / other arches unchanged.

## 1. `Int16` backend — NEON `SMLAL` widening accumulate

The Int16 downconvert+correlate backend had an **x86-only** fast path (Int16 carrier wipe + `vpmaddwd`, gated on `_INT16_HAS_MADDWD`). Every other arch — including aarch64 — ran the whole wipe *and* accumulate in Int32 (4 lanes/128-bit register, no widening MAC).

- New `_INT16_WIDE_WIPE = _INT16_HAS_MADDWD || Sys.ARCH === :aarch64` drives the wipe element type.
- New `use_smlal` codegen branch (both `@generated` kernels + dynamic fallback): `aI += _wide32(codew) * _wide32(DI)` with code widened Int8→Int16; LLVM lowers the `sext(i16)·sext(i16)` accumulate to `SMLAL`/`SMLAL2` (verified via `@code_native` — 25 `smlal` in the real kernel), no intrinsic needed.

The wipe now runs in Int16 (8 lanes/reg) and the DI/DQ tile memory halves. Overflow safety is unchanged (same `2·max_meas·amp ≤ typemax(Int16)` premise; `max_meas ≥ 2^14` still uses the exact Int32 fallback).

**Measured (Jetson Orin, 1 ms):** 1.25–1.41× (GPS L1CA EPL/VEPL, Galileo E1B EPL).

## 2. `OneBit` backend — faster NEON sign-mask (`addp` tree)

The one-bit backend packs sign planes with `_ob_mm` (movemask): `icmp slt` + `bitcast <64 x i1> to i64`. Optimal on x86 (`vpmovmskb`), but on aarch64 LLVM emits a per-16-lane `cmlt`+`and`+`addv`+GPR-move sequence dominated by the serial `addv`→GPR moves. Profiling showed sign-plane packing is ~29 % of the kernel.

- New aarch64-only `_ob_mm` isolates each lane's sign bit with the `{1,2,…,128}` bitmask and reduces with a 4-deep `addp` (vpaddq) tree — one GPR move total.

**Measured:** the movemask itself is ≈2.4× (Int8) / ≈1.9× (Int16) faster → ≈1.12–1.17× on the whole one-bit kernel (GPS L1CA/L5I EPL/VEPL).

(The one-bit kernel's other big cost — 1-bit carrier-sign generation, ~39 % — lives in the SinCosLUT dependency, which already has a NEON path; the correlate popcount loop is already register-pressure-optimal on NEON, so neither is touched here.)

## Validation

- Full `] test` passes on the Jetson Orin (aarch64); Int16 (114) and OneBit (127) suites pass.
- Bit-identical outputs before/after on both backends.
- CI green across Linux/Windows/macOS × Julia 1.10 & 1, plus both benchmark runners (x86 + Apple-Silicon ARM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)