### PR TITLE
[CI PROBE - do not merge] base on Julia 1.10 with today's deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ For usage examples and detailed documentation, see the [stable docs](https://Jul
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+<!-- ci probe (temporary): does base pass Julia 1.10 with today's deps? -->


### PR DESCRIPTION
Temporary probe: unmodified base code (README no-op only) to check whether Julia 1.10 CI fails today due to a freshly-resolved dependency rather than PR #194's source change. Will be closed once the 1.10 job reports.