### PR TITLE
perf(bit-buffer): allocation-free Student-t quantile in the CFAR bit-edge threshold

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -926,6 +926,14 @@ end
 # leak, `20 blk` allocates ~10× the per-iteration bytes of `2 blk`; without it,
 # both sit at the same one-time-seed floor.
 #
+# The presync lengths run out to 200 blocks because the CFAR detector scores
+# nothing — and so never evaluates its Student-t threshold — until
+# `num_blocks ≥ 2 * blocks_per_bit` = 40: a leak in the scoring path is
+# invisible at 2 and 20 blocks. An allocating `beta_inc_inv` in that threshold
+# is exactly how one slipped through once. `test/track_in_place.jl`'s pre-sync
+# guard makes the same point as a hard assertion; see the comment there for the
+# `dof` ranges each length sweeps.
+#
 # Two states per length: `presync` (bit not yet found — exercises the
 # per-code-block bit-edge search every iteration, the path that regressed) and
 # `synced` (`bit_buffer.found = true` — the post-sync steady state). To measure
@@ -939,7 +947,7 @@ end
 if _HAS_TRACKED_SIGNAL && isdefined(Tracking, :track!)
     let sfreq = 5e6Hz, gpsl1 = GPSL1CA()
         samples_per_block = 5000               # 1 ms GPS L1CA code period @ 5 MHz
-        for n_blocks in (2, 20)
+        for n_blocks in (2, 20, 200)
             nsamp = samples_per_block * n_blocks
             sig = rand(ComplexF32, nsamp)
             dc = _make_cpu_dc(sfreq)
@@ -957,6 +965,9 @@ if _HAS_TRACKED_SIGNAL && isdefined(Tracking, :track!)
                 ),
                 evals = 1,
             )
