### PR TITLE
fix(gpsl1ca): Student-t small-sample threshold in CFAR bit-edge detector

### DIFF
--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -6,7 +6,7 @@ using FastSinCos
 using GNSSSignals
 using SIMD
 using SinCosLUT
-using SpecialFunctions: erfinv
+using SpecialFunctions: beta_inc_inv
 using StaticArrays
 using TrackingLoopFilters
 using Dictionaries

--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -25,13 +25,39 @@ end
 """
 $(SIGNATURES)
 
-Standard-normal quantile (inverse CDF) `Φ⁻¹(probability)` for
-`probability ∈ (0, 1)`, as `√2 · erfinv(2·probability − 1)` (`erfinv` from
-SpecialFunctions.jl). Used by [`_detect_bit_edge_cfar`](@ref) to turn a
-false-sync probability into a detection z-score threshold. Returns `±Inf`
-at `probability = 1` / `0`; callers keep the argument in the open interval.
+`probability`-quantile of a Student-t distribution with `dof` degrees of
+freedom, i.e. `t` such that `P(T ≤ t) = probability`. Used by
+[`_detect_bit_edge_cfar`](@ref) in place of a standard-normal quantile as a
+**small-sample penalty**, not because the detector's z-score is exactly
+Student-t distributed. The z-score there divides the energy gap by a standard
+error built from a variance *estimated* over `peak_bin_count` bins; a normal
+threshold treats that estimate as exact and is badly overconfident when the
+count is tiny (its ~3.9 threshold is a ~10% per-phase false alarm at one d.o.f.,
+not the intended ~1e-4), which let a variance-collapsed 1–2-bin fluctuation lock
+(JuliaGNSS/Tracking#124 fixed a 1-block hard-detector miss; this closes the soft
+detector's own few-bin false-lock). The t-quantile is the right *shape* of
+correction — it grows steeply as `dof → 1` and relaxes to the normal quantile as
+`dof → ∞` (so mature many-bin locks are unaffected, no cutoff needed) — but its
+nominal `dof = peak_bin_count − 1` is a heuristic, **not** the true degrees of
+freedom: the per-bin values are χ² (non-central) energies rather than Gaussian,
+and the competing phases share blocks (correlated), so the exact sampling
+distribution is neither normal nor Student-t and the realised false-alarm rate
+is only approximately the nominal one. It is used as a conservative,
+integration-forcing penalty, not an exact calibration.
+
+The upper tail (`probability > 0.5`) uses the regularized incomplete beta
+inverse: for `t > 0`, `P(T > t) = ½·Iₓ(dof/2, ½)` with `x = dof/(dof + t²)`, so
+`x = beta_inc_inv(dof/2, ½, 2·(1 − probability))` and `t = √(dof·(1 − x)/x)`.
+The lower tail is reflected by symmetry, and the median `t(0.5) = 0` is returned
+directly — which also avoids a `1 − 0.5` self-recursion. The sole caller passes
+`probability > 0.5` (and `dof ≥ 1`, since `peak_bin_count ≥ 2` at the call site).
 """
