### PR TITLE
ci(bench): add memory ratio column to the base-vs-head table

### DIFF
--- a/.github/scripts/bench_table.jl
+++ b/.github/scripts/bench_table.jl
@@ -64,6 +64,18 @@ function fmt_ratio(r)
     r >= 1.05 ? "$s ✅" : r <= 0.95 ? "$s ⚠️" : s
 end
 
+# Memory ratio cell: base/head bytes allocated (>1 ⇒ the PR allocates less, same
+# "bigger is better" direction as the time ratio). Bytes are often zero for these
+# in-place `track!` benchmarks, so guard the degenerate ratios: `∞` when the PR
+# drops to zero allocations, `0` when it introduces them, `—` when both are zero.
+function fmt_mem_ratio(b, h)
+    bm = Float64(b["memory"]); hm = Float64(h["memory"])
+    bm == 0 && hm == 0 && return "—"
+    hm == 0 && return "∞ ✅"
+    bm == 0 && return "0 ⚠️"
+    fmt_ratio(bm / hm)
+end
+
 base = leaves!(Dict{String,Any}(), readrev(base_rev))
 head = leaves!(Dict{String,Any}(), readrev(head_rev))
 
@@ -163,13 +175,23 @@ println(io)
 # --- memory table ---
 println(io, "<details><summary>Memory benchmarks (base vs PR head)</summary>")
 println(io)
-println(io, "|  | $baselbl | $headlbl |")
-println(io, "|:--|--:|--:|")
+println(io, "Ratio = $baselbl / $headlbl (bytes allocated): **>1 means the PR allocates less**. ",
+            "✅ ≥ 5 % less, ⚠️ ≥ 5 % more. `∞`/`0` mark a benchmark that drops to / picks up ",
+            "allocations, `—` means both revisions allocate nothing. A blank cell means the ",
+            "benchmark exists on only one revision (🆕 = new on the PR, 🗑 = removed).")
+println(io)
+println(io, "|  | $baselbl | $headlbl | $baselbl / $headlbl |")
+println(io, "|:--|--:|--:|--:|")
 for n in names
     b = get(base, n, nothing); h = get(head, n, nothing)
     bcell = b === nothing ? "" : fmt_mem(b)
     hcell = h === nothing ? "" : fmt_mem(h)
-    println(io, "| $n | $bcell | $hcell |")
+    if b !== nothing && h !== nothing
+        rcell = fmt_mem_ratio(b, h)
+    else
+        rcell = h === nothing ? "🗑" : "🆕"
+    end
+    println(io, "| $n | $bcell | $hcell | $rcell |")
 end
 println(io)
 println(io, "</details>")


### PR DESCRIPTION
## What

The PR-comment benchmark builder (`.github/scripts/bench_table.jl`) showed a `base / head` **ratio** for the time regression table but printed the memory table with only the two raw values — no ratio. This adds a matching ratio column to the memory table.

## Details

- New `fmt_mem_ratio` helper computes `base / head` bytes allocated (`>1` ⇒ the PR allocates less), using the same direction and ✅ ≥ 5 % / ⚠️ ≥ 5 % thresholds as the time ratio.
- Memory bytes are frequently zero for these in-place `track!` benchmarks, so the helper guards the degenerate ratios:

  | Case | Cell |
  |---|---|
  | both revisions allocate nothing | `—` |
  | PR drops to zero allocations | `∞ ✅` |
  | PR introduces allocations | `0 ⚠️` |
  | normal | e.g. `1.25 ✅` |
  | benchmark on one revision only | `🆕` / `🗑` |

## Testing

Ran the script against synthetic result JSONs exercising every case above; the memory table renders the ratio column correctly for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)