+            # The synced rows stay short: post-sync there is no per-block search
+            # to leak from, so the extra length would only cost runtime.
+            n_blocks == 200 && continue
             SUITE["track"]["8. L1CA synced $(n_blocks) blk – track!"] = @benchmarkable(
                 Tracking.track!($sig, ts, $sfreq; downconvert_and_correlator = $dc),
                 setup = (

--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -6,7 +6,7 @@ using FastSinCos
 using GNSSSignals
 using SIMD
 using SinCosLUT
-using SpecialFunctions: beta_inc_inv
+using SpecialFunctions: erfinv
 using StaticArrays
 using TrackingLoopFilters
 using Dictionaries

--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -25,6 +25,17 @@ end
 """
 $(SIGNATURES)
 
+Standard-normal quantile (inverse CDF) `Φ⁻¹(probability)` for
+`probability ∈ (0, 1)`, as `√2 · erfinv(2·probability − 1)` (`erfinv` from
+SpecialFunctions.jl). Used by [`_t_quantile`](@ref) as the `dof → ∞` anchor
+that its tail expansion corrects. Returns `±Inf` at `probability = 1` / `0`;
+callers keep the argument in the open interval.
+"""
+@inline _norm_quantile(probability::Float64) = sqrt(2.0) * erfinv(2 * probability - 1)
+
+"""
+$(SIGNATURES)
+
 `probability`-quantile of a Student-t distribution with `dof` degrees of
 freedom, i.e. `t` such that `P(T ≤ t) = probability`. Used by
 [`_detect_bit_edge_cfar`](@ref) in place of a standard-normal quantile as a
@@ -45,18 +56,77 @@ distribution is neither normal nor Student-t and the realised false-alarm rate
 is only approximately the nominal one. It is used as a conservative,
 integration-forcing penalty, not an exact calibration.
 
-The upper tail (`probability > 0.5`) uses the regularized incomplete beta
-inverse: for `t > 0`, `P(T > t) = ½·Iₓ(dof/2, ½)` with `x = dof/(dof + t²)`, so
-`x = beta_inc_inv(dof/2, ½, 2·(1 − probability))` and `t = √(dof·(1 − x)/x)`.
-The lower tail is reflected by symmetry, and the median `t(0.5) = 0` is returned
-directly — which also avoids a `1 − 0.5` self-recursion. The sole caller passes
-`probability > 0.5` (and `dof ≥ 1`, since `peak_bin_count ≥ 2` at the call site).
+# Implementation
+
+Hill's algorithm (Hill, G. W. (1970), *Algorithm 396: Student's t-quantiles*,
+Comm. ACM 13(10), 619–620), driven by the two-tailed probability
+`2·(1 − probability)`: `dof = 1` (Cauchy) and `dof = 2` invert in elementary
+functions and are returned exactly, and above that a series in either the
+normal deviate [`_norm_quantile`](@ref) (tail branch) or the two-tailed
+probability itself (central branch) is used. The lower tail is reflected by
+symmetry, and the median `t(0.5) = 0` is returned directly — which also avoids
+a `1 − 0.5` self-recursion. The sole caller passes `probability > 0.5` (and
+`dof ≥ 1`, since `peak_bin_count ≥ 2` at the call site).
+
+Hill's series is accurate to ≲2e-4 *relative* — worst around `dof ≈ 3–10`,
+better than 1e-5 by `dof ≈ 50` — which is orders of magnitude finer than the
+nominal-d.o.f. modelling error above, and far too fine to move which block the
+detector locks on. That error buys both of the properties this call site needs,
+against an exact inversion through `SpecialFunctions.beta_inc_inv`:
+
+  - **Allocation-free.** `beta_inc_inv` allocates internal scratch arrays
+    (`zeros(22)` / `zeros(31)` inside the incomplete-beta asymptotic
+    expansions) over part of the `dof` range the detector sweeps. This
+    function runs once per primary-code block for every unsynced satellite, so
+    an allocation here makes `track!` allocate in proportion to the signal
+    length across the whole acquisition — the regression
+    `test/track_in_place.jl`'s pre-sync guard exists to catch.
+  - **Cheap.** `beta_inc_inv` is an iterative Newton solve that evaluates a
+    full regularized incomplete beta per step (~0.2–2.8 µs here); Hill's is a
+    single closed-form pass (~3–78 ns), 10–170× faster over the whole `dof`
+    range and never slower. End to end that is a pre-sync `track!` at 1.7× (200
+    blocks) to 1.3× (900 blocks).
 """
-@inline function _t_quantile(probability::Float64, dof::Real)
+function _t_quantile(probability::Float64, dof::Real)
     probability == 0.5 && return 0.0
     probability < 0.5 && return -_t_quantile(1 - probability, dof)
-    x = first(beta_inc_inv(dof / 2, 0.5, 2 * (1 - probability)))
-    sqrt(dof * (1 - x) / x)
+    # Hill's algorithm is written in terms of the two-tailed probability.
+    two_tailed_probability = 2 * (1 - probability)
+    # `dof = 1` is the standard Cauchy, `quantile(p) = cot(π·two_tailed/2)`
+    # (the cotangent form keeps its accuracy in the far tail, where the
+    # equivalent `tan(π(probability − ½))` cancels). At `dof = 2` the CDF
+    # `½·(1 + t/√(2 + t²))` inverts in closed form. Both are exact, and both
+    # are where the series below is weakest.
+    dof == 1 &&
+        return cos(two_tailed_probability * pi / 2) / sin(two_tailed_probability * pi / 2)
+    dof == 2 && return sqrt(2 / (two_tailed_probability * (2 - two_tailed_probability)) - 2)
+    a = 1 / (dof - 0.5)
+    b = 48 / a^2
+    c = ((20700 * a / b - 98) * a - 16) * a + 96.36
+    d = ((94.5 / (b + c) - 3) / b + 1) * sqrt(a * pi / 2) * dof
+    y = (d * two_tailed_probability)^(2 / dof)
+    if y > 0.05 + a
+        # Tail branch: correct the normal deviate (the `dof → ∞` limit) by an
+        # asymptotic series in `1/dof`, so the result relaxes onto `Φ⁻¹` as the
+        # bin count grows — no cutoff, mature locks keep the normal threshold.
+        x = _norm_quantile(probability)
+        y = x^2
+        dof < 5 && (c += 0.3 * (dof - 4.5) * (x + 0.6))
+        c = (((0.05 * d * x - 5) * x - 7) * x - 2) * x + b + c
+        y = (((((0.4 * y + 6.3) * y + 36) * y + 94.5) / c - y - 3) / b + 1) * x
+        y = expm1(a * y^2)
+    else
+        # Central branch: a series in the two-tailed probability itself, used
+        # where the normal deviate is a poor starting point.
+        y =
+            (
+                (
+                    1 / (((dof + 6) / (dof * y) - 0.089 * d - 0.822) * (dof + 2) * 3) +
+                    0.5 / (dof + 4)
+                ) * y - 1
+            ) * (dof + 1) / (dof + 2) + 1 / y
+    end
+    sqrt(dof * y)
 end
 
 """

--- a/test/bit_buffer.jl
+++ b/test/bit_buffer.jl
@@ -11,6 +11,7 @@ using Tracking:
     has_bit_or_secondary_code_been_found,
     SyncResult,
     PhaseAccumulators,
+    _norm_quantile,
     _t_quantile,
     _detect_bit_edge_cfar,
     _seed_phase_accumulators!,
@@ -22,6 +23,23 @@ using Tracking:
     @test r.phase == 0
     @test r.polarity == 0
 end
+
+@testset "_norm_quantile" begin
+    @test _norm_quantile(0.5) == 0.0
+    @test _norm_quantile(0.975) ≈ 1.959964 atol = 1e-6     # tabulated Φ⁻¹
+    @test _norm_quantile(0.999) ≈ 3.090232 atol = 1e-6
+    @test _norm_quantile(0.025) ≈ -_norm_quantile(0.975) atol = 1e-12
+    # The open-interval contract: `_t_quantile` clamps before calling in, so
+    # the ±Inf endpoints are documented behaviour rather than an error.
+    @test _norm_quantile(1.0) == Inf
+    @test _norm_quantile(0.0) == -Inf
+end
+
+# `@allocated` at module scope picks up boxing from untyped global lookups, so
+# the measurement goes through a typed function — the same reason
+# `test/track_in_place.jl` measures inside helpers.
+_measure_t_quantile_alloc(probability::Float64, dof::Int) =
+    (_t_quantile(probability, dof); @allocated _t_quantile(probability, dof))
 
 @testset "_t_quantile" begin
     # Median is exactly 0 — and, as a regression guard, `probability == 0.5`
@@ -35,6 +53,22 @@ end
     # Symmetric about 0.
     @test _t_quantile(0.25, 1) ≈ -_t_quantile(0.75, 1) atol = 1e-9
     @test _t_quantile(0.001, 7) ≈ -_t_quantile(0.999, 7) atol = 1e-6
+    # Accuracy against standard Student-t tables. `dof = 1` (Cauchy) and
+    # `dof = 2` are closed forms and land on the exact value; above that Hill's
+    # series carries a small relative error (worst ~2e-4 around dof 3–10),
+    # which is still orders of magnitude finer than the nominal-d.o.f.
+    # modelling error the threshold is built on — and far too fine to move
+    # which block the detector locks on.
+    # (The two closed forms are pinned at the precision of the table literal
+    # itself, 7 significant digits — they agree with the exact value to ~1e-16.)
+    @test _t_quantile(0.975, 1) ≈ 12.706205 rtol = 1e-7
+    @test _t_quantile(0.975, 2) ≈ 4.302653 rtol = 1e-7
+    @test _t_quantile(0.995, 3) ≈ 5.840909 rtol = 1e-4
+    @test _t_quantile(0.95, 5) ≈ 2.015048 rtol = 1e-4
+    @test _t_quantile(0.975, 10) ≈ 2.228139 rtol = 1e-4
+    @test _t_quantile(0.999, 20) ≈ 3.551808 rtol = 1e-4
+    @test _t_quantile(0.975, 30) ≈ 2.042272 rtol = 1e-4
+    @test _t_quantile(0.975, 120) ≈ 1.979930 rtol = 1e-4
     # Heavier tails than the normal, converging to it as dof → ∞ (no cutoff).
     p = 1 - (1 - 0.999) / (20 - 1)   # the detector's Bonferroni-split argument, L1CA
     normal_limit = 3.87813           # tabulated Φ⁻¹(p), the dof → ∞ limit
@@ -45,6 +79,23 @@ end
     # clean z ≈ 3.9 clears it.
     @test _t_quantile(p, 1) > 1000
     @test _t_quantile(p, 69) < 4.2
+    # Monotone in dof over the whole range the detector sweeps — no branch seam
+    # between the closed forms (dof ≤ 2) and Hill's two series.
+    @test issorted([_t_quantile(p, dof) for dof = 1:400]; rev = true)
+    # Allocation-free at every dof. The detector calls this once per
+    # primary-code block for every unsynced satellite, so an allocating
+    # quantile makes `track!` allocate in proportion to the signal length
+    # (the exact `SpecialFunctions.beta_inc_inv` inversion did, via internal
+    # `zeros(31)` scratch, from ~12 d.o.f. upwards). `test/track_in_place.jl`
+    # guards the same property end-to-end; this pins it per dof, where the
+    # allocating stretches of the range are unmissable.
+    @test all(_measure_t_quantile_alloc(p, dof) == 0 for dof = 1:400)
+    @test _measure_t_quantile_alloc(0.25, 7) == 0    # the reflected branch too
+    # The detector clamps its argument to the open interval; the endpoint must
+    # still produce a finite (huge) threshold rather than NaN, or the
+    # `z_score < threshold` gate would silently pass.
+    @test isfinite(_t_quantile(prevfloat(1.0), 1))
+    @test isfinite(_t_quantile(prevfloat(1.0), 40))
 end
 
 const L1CA_BLOCKS_PER_BIT = 20  # primary-code blocks per L1 C/A navigation bit

--- a/test/track_in_place.jl
+++ b/test/track_in_place.jl
@@ -171,6 +171,24 @@ end
 # would have caught it. Single-threaded backend so the assertion is a clean
 # `== 0` (the threaded backend keeps a small Polyester residual — see above).
 #
+# The chunk lengths have to straddle the detector's own arming point, not just
+# `_buffer_find_bit`'s. `_detect_bit_edge_cfar` returns before scoring anything
+# while `num_blocks < 2 * blocks_per_bit` (40 for L1 C/A), so at 2 and 20 blocks
+# the statistic — and with it the threshold quantile — is never reached: a leak
+# in the *scoring* path is invisible there. That is exactly how an allocating
+# `SpecialFunctions.beta_inc_inv` in the Student-t threshold shipped past this
+# guard once. It allocated internal `zeros(31)` scratch inside the
+# incomplete-beta asymptotic expansions, ~600 B per code block — but only over
+# parts of the `dof = peak_bin_count - 1` range it was called at: around
+# `dof = 11`, then continuously from `dof ≈ 42` up.
+#
+# The measured call is the *second* one, so `measure_track_alloc(n)` sweeps
+# blocks `n+1 … 2n`, i.e. `dof ≈ n/20 … n/10`. The two lengths below are picked
+# to land in those two stretches: 200 blocks sweeps `dof ≈ 9…19` (catching the
+# `dof = 11` spike, ~8 kB) and 900 blocks sweeps `dof ≈ 44…89` (catching the
+# whole upper stretch, ~3.5 MB). Both were verified to fail against the
+# allocating implementation. They cost ~5 ms / ~40 ms.
+#
 # Gated to Julia ≥ 1.11. On 1.10 the compiler leaves a per-block allocation in
 # the pre-sync soft-bit path (~770 B/block — measured 2144 B at 2 blocks vs
 # 15968 B at 20; unrelated to the box, which was ~80 B/block) that 1.11+ elides,
@@ -200,6 +218,10 @@ if VERSION >= v"1.11"
         end
         @test measure_track_alloc(2) == 0
         @test measure_track_alloc(20) == 0
+        # Past `2 * blocks_per_bit`, so the CFAR statistic and its Student-t
+        # threshold are actually scored on every block (see above).
+        @test measure_track_alloc(200) == 0
+        @test measure_track_alloc(900) == 0
     end
 end
 


### PR DESCRIPTION
## Summary

#208 made the GPS L1 C/A soft bit-edge detector threshold on a Student-t
quantile, inverting the CDF through `SpecialFunctions.beta_inc_inv`. That
routine allocates, and the detector calls it **once per primary-code block for
every unsynced satellite** — so `track!` went back to allocating in proportion
to signal length across the whole acquisition.

This PR keeps the fix and its behaviour exactly, and makes the quantile
closed-form: allocation-free at every `dof`, and 10–170× cheaper.

## Root cause

`beta_inc_inv` is an iterative Newton solve, and the incomplete-beta asymptotic
expansions it evaluates per step build `zeros(22)` / `zeros(31)` scratch arrays —
~600 B per call. It only hits over part of the `dof = peak_bin_count − 1` range
the detector sweeps (a spike around `dof = 11`, then continuously from
`dof ≈ 42` up), which is why it looked clean locally.

Measured on a pre-sync `track!` (noise input, so the detector never locks and the
search runs every block):

| pre-sync `track!` | before | after |
|---|---|---|
| 200 code blocks | 12,768 B | **0 B** |
| 900 code blocks | 3,479,584 B | **0 B** |

This is the same "allocates per completed integration, scales with signal
length" symptom as #198 — fixed in a892769, guarded by 3dbf778.

### Why the existing guard missed it

`test/track_in_place.jl`'s pre-sync guard measures 2 and 20 blocks.
`_detect_bit_edge_cfar` returns before scoring anything while
`num_blocks < 2 * blocks_per_bit` (40 for L1 C/A), so at those lengths the
statistic — and with it the threshold quantile — is never evaluated. The guard
was watching `_buffer_find_bit`'s arming point, not the detector's.

## The fix

Hill's algorithm (Hill, G. W. (1970), *Algorithm 396: Student's t-quantiles*,
Comm. ACM 13(10), 619–620): closed form, allocation-free at every `dof`, exact at
`dof = 1` (Cauchy) and `dof = 2`, and above that a series anchored on the normal
deviate — so `_norm_quantile` and its `erfinv` import return, now with a caller
that genuinely needs them.

**Detector semantics are unchanged**: still a Student-t small-sample penalty at a
nominal `peak_bin_count − 1` d.o.f., still steep as `dof → 1`, still relaxing onto
the normal quantile as `dof → ∞` with no cutoff.

**Accuracy.** Hill's series carries ≲2e-4 relative error (worst around
`dof ≈ 3–10`, better than 1e-5 by `dof ≈ 50`) — orders of magnitude finer than
the nominal-d.o.f. modelling error the threshold is built on, which #208
documents as only approximately calibrated. Far too fine to move a lock block:
**every #208 lock-latency expectation still holds unchanged** (block 60 for the
near-noiseless L1 C/A signal, both `bit_buffer` CFAR-latency streams).

**Speed.** It is also strictly cheaper — a single closed-form pass instead of a
Newton loop with a full regularized incomplete beta per step:

| `dof` | `beta_inc_inv` | Hill | speedup |
|---:|---:|---:|---:|
| 1 | 984 ns | 5.7 ns | 173× |
| 3 | 843 ns | 32 ns | 26× |
| 11 | 2810 ns (608 B) | 52 ns | 54× |
| 43 | 1181 ns (4256 B) | 52 ns | 23× |
| 100 | 827 ns (3648 B) | 78 ns | 11× |
| 2000 | 1230 ns (3648 B) | 78 ns | 16× |

End to end: pre-sync `track!` at 200 blocks 0.856 → 0.499 ms (1.7×), at 900
blocks 4.133 → 3.187 ms (1.3×). Never slower at any `dof`.

## Guards

- **`test/track_in_place.jl`** — the pre-sync guard now also measures 200 and 900
  blocks. The measured call is the second one, so `measure_track_alloc(n)` sweeps
  blocks `n+1…2n` (`dof ≈ n/20…n/10`); the two lengths land in both stretches
  where the inversion allocated (`dof ≈ 9–19`, catching the `dof = 11` spike at
  ~8 kB; `dof ≈ 44–89`, catching the upper stretch at ~3.5 MB). Both were
  verified to **fail** against the allocating implementation and pass after.
  Cost ~5 ms / ~40 ms.
- **`test/bit_buffer.jl`** — `_norm_quantile` testset restored; `_t_quantile`
  extended with accuracy against standard t-tables, monotonicity in `dof` across
  the detector's sweep (no seam between the closed forms and Hill's two series),
  the clamped-endpoint finiteness contract, and a per-`dof` allocation sweep over
  `1:400`.
- **`benchmark/benchmarks.jl`** — presync rows extended to 200 blocks so the
  base-vs-head memory table has the same reach. Synced rows stay short; there is
  no per-code-block search post-sync.

## Validation

Full `Tracking` test suite passes (208 testsets), including Aqua and the
JuliaFormatter 2.8.5 check. No test expectation from #208 needed changing.

## Notes

The trade here is exactness for allocation-freedom and speed. Caching the
threshold instead was considered and rejected: `peak_bin_count` changes once per
bin, so caching only cuts the call frequency ~20×, never to zero.

If bit-exact agreement with `beta_inc_inv` is preferred over Hill's ≲2e-4, the
alternative is Hill as an initial estimate plus Newton polish against a
continued-fraction incomplete beta — allocation-free too, but ~30 more lines and
slower.

Follow-up to #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