-@inline _norm_quantile(probability::Float64) = sqrt(2.0) * erfinv(2 * probability - 1)
+@inline function _t_quantile(probability::Float64, dof::Real)
+    probability == 0.5 && return 0.0
+    probability < 0.5 && return -_t_quantile(1 - probability, dof)
+    x = first(beta_inc_inv(dof / 2, 0.5, 2 * (1 - probability)))
+    sqrt(dof * (1 - x) / x)
+end
 
 """
 $(SIGNATURES)
@@ -171,11 +197,15 @@ signal and then mistake a tiny systematic cross-phase asymmetry for a real
 edge.) The peak is accepted only when it beats the runner-up by a margin
 significant under that spread:
 
-    z_score = energy_gap / standard_error   ≥   Φ⁻¹(1 - false_alarm_probability/(blocks_per_bit - 1))
+    z_score = energy_gap / standard_error   ≥   t⁻¹(1 - false_alarm_probability/(blocks_per_bit - 1);  ν = peak_bin_count − 1)
 
 where the standard error combines the peak phase's per-bin energy variance
 over the peak and runner-up bin counts, `false_alarm_probability = 1 - confidence` is Bonferroni-split over the `blocks_per_bit - 1` competing
-phases, and `Φ⁻¹` is [`_norm_quantile`](@ref). A real edge has a structural
+phases, and the quantile is the Student-t inverse-CDF [`_t_quantile`](@ref) at
+a nominal `ν = peak_bin_count − 1` d.o.f. — a small-sample penalty for dividing
+by a variance estimated over that few bins, not a claim that `z_score` is exactly
+Student-t (the per-bin energies are χ² and the phases correlated; see
+[`_t_quantile`](@ref)). A real edge has a structural
 gap that dwarfs the thermal bin-to-bin spread, so `z_score` grows like the
 square root of the bin count and crosses the threshold sooner at high C/N₀
 and later in noise — the detector self-paces — while a drift-only asymmetry
@@ -271,9 +301,9 @@ function _detect_bit_edge_cfar(
     # `confidence` is the (1 - false-sync probability) target, Bonferroni-
     # split over the `blocks_per_bit - 1` competing phases. Clamp the quantile
     # argument to the open interval (0, 1): otherwise `confidence = 1.0` (or
-    # the rounding of `1 - tiny/(blocks_per_bit-1)` up to 1.0) yields
-    # `Φ⁻¹(1) = NaN`, and the `z_score < threshold` gate would silently pass
-    # (NaN comparisons are false), turning "maximum confidence" into "lock
+    # the rounding of `1 - tiny/(blocks_per_bit-1)` up to 1.0) yields a
+    # `quantile(1) = NaN`, and the `z_score < threshold` gate would silently
+    # pass (NaN comparisons are false), turning "maximum confidence" into "lock
     # immediately".
     false_alarm_probability = 1 - confidence
     quantile_argument = clamp(
@@ -281,7 +311,19 @@ function _detect_bit_edge_cfar(
         nextfloat(0.0),
         prevfloat(1.0),
     )
-    z_threshold = _norm_quantile(quantile_argument)
+    # `standard_error` divides by a variance ESTIMATED from `peak_bin_count`
+    # bins, so a normal threshold is badly overconfident at 1-2 bins (its ~3.9
+    # value is a ~10% per-phase false alarm at 1 d.o.f., not the intended 1e-4),
+    # which let a variance-collapsed 2-bin fluctuation lock ~8 blocks off the true
+    # edge on a fast reacquisition — silent because <10 blocks still decodes by
+    # majority. Apply the Student-t quantile at a nominal `peak_bin_count - 1`
+    # d.o.f. as a small-sample penalty (NOT because `z_score` is exactly Student-t:
+    # the per-bin energies are χ² and the phases correlated, so the nominal d.o.f.
+    # and false-alarm rate are approximate — see `_t_quantile`). It demands z ≈ 6000
+    # at 1 d.o.f. and relaxes to the normal threshold as bins accumulate, forcing
+    # enough integration before a lock (which also lets the carrier settle) while
+    # leaving mature clean locks (many bins ⇒ t ≈ normal) unchanged.
+    z_threshold = _t_quantile(quantile_argument, peak_bin_count - 1)
     z_score < z_threshold && return SyncResult(false, 0, Int8(0))
 
     # Fire only at the winning phase's own bit boundary so the upcoming

--- a/test/bit_buffer.jl
+++ b/test/bit_buffer.jl
@@ -11,7 +11,7 @@ using Tracking:
     has_bit_or_secondary_code_been_found,
     SyncResult,
     PhaseAccumulators,
-    _norm_quantile,
+    _t_quantile,
     _detect_bit_edge_cfar,
     _seed_phase_accumulators!,
     _update_phase_accumulators!
@@ -23,15 +23,28 @@ using Tracking:
     @test r.polarity == 0
 end
 
-@testset "_norm_quantile" begin
-    # Symmetry and a few tabulated standard-normal quantiles.
-    @test _norm_quantile(0.5) ≈ 0.0 atol = 1e-9
-    @test _norm_quantile(0.975) ≈ 1.959963985 atol = 1e-6
-    @test _norm_quantile(0.025) ≈ -1.959963985 atol = 1e-6
-    @test _norm_quantile(0.999) ≈ 3.090232306 atol = 1e-6
-    @test _norm_quantile(1 - 0.999) ≈ -3.090232306 atol = 1e-6
-    # Monotonically increasing.
-    @test _norm_quantile(0.1) < _norm_quantile(0.2) < _norm_quantile(0.8)
+@testset "_t_quantile" begin
+    # Median is exactly 0 — and, as a regression guard, `probability == 0.5`
+    # must return directly rather than recurse into `_t_quantile(1 - 0.5, dof)`
+    # (which previously self-recursed forever → stack overflow).
+    @test _t_quantile(0.5, 1) === 0.0
+    @test _t_quantile(0.5, 30) === 0.0
+    # dof = 1 is the standard Cauchy, quantile(p) = tan(π(p − 0.5)).
+    @test _t_quantile(0.75, 1) ≈ 1.0 atol = 1e-6            # tan(π/4)
+    @test _t_quantile(0.9, 1) ≈ tan(pi * 0.4) atol = 1e-6   # ≈ 3.0777
+    # Symmetric about 0.
+    @test _t_quantile(0.25, 1) ≈ -_t_quantile(0.75, 1) atol = 1e-9
+    @test _t_quantile(0.001, 7) ≈ -_t_quantile(0.999, 7) atol = 1e-6
+    # Heavier tails than the normal, converging to it as dof → ∞ (no cutoff).
+    p = 1 - (1 - 0.999) / (20 - 1)   # the detector's Bonferroni-split argument, L1CA
+    normal_limit = 3.87813           # tabulated Φ⁻¹(p), the dof → ∞ limit
+    @test _t_quantile(p, 1) > _t_quantile(p, 10) > _t_quantile(p, 1000) > normal_limit
+    @test _t_quantile(p, 100_000) ≈ normal_limit atol = 1e-3
+    # The behaviour the fix relies on: at 1 d.o.f. (2 bins) the threshold is huge,
+    # so the observed z ≈ 40 reacquisition fluctuation is rejected; by ~70 bins a
+    # clean z ≈ 3.9 clears it.
+    @test _t_quantile(p, 1) > 1000
+    @test _t_quantile(p, 69) < 4.2
 end
 
 const L1CA_BLOCKS_PER_BIT = 20  # primary-code blocks per L1 C/A navigation bit
@@ -108,7 +121,7 @@ end
         # lower one, and always at a true bit boundary.
         function lock_block(confidence, seed)
             rng = MersenneTwister(seed)
-            clean = _bitstream([bit % 2 for bit = 0:9]; amp = 8.0)
+            clean = _bitstream([bit % 2 for bit = 0:39]; amp = 8.0)
             noisy = ComplexF64[prompt + complex(randn(rng), randn(rng)) for prompt in clean]
             _detect_over(noisy, confidence)
         end
@@ -132,7 +145,7 @@ end
         # NaN-threshold path did. (A noiseless edge has z = Inf and still
         # locks — genuine certainty, exercised above.)
         rng = MersenneTwister(7)
-        clean = _bitstream([bit % 2 for bit = 0:9]; amp = 3.0)
+        clean = _bitstream([bit % 2 for bit = 0:39]; amp = 3.0)
         noisy = ComplexF64[prompt + complex(randn(rng), randn(rng)) for prompt in clean]
         low_confidence_lock = _detect_over(noisy, 0.99)
         high_confidence_lock = _detect_over(noisy, 1.0)

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -30,12 +30,15 @@ using Tracking:
     code_frequency = get_code_frequency(gpsl1)
     carrier_doppler = 0.0Hz
 
-    # Run the same bit stream at both lock polarities: the bit-edge detector
-    # locks at block 40, where the newest 20 buffered blocks carry the second
-    # data bit — `1, 0, …` yields a negative-polarity lock, `0, 1, …` a
-    # positive one. The bits recovered from the pre-sync buffer and the bits
-    # decoded after sync must be consistent: equal to the transmitted bits up
-    # to a single *global* inversion across the whole stream (issue #127).
+    # Run the same bit stream at both lock polarities. Under the Student-t
+    # small-sample threshold this near-noiseless Float64 signal locks at block
+    # 60 (the third data-bit boundary): a 2-bin lock needs an exactly-infinite
+    # z-score (zero bin-to-bin variance), and the floating-point residual here
+    # yields a large-but-finite z that clears the threshold only once dof grows
+    # to a third bin. It still fires at a true bit boundary (the #124 property —
+    # never one block early). The bits recovered from the pre-sync buffer and
+    # the bits decoded after sync must be consistent: equal to the transmitted
+    # bits up to a single *global* inversion across the whole stream (issue #127).
     for data_bits in ([1, 0, 1, 1, 0, 0, 1], [0, 1, 0, 0, 1, 1, 0])
         track_state = TrackState(gpsl1, [TrackedSat(gpsl1, 1, 0, carrier_doppler)];)
 
@@ -59,10 +62,11 @@ using Tracking:
                     code_phase,
                 )
             track_state = track(signal, track_state, sampling_frequency)
-            @test has_bit_or_secondary_code_been_found(track_state) == (index >= 40)
-            # Sync at block 40 recovers the 2 buffered bits; afterwards one
-            # bit completes every 20 blocks.
-            expected_num_bits = index == 40 ? 2 : (index > 40 && index % 20 == 0 ? 1 : 0)
+            @test has_bit_or_secondary_code_been_found(track_state) == (index >= 60)
+            # Sync at block 60 recovers the 3 buffered bits (the UInt64 sign
+            # window still holds all 60); afterwards one bit completes every 20
+            # blocks.
+            expected_num_bits = index == 60 ? 3 : (index > 60 && index % 20 == 0 ? 1 : 0)
             num_bits = get_num_bits(track_state)
             @test num_bits == expected_num_bits
             bits_word = get_bits(track_state)
@@ -90,9 +94,9 @@ end
 # Multi-block coherent integration: bits keep flowing with `preferred > 1`.
 #
 # Until bit sync the integration length is clamped to one code block, so the
-# preferred length can be set from the start. After sync at block 40 (one
-# full bit of each polarity plus the transition) each integration spans 4
-# code blocks, five integrations form a bit, and a hard + soft bit must be
+# preferred length can be set from the start. After sync at block 60 each
+# integration spans 4 code blocks, five integrations form a bit, and a hard +
+# soft bit must be
 # emitted at every 20-block bit boundary — with `preferred = 3` (which does
 # not divide the 20 blocks per bit and is therefore rejected since issue
 # #128) the integrations would straddle bit boundaries and bit emission
@@ -133,10 +137,11 @@ end
         )
         multi_state = track(signal, multi_state, sampling_frequency)
         single_state = track(signal, single_state, sampling_frequency)
-        @test has_bit_or_secondary_code_been_found(multi_state) == (index >= 40)
-        # Two bits are recovered from the buffered history at sync (block 40);
+        @test has_bit_or_secondary_code_been_found(multi_state) == (index >= 60)
+        # Three bits are recovered from the buffered history at sync (block 60,
+        # the near-noiseless lock latency under the t-quantile threshold);
         # afterwards exactly one bit must appear at every 20-block boundary.
-        expected_num_bits = index == 40 ? 2 : (index > 40 && index % 20 == 0 ? 1 : 0)
+        expected_num_bits = index == 60 ? 3 : (index > 60 && index % 20 == 0 ? 1 : 0)
         @test get_num_bits(multi_state) == expected_num_bits
         @test get_num_bits(single_state) == expected_num_bits
         num_bits = get_num_bits(multi_state)
@@ -149,8 +154,8 @@ end
     end
 
     # All five data bits arrive and match the single-block reference bit for
-    # bit. The two bits replayed from the buffered history at sync alternate,
-    # and so do the three streamed post-sync bits; the relative polarity
+    # bit. The three bits replayed from the buffered history at sync alternate,
+    # and so do the two streamed post-sync bits; the relative polarity
     # between the replayed and the streamed portion is a property of the
     # bit-sync polarity convention and not asserted here.
     @test length(multi_bits) == 5
@@ -161,10 +166,11 @@ end
 
     # The soft bits agree with the reference in sign; post-sync each bit is
     # the sum of five 4-block prompts (magnitude ~5) instead of twenty
-    # single-block prompts.
+    # single-block prompts. Sync at block 60 replays three pre-sync bits, so the
+    # streamed post-sync bits start at index 4.
     @test sign.(multi_soft) == sign.(single_soft)
-    @test all(x -> abs(x) ≈ 5, multi_soft[3:end])
-    @test all(x -> abs(x) ≈ 20, single_soft[3:end])
+    @test all(x -> abs(x) ≈ 5, multi_soft[4:end])
+    @test all(x -> abs(x) ≈ 20, single_soft[4:end])
 end
 
 # GPS L5I secondary-code (NH10) sync and phase recovery.


### PR DESCRIPTION
## Summary

The GPS L1 C/A soft-decision CFAR bit-edge detector (added in #124) can declare
a **confident lock on as few as 2 bins** during a fast/marginal (re)acquisition,
landing a few code-periods off the true bit boundary. Because a lock < 10 blocks
off still decodes the correct nav bits (12-vs-8 majority), it passes every sanity
check (TOW, parity, health, IODC) yet leaves the ranging code-phase anchored to
the wrong boundary — a **constant integer-millisecond pseudorange bias** that
persists until the satellite loses lock.

This PR thresholds the detector with a **Student-t quantile at a nominal
`peak_bin_count − 1` d.o.f.**, used as a *small-sample penalty* that forces enough
integration before a lock.

## Root cause

A lock is accepted when `z = energy_gap / standard_error ≥ Φ⁻¹(…)`, but
`standard_error` divides by a variance **estimated** over `peak_bin_count` bins.
Treating that estimate as exact (the normal quantile) is badly overconfident at
the 2-bin minimum:

- the 2-sample variance can collapse (`sum_sq_dev → 0 ⇒ SE → 0 ⇒ z → ∞`), and
- the normal threshold `≈ 3.9` is a **~8 % per-phase** false alarm at 1 nominal
  d.o.f., not the intended `~1e-4`.

## Observed on real data (TEX-CUP `ntlab.bin`)

GPS PRN 9 reacquired and its bit-sync fired at **~2.6 bins with z ≈ 40** (vs the
clean acquisitions at ~70/160 bits, z ≈ 3.9), ~8 code-periods off the true edge:

| | before | after |
|---|---|---|
| PRN 9 pseudorange bias | +2,398,370 m (8 ms) | — (no false lock) |
| worst residual over the full 4957 s run | 785,699 m | **78.9 m** |
| worst horizontal PVT error | 552 km | **3.6 km** (rover travel) |

The bias survived ~24 s until PRN 9 next dropped lock.

## The fix

- Threshold with `_t_quantile(quantile_argument, peak_bin_count − 1)` — an exact
  Student-t quantile via `SpecialFunctions.beta_inc_inv` (returning the median
  directly and the lower tail by symmetry, which also avoids a `1 − 0.5`
  self-recursion). It demands `z ≈ 6000` at 1 d.o.f. and relaxes to the normal
  quantile as bins accumulate (**no cutoff**), so mature clean locks are unchanged.
- **It is documented honestly as a heuristic penalty, not an exact distribution.**
  The per-bin values are χ² (non-central) energies, not Gaussian, and the competing
  phases share blocks (correlated), so `peak_bin_count − 1` is a *nominal* d.o.f.
  and the realised false-alarm rate is only approximately the nominal one.
- Removes the now-unused `_norm_quantile` and its sole-purpose `erfinv` import.

## Scope

GPS L1 C/A only — the sole signal with `uses_soft_bit_edge_detection`
(multi-block bit, no secondary code). The secondary-code and immediate-lock
detectors are untouched. The change can only ever *raise* the threshold, so a
clean lock is never advanced or corrupted, only (slightly) delayed.

## Validation

- All visible GPS L1 C/A satellites still lock, self-pacing by C/N₀ (~8–149 bits;
  PRN 9 clean lock 74 vs 70 bits).
- Full ~4957 s TEX-CUP recording (44,792 PVT epochs): **zero gross outliers**.
- **Full `Tracking` test suite passes**, incl. Aqua and the format check.

## Tests

- New `_t_quantile` testset (median/recursion regression, dof=1 Cauchy values,
  symmetry, tail monotonicity, convergence to a tabulated normal limit);
  `_norm_quantile` testset dropped.
- Lock-latency expectations re-baselined to the higher threshold: the two
  `bit_buffer` CFAR-latency streams are lengthened, and the two
  `bit_integration_test` L1 C/A testsets now expect the near-noiseless signal to
  lock at block 60 (3 bins) rather than 40 (2 bins) — still a true bit boundary
  (the #124 "never one block early" property), just one bit later.

## Notes / possible follow-ups (out of scope)

Complementary hardening worth considering separately: a hard minimum-bins floor,
and PVT-level RAIM/residual screening (which would reject a *k* × 300 km outlier
regardless of the tracking cause).

Follow-up to #124.
