### PR TITLE
feat(track): soft-decision CFAR secondary-code detection

### DIFF
--- a/docs/src/bit_sync.md
+++ b/docs/src/bit_sync.md
@@ -48,46 +48,52 @@ current_code_wrap
 
 Each per-signal `BitBuffer` runs an `detect_bit_or_secondary_code_sync` detector against the running buffer of primary-code-block signs. The detector returns a `SyncResult` containing whether sync was found, the secondary-code phase (chip offset within the secondary code, used for code-phase seeding — see below), and the locked polarity (±1).
 
-Per-signal contract. *Min-to-fire* is the smallest `num_code_blocks` the detector accepts before it tries a match (smaller windows return `SyncResult(false, …)` without searching). *Buffer width* is the sliding window's container type, picked by `get_code_block_buffer_type(signal)`. The GPS L1 C/A bit-edge detector needs `2 × symbol` (40 blocks) so a full bit can slide past either polarity; the secondary-code signals (GPS L5I, GPS L1C-P) only need **one** full secondary period, because their rotation search (`_secondary_code_search`) matches at any alignment and recovers the phase — so they lock in `1 ×` the period worst case, not `2 ×`.
+There are three detector families:
 
-| Signal | Min-to-fire | Buffer width | Template | Tolerance | Phase | Blocks per symbol |
-|--------|-------------|--------------|----------|-----------|-------|---------------------|
-| GPS L1 C/A | 40 blocks | `UInt64` (40 bits used) | bit-edge `0xfffff` (20+20) | 1 error (2.5 %) | 0 | 20 |
-| Galileo E1B | n/a | `UInt8` (unused) | trivial (1 block per symbol) | n/a | 0 | 1 |
-| GPS L5I | 10 blocks | `UInt32` (low 10 bits used) | NH10 `0x035` (rotation search) | 0 errors (2.5 % → exact match) | `0..9` | 10 (secondary code) |
-| GPS L5Q | 20 blocks | `UInt32` (low 20 bits used) | NH20 (rotation search) | 0 errors (2.5 % → exact match) | `0..19` | 20 (secondary code, pilot) |
-| GPS L1C-D | n/a | `UInt8` (unused) | trivial (1 block per symbol) | n/a | 0 | 1 |
-| GPS L1C-P | 1800 blocks | `UInt1800` (exact width) | per-PRN overlay (rotation search) | 45 errors (2.5 %) | `0..1799` | n/a (pilot) |
-| GPS L2CM | n/a | `UInt8` (unused) | trivial (1 block per symbol) | n/a | 0 | 1 |
-| GPS L2CL | never fires | `UInt8` (unused) | none (dataless pilot, no secondary code) | n/a | 0 | n/a (pilot) |
-| Galileo E1C | 25 blocks | `UInt32` (low 25 bits used) | CS25 (rotation search) | 0 errors (2.5 % → exact match) | `0..24` | 25 (secondary code, pilot) |
-| Galileo E5a-I | 20 blocks | `UInt32` (low 20 bits used) | CS20 (rotation search) | 0 errors (2.5 % → exact match) | `0..19` | 20 (secondary code) |
-| Galileo E5a-Q | 100 blocks | `UInt128` (low 100 bits used) | per-PRN CS100 (rotation search) | 2 errors (2.5 %) | `0..99` | 100 (secondary code, pilot) |
+- **Soft, maximum-energy CFAR** — GPS L1 C/A (bit-edge, `_detect_bit_edge_cfar`) and the short-secondary-code signals GPS L5I/L5Q and Galileo E1C/E5a-I/E5a-Q (overlay-rotation, `_detect_secondary_code_cfar`). These accumulate per-hypothesis, coherently-summed bin energy in `PhaseAccumulators` and lock when the peak hypothesis beats its runner-up with a Student-t confidence (`get_bit_edge_detection_confidence`, default `0.999`). They self-pace with C/N₀ and fire only at the winning hypothesis's own boundary — so they report **`phase = 0`** (the upcoming integration starts a fresh data bit / secondary-code period). Selected by `uses_soft_bit_edge_detection` / `uses_soft_secondary_code_detection`.
+- **Hard-decision rotation/Hamming sweep** (`_secondary_code_search`) — among the currently implemented signals, GPS L1C-P alone. It matches packed prompt *signs* against the known overlay at every rotation, accepting the best within `get_bit_edge_or_secondary_code_tolerance`; it locks in **one** full period worst case (matches at any alignment) and reports the recovered secondary-chip `phase`.
+- **Trivial / none** — Galileo E1B, GPS L1C-D and GPS L2CM broadcast one channel symbol per primary period, so their detector returns `SyncResult(true, 0, +1)` immediately; GPS L2CL is a dataless pilot with no sync.
 
-The buffer-width type threads through `BitBuffer{B}` and `TrackedSignal{Sig, B, C, PCF}` as a type parameter. The L1C-P case uses an exact-width `UInt1800` defined via `BitIntegers.@define_integers 1800`; the other signals use built-in `UInt8` / `UInt32` / `UInt64` / `UInt128`. The secondary-code signals other than GPS L5I / L1C-P get their packed reference from the generic `_packed_secondary_code(::Type{B}, ::AbstractGNSSSignal, prn)`, which derives it directly from `get_secondary_code(signal)` — so a new secondary-coded signal needs no bespoke template, only a wide enough `get_code_block_buffer_type`.
+*Min-to-fire* is the smallest `num_code_blocks` the detector accepts before it can lock. The soft CFAR detectors need `2 × period` blocks before a runner-up (and hence a decision) exists, then fire at the next winning-hypothesis boundary; the hard sweep needs `1 × period`. *Buffer width* is `get_code_block_buffer_type(signal)`; note it sizes the packed prompt-sign buffer that **only the hard sweep consults** — the soft detectors read `PhaseAccumulators` instead, so for them the packed buffer is vestigial.
 
-The 2.5 % tolerance is a package-wide default and adjustable per-signal via dispatch:
+| Signal | Detector | Min-to-fire | Buffer width | Accept rule | Phase | Blocks per symbol |
+|--------|----------|-------------|--------------|-------------|-------|---------------------|
+| GPS L1 C/A | soft bit-edge CFAR | 40 blocks (2 × 20) | `UInt64` (vestigial) | confidence 0.999 | 0 | 20 |
+| Galileo E1B | trivial | n/a | `UInt8` (unused) | always | 0 | 1 |
+| GPS L5I | soft secondary CFAR | 20 blocks (2 × NH10) | `UInt32` (vestigial) | confidence 0.999 | 0 | 10 |
+| GPS L5Q | soft secondary CFAR | 40 blocks (2 × NH20) | `UInt32` (vestigial) | confidence 0.999 | 0 | 20 (pilot) |
+| GPS L1C-D | trivial | n/a | `UInt8` (unused) | always | 0 | 1 |
+| GPS L1C-P | **hard** rotation sweep | 1800 blocks | `UInt1800` (exact width) | 45 errors (2.5 %) | `0..1799` | n/a (pilot) |
+| GPS L2CM | trivial | n/a | `UInt8` (unused) | always | 0 | 1 |
+| GPS L2CL | never fires | `UInt8` (unused) | none (dataless pilot) | n/a | 0 | n/a (pilot) |
+| Galileo E1C | soft secondary CFAR | 50 blocks (2 × CS25) | `UInt32` (vestigial) | confidence 0.999 | 0 | 25 (pilot) |
+| Galileo E5a-I | soft secondary CFAR | 40 blocks (2 × CS20) | `UInt32` (vestigial) | confidence 0.999 | 0 | 20 |
+| Galileo E5a-Q | soft secondary CFAR | 200 blocks (2 × CS100) | `UInt128` (vestigial) | confidence 0.999 | 0 | 100 (pilot) |
+
+The buffer-width type threads through `BitBuffer{B}` and `TrackedSignal{Sig, B, C, PCF}` as a type parameter. The L1C-P case uses an exact-width `UInt1800` defined via `BitIntegers.@define_integers 1800`. The soft secondary CFAR detectors take the ±1 overlay chip directly from `get_secondary_code(signal)` per rotation, so a new short-secondary-code signal needs no bespoke template — only for `uses_soft_secondary_code_detection` to return `true` (secondary length `1 < N ≤ 100`).
+
+The soft CFAR confidence is package-wide and adjustable per signal via `get_bit_edge_detection_confidence`; the hard-sweep Hamming tolerance is adjustable per (hard-path) signal via `get_bit_edge_or_secondary_code_tolerance`:
 
 ```jldoctest tolerance_override
 julia> using Tracking, GNSSSignals
 
-julia> Tracking.get_bit_edge_or_secondary_code_tolerance(GPSL1CA())  # default
+julia> Tracking.get_bit_edge_or_secondary_code_tolerance(GPSL1C_P())  # default
 0.025
 
-julia> # Loosen the L1 C/A ceiling to 5 % (= 2 errors over 40 blocks) for low-C/N₀ work.
-       Tracking.get_bit_edge_or_secondary_code_tolerance(::GPSL1CA) = 0.05;
+julia> # Loosen the L1C-P ceiling to 5 % (= 90 errors over 1800 blocks) for low-C/N₀ work.
+       Tracking.get_bit_edge_or_secondary_code_tolerance(::GPSL1C_P) = 0.05;
 
-julia> Tracking.get_bit_edge_or_secondary_code_tolerance(GPSL1CA())  # after override
+julia> Tracking.get_bit_edge_or_secondary_code_tolerance(GPSL1C_P())  # after override
 0.05
 ```
 
-Each detector reads the trait at its call site and converts to an integer error budget via `floor(Int, tolerance × window_size)`, so the override picks up the next time `detect_bit_or_secondary_code_sync` runs — no `TrackState` rebuild needed. Galileo E1B and GPS L1C-D have trivially-true detectors and ignore the trait.
+The hard sweep reads the tolerance at its call site and converts to an integer error budget via `floor(Int, tolerance × window_size)`, so the override picks up the next time `detect_bit_or_secondary_code_sync` runs — no `TrackState` rebuild needed. It has no effect on the soft-detector signals (tune their confidence instead); the trivial detectors ignore both.
 
 ### Lifecycle of a `BitBuffer`
 
 Two distinct phases, separated by the `found::Bool` flag:
 
-1. **Pre-sync search** (`found = false`). Each completed integration shifts one bit (the sign of the prompt's real part) into `code_block_buffer::B`. `detect_bit_or_secondary_code_sync` is called on every shift; while it returns `SyncResult(false, ...)` the loop keeps integrating one primary code period at a time. The **bit-edge** detector (GPS L1 C/A) only matches at a true bit boundary, so the call that flips `found` lands exactly on the edge between two data symbols and reports `phase = 0`. The **secondary-code** detectors (GPS L5I, GPS L1C-P) instead lock as soon as one full secondary period has been buffered — at *any* alignment — and report the recovered `phase` (the upcoming integration's secondary chip); the integration cadence then re-aligns to the secondary-code boundary (see below).
+1. **Pre-sync search** (`found = false`). Each completed integration folds the prompt into the running state and the detector is called; while it returns `SyncResult(false, ...)` the loop keeps integrating one primary code period at a time. The **soft CFAR** detectors (GPS L1 C/A bit-edge; GPS L5I/L5Q and Galileo E1C/E5a-I/E5a-Q overlay) fold each prompt into `PhaseAccumulators` and lock only at the winning hypothesis's own boundary — so the call that flips `found` lands exactly on a data-bit / secondary-code-period boundary and reports `phase = 0` (the upcoming integration starts a fresh period). The **hard rotation-sweep** detector (GPS L1C-P) instead shifts each prompt sign into `code_block_buffer::B` and locks as soon as one full overlay period has been buffered — at *any* alignment — reporting the recovered `phase` (the upcoming integration's secondary chip); the integration cadence then re-aligns to that boundary (see below).
 
 2. **Post-sync accumulation** (`found = true`). The post-sync branch in `Tracking.buffer` ignores `code_block_buffer` and instead accumulates the complex prompt into `prompt_accumulator`. (Pilot signals such as GPS L1C-P carry no data bits, so for them this branch is a no-op — the buffer just retains `found` / `secondary_phase` / `polarity`.) Because each post-sync integration spans to the next secondary-code (data-bit) boundary, bit decoding stays aligned even when sync fired mid-period. Each integration also bumps `prompt_accumulator_integrated_code_blocks`. Once that counter reaches the per-signal "blocks per symbol" value above — `_calc_num_code_blocks_that_form_a_bit(signal) = get_code_frequency(signal) / (get_code_length(signal) * get_data_frequency(signal))` — one decoded bit is committed to `buffer::UInt128` and the accumulator resets to zero. For Galileo E1B and GPS L1C-D the counter is `1`, so one symbol commits per integration; for GPS L1 C/A it's `20`, so the loop counts 20 primary-code periods (≈ 20 × 1023 chips = 20460 chips of `code_phase` advance, modulo wrap) per data bit; for GPS L5I it's `10`. The polarity flag flips the accumulator's sign at commit time when the detector locked at negative polarity, so downstream consumers always see `1 = data symbol 0`.
 
@@ -95,7 +101,7 @@ Pilot signals (`get_data_frequency = 0 Hz`, e.g. GPS L1C-P) never enter the post
 
 ### Code-phase seeding from the secondary-code phase
 
-When a signal whose detector exposes a `secondary_phase` syncs — GPS L5I and GPS L1C-P — that phase is used to seed `TrackedSat.code_phase` so subsequent wrap-mod-[`current_code_wrap`](@ref) arithmetic gives the absolute position in the longest secondary-code cycle. The seeding follows a fallback chain: the synced signal with the largest `(primary × secondary)` code length wins.
+When a signal with a secondary code (`secondary_code_length > 1`) syncs — GPS L5I/L5Q, Galileo E1C/E5a-I/E5a-Q, or GPS L1C-P — its `secondary_phase` seeds `TrackedSat.code_phase` so subsequent wrap-mod-[`current_code_wrap`](@ref) arithmetic gives the absolute position in the longest secondary-code cycle. The seeding follows a fallback chain: the synced signal with the largest `(primary × secondary)` code length wins. For the soft-CFAR signals `secondary_phase` is always `0` (they fire on a period boundary, so the upcoming integration is at chip 0); for the hard-sweep L1C-P it is the recovered chip offset. Either way it is a multiple-of-primary snap into the correct secondary window.
 
 Signals with `secondary_code_length == 1` (bit-edge only, e.g. GPS L1 C/A) do **not** carry an explicit `secondary_phase` to snap — there's no per-PRN overlay to recover a chip offset from. Instead, their post-sync bit-edge alignment is captured by **two complementary mechanisms**:
 

--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -8,10 +8,13 @@ Fields:
   - `found::Bool` — whether the detector locked on this update.
   - `phase::Int` — when `found = true`, the secondary-code chip the
     *upcoming* integration aligns to, in `0:secondary_code_length-1`
-    (recovered by the rotation search in [`_secondary_code_search`](@ref)).
+    (recovered by the hard rotation search in [`_secondary_code_search`](@ref)).
     Zero for signals without a secondary code (the L1 C/A bit-edge case
     fires at the data-bit boundary, where the upcoming integration starts a
-    new bit, not at a secondary-chip offset).
+    new bit, not at a secondary-chip offset) and also for the soft
+    [`_detect_secondary_code_cfar`](@ref), which only fires at the winning
+    rotation's own period boundary, so the upcoming integration always starts
+    at secondary chip 0.
   - `polarity::Int8` — `+1` or `-1`; which match orientation the detector
     locked. Carries through to the post-sync prompt accumulator so that a
     negative-polarity lock doesn't trip the downstream bit decoder.
@@ -62,8 +65,9 @@ Hill's algorithm (Hill, G. W. (1970), *Algorithm 396: Student's t-quantiles*,
 Comm. ACM 13(10), 619–620), driven by the two-tailed probability
 `2·(1 − probability)`: `dof = 1` (Cauchy) and `dof = 2` invert in elementary
 functions and are returned exactly, and above that a series in either the
-normal deviate [`_norm_quantile`](@ref) (tail branch) or the two-tailed
-probability itself (central branch) is used. The lower tail is reflected by
+normal deviate [`_norm_quantile`](@ref) (the near-normal branch, `y > 0.05 + a`)
+or the two-tailed probability itself (the deep-tail branch, `y ≤ 0.05 + a`) is
+used, where `y = (d·two_tailed)^(2/dof)`. The lower tail is reflected by
 symmetry, and the median `t(0.5) = 0` is returned directly — which also avoids
 a `1 − 0.5` self-recursion. The sole caller passes `probability > 0.5` (and
 `dof ≥ 1`, since `peak_bin_count ≥ 2` at the call site).
@@ -106,9 +110,10 @@ function _t_quantile(probability::Float64, dof::Real)
     d = ((94.5 / (b + c) - 3) / b + 1) * sqrt(a * pi / 2) * dof
     y = (d * two_tailed_probability)^(2 / dof)
     if y > 0.05 + a
-        # Tail branch: correct the normal deviate (the `dof → ∞` limit) by an
-        # asymptotic series in `1/dof`, so the result relaxes onto `Φ⁻¹` as the
-        # bin count grows — no cutoff, mature locks keep the normal threshold.
+        # Near-normal branch (large `y`): correct the normal deviate (the
+        # `dof → ∞` limit) by an asymptotic series in `1/dof`. This is where
+        # mature (large-dof) locks land — `y → 1` as the bin count grows — so
+        # the threshold relaxes onto `Φ⁻¹` with no cutoff.
         x = _norm_quantile(probability)
         y = x^2
         dof < 5 && (c += 0.3 * (dof - 4.5) * (x + 0.6))
@@ -116,8 +121,9 @@ function _t_quantile(probability::Float64, dof::Real)
         y = (((((0.4 * y + 6.3) * y + 36) * y + 94.5) / c - y - 3) / b + 1) * x
         y = expm1(a * y^2)
     else
-        # Central branch: a series in the two-tailed probability itself, used
-        # where the normal deviate is a poor starting point.
+        # Deep-tail branch (small `y`): a series in the two-tailed probability
+        # itself, used at few-bin / small-dof arguments where the normal deviate
+        # is a poor starting point.
         y =
             (
                 (
@@ -132,12 +138,18 @@ end
 """
 $(SIGNATURES)
 
-Per-phase bin statistics for the soft, maximum-energy bit-edge detector
-[`_detect_bit_edge_cfar`](@ref) — one entry per candidate edge phase
-`phase ∈ 0:blocks_per_bit-1`, where `blocks_per_bit` is the (per-signal)
-number of primary-code blocks per navigation bit. Updated one primary-code
-block at a time by [`_update_phase_accumulators!`](@ref) so detection stays
-O(blocks_per_bit) per block with no growing pre-sync history.
+Per-hypothesis bin statistics for the soft, maximum-energy CFAR sync
+detectors — one entry per candidate timing hypothesis. It backs **both** soft
+detectors (a signal uses at most one): the GPS L1 C/A bit-edge detector
+[`_detect_bit_edge_cfar`](@ref), where a hypothesis is an edge phase
+`phase ∈ 0:blocks_per_bit-1` and the bin is one navigation bit, updated by
+[`_update_phase_accumulators!`](@ref); and the secondary-code detector
+[`_detect_secondary_code_cfar`](@ref), where a hypothesis is an overlay rotation
+`d ∈ 0:N-1` and the bin is one (overlay-wiped) secondary-code period, updated by
+[`_update_secondary_accumulators!`](@ref). In both cases it is advanced one
+primary-code block at a time so detection stays O(hypotheses) per block with no
+growing pre-sync history. Below, `period` is `blocks_per_bit` (L1 C/A) or the
+secondary-code length `N`.
 
 The vectors are mutated in place across the immutable [`BitBuffer`](@ref)
 reconstructions (the same pattern as `soft_bits`). This is deliberate: the
@@ -148,13 +160,14 @@ each block — both reintroduce the per-block allocation this design exists
 to avoid. A single shared, in-place-updated buffer per satellite is the
 allocation-free choice.
 
-Fields (all length `blocks_per_bit` once seeded; empty before the first block):
+Fields (all length `period` once seeded; empty before the first block):
 
-  - `open_bin_sum` — coherent sum of the phase's *currently open* bin.
+  - `open_bin_sum` — coherent sum of the hypothesis's *currently open* bin
+    (overlay-wiped for the secondary-code detector).
   - `mean_bin_energy` / `bin_energy_sum_of_squared_deviations` — Welford running mean and
-    sum of squared deviations (`M₂ = Σ(energyᵢ − mean)²`) of the phase's
+    sum of squared deviations (`M₂ = Σ(energyᵢ − mean)²`) of the hypothesis's
     *completed*-bin energies, for a numerically stable variance. The bin
-    count is not stored — it is `div(num_blocks - phase, blocks_per_bit)`.
+    count is not stored — it is `div(num_blocks - hypothesis, period)`.
   - `last_bin_polarity` — sign (`±1`, `0` before the first bin) of the most
     recently completed bin's real part, i.e. the lock polarity.
 """
@@ -229,57 +242,188 @@ end
 """
 $(SIGNATURES)
 
+Shared CFAR (constant-false-alarm-rate) decision core for the soft,
+maximum-energy sync detectors — both the GPS L1 C/A bit-edge detector
+[`_detect_bit_edge_cfar`](@ref) and the secondary-code detector
+[`_detect_secondary_code_cfar`](@ref) route through here. Given the
+per-hypothesis running statistics carried in [`PhaseAccumulators`](@ref) it
+identifies the maximum-energy hypothesis, its closest competitor, and decides
+whether the peak is significant enough to lock. The two detectors differ only in
+what a "hypothesis" is (a bit-edge phase vs. a secondary-code rotation) and how
+the accumulators are fed; the decision below is identical.
+
+Arguments:
+
+  - `mean_bin_energy` — per-hypothesis mean completed-bin energy
+    (`accumulators.mean_bin_energy`).
+  - `bin_energy_sum_of_squared_deviations` — per-hypothesis Welford `M₂`
+    (`accumulators.bin_energy_sum_of_squared_deviations`), used only for the
+    peak.
+  - `num_blocks` — total primary-code blocks folded so far.
+  - `period` — number of primary-code blocks per bin, which is also the number
+    of competing hypotheses: `blocks_per_bit` (20 for L1 C/A) or the
+    secondary-code length `N`. A hypothesis `h ∈ 0:period-1` has completed-bin
+    count `div(num_blocks - h, period)`.
+  - `confidence` — target `1 − P(false lock)`.
+
+Returns `(accepted, peak_index, peak_bin_count)`: `accepted` is whether the
+peak's energy gap over its runner-up is statistically significant (the caller
+still applies its own bin-boundary gate before firing); `peak_index` is the
+0-based winning hypothesis (`-1` if none qualifies) and `peak_bin_count` its
+completed-bin count.
+
+# Statistic
+
+Each hypothesis coherently sums its `period`-block bins and the per-bin energy
+`|Σ|²` is folded into a running mean; the true hypothesis keeps full coherent
+gain on every bin while wrong ones lose energy (L1 C/A: wrong phases straddle a
+data-bit transition; secondary code: wrong rotations fail to wipe the overlay).
+The per-hypothesis mean bin energy is therefore the maximum-likelihood timing
+statistic.
+
+# CFAR confidence
+
+The noise scale is the *bin-to-bin* sample variance of the winning hypothesis's
+own completed-bin energies (Welford, numerically stable at any bin count). The
+true hypothesis's bins vary only with thermal noise and slow drift — exactly the
+run-to-run spread the test must compare the gap against. The peak is accepted
+only when it beats the runner-up by a margin significant under that spread:
+
+    z_score = energy_gap / standard_error   ≥   t⁻¹(1 - false_alarm_probability/(period - 1);  ν = peak_bin_count − 1)
+
+where the standard error combines the peak's per-bin energy variance over the
+peak and runner-up bin counts, `false_alarm_probability = 1 - confidence` is
+Bonferroni-split over the `period - 1` competing hypotheses, and the quantile is
+the Student-t inverse-CDF [`_t_quantile`](@ref) at a nominal `ν = peak_bin_count − 1` d.o.f. — a small-sample penalty for dividing by a variance estimated over
+that few bins, not a claim that `z_score` is exactly Student-t (the per-bin
+energies are χ² and the hypotheses correlated; see [`_t_quantile`](@ref)). A real
+peak has a structural gap that dwarfs the thermal bin-to-bin spread, so `z_score`
+grows like the square root of the bin count and crosses the threshold sooner at
+high C/N₀ and later in noise — the detector self-paces — while a drift-only
+asymmetry keeps `z_score` bounded and never locks.
+"""
+@inline function _cfar_decide(
+    mean_bin_energy::AbstractVector{Float64},
+    bin_energy_sum_of_squared_deviations::AbstractVector{Float64},
+    num_blocks::Int,
+    period::Int,
+    confidence::Float64,
+)
+    # Need at least two complete bins on some hypothesis before any hypothesis
+    # can serve as a runner-up; below that a transition cannot have been
+    # localized yet.
+    num_blocks < 2 * period && return (false, -1, 0)
+
+    # Single O(period) pass: the peak (highest mean bin energy among hypotheses
+    # with ≥ 2 complete bins) and the two highest hypotheses overall. The
+    # runner-up is the higher of those two that isn't the peak. A hypothesis's
+    # completed-bin count is `div(num_blocks - h, period)`.
+    peak_index = -1
+    peak_energy = -1.0
+    peak_bin_count = 0          # best, ≥ 2 bins
+    best_index = -1
+    best_energy = -1.0
+    best_bin_count = 0          # highest, ≥ 1 bin
+    second_best_energy = -1.0
+    second_best_bin_count = 0             # 2nd highest, ≥ 1 bin
+    @inbounds for h = 0:(period-1)
+        bin_count = div(num_blocks - h, period)
+        bin_count < 1 && continue
+        energy = mean_bin_energy[h+1]
+        if energy > best_energy
+            second_best_energy = best_energy
+            second_best_bin_count = best_bin_count
+            best_energy = energy
+            best_index = h
+            best_bin_count = bin_count
+        elseif energy > second_best_energy
+            second_best_energy = energy
+            second_best_bin_count = bin_count
+        end
+        if bin_count >= 2 && energy > peak_energy
+            peak_energy = energy
+            peak_index = h
+            peak_bin_count = bin_count
+        end
+    end
+    # `num_blocks >= 2 * period` guarantees hypothesis 0 has ≥ 2 bins, so
+    # `peak_index` is always set.
+    peak_index < 0 && return (false, -1, 0)
+
+    # Runner-up: the highest-energy hypothesis that isn't the peak (any bin count).
+    runner_up_energy, runner_up_bin_count =
+        best_index == peak_index ? (second_best_energy, second_best_bin_count) :
+        (best_energy, best_bin_count)
+    runner_up_bin_count < 1 && return (false, peak_index, peak_bin_count)
+
+    energy_gap = peak_energy - runner_up_energy
+    energy_gap <= 0 && return (false, peak_index, peak_bin_count)
+
+    # Noise scale: the bin-to-bin variance of the peak hypothesis's own
+    # completed-bin energies, maintained by Welford so it is numerically stable
+    # at any bin count. The true hypothesis has pure (non-straddling) bins, so
+    # this is the genuine run-to-run spread — thermal noise *and* slow drift /
+    # quantization — which a within-bin residual would miss and then mistake a
+    # tiny systematic cross-hypothesis asymmetry for a significant peak. The
+    # runner-up is assumed to share this per-bin variance (it can only be larger,
+    # from its straddling bins, so this is the optimistic — fastest-locking —
+    # choice that still rejects drift-only asymmetries).
+    @inbounds bin_energy_variance =
+        bin_energy_sum_of_squared_deviations[peak_index+1] / (peak_bin_count - 1)
+    standard_error =
+        sqrt(bin_energy_variance * (1 / peak_bin_count + 1 / runner_up_bin_count))
+    z_score =
+        standard_error > 0 ? energy_gap / standard_error : (energy_gap > 0 ? Inf : 0.0)
+
+    # `confidence` is the (1 - false-sync probability) target, Bonferroni-split
+    # over the `period - 1` competing hypotheses. Clamp the quantile argument to
+    # the open interval (0, 1): otherwise `confidence = 1.0` (or the rounding of
+    # `1 - tiny/(period-1)` up to 1.0) yields a `quantile(1) = NaN`, and the
+    # `z_score < threshold` gate would silently pass (NaN comparisons are false),
+    # turning "maximum confidence" into "lock immediately".
+    false_alarm_probability = 1 - confidence
+    quantile_argument =
+        clamp(1 - false_alarm_probability / (period - 1), nextfloat(0.0), prevfloat(1.0))
+    # `standard_error` divides by a variance ESTIMATED from `peak_bin_count`
+    # bins, so a normal threshold is badly overconfident at 1-2 bins (its ~3.9
+    # value is a ~10% per-hypothesis false alarm at 1 d.o.f., not the intended
+    # 1e-4), which let a variance-collapsed 2-bin fluctuation lock. Apply the
+    # Student-t quantile at a nominal `peak_bin_count - 1` d.o.f. as a
+    # small-sample penalty (NOT because `z_score` is exactly Student-t: the
+    # per-bin energies are χ² and the hypotheses correlated, so the nominal
+    # d.o.f. and false-alarm rate are approximate — see `_t_quantile`). It
+    # demands z ≈ 6000 at 1 d.o.f. and relaxes to the normal threshold as bins
+    # accumulate, forcing enough integration before a lock (which also lets the
+    # carrier settle) while leaving mature clean locks (many bins ⇒ t ≈ normal)
+    # unchanged.
+    z_threshold = _t_quantile(quantile_argument, peak_bin_count - 1)
+    z_score < z_threshold && return (false, peak_index, peak_bin_count)
+
+    (true, peak_index, peak_bin_count)
+end
+
+"""
+$(SIGNATURES)
+
 Soft-decision, CFAR bit-edge detector — a signal-agnostic maximum-energy
 timing synchronizer for any signal whose navigation bit spans more than one
 primary-code period with no secondary code (selected by
 [`uses_soft_bit_edge_detection`](@ref); GPS L1 C/A is the current example
 with `blocks_per_bit = 20`). Signals with a periodic secondary code (GPS
-L5I, GPS L1C-P) instead use [`_secondary_code_search`](@ref), which
-correlates against a known overlay.
+L5I, GPS L1C-P) instead use the soft [`_detect_secondary_code_cfar`](@ref) or
+the hard [`_secondary_code_search`](@ref), which correlate against a known
+overlay.
 
 The per-phase bin statistics are carried in `accumulators`
 ([`PhaseAccumulators`](@ref), advanced in place by
 [`_update_phase_accumulators!`](@ref)); `blocks_per_bit` is the number of
 primary-code blocks per navigation bit (20 for L1 C/A) and `num_blocks` is
-the total number of prompts seen. The detector is O(blocks_per_bit) per
-call — no rescan of history — so it stays cheap on the pre-sync hot path no
-matter how long sync takes.
-
-# Statistic
-
-Under the hypothesis that the bit edge sits at `phase ∈ 0:blocks_per_bit-1`,
-the prompts partition into `blocks_per_bit`-block bins aligned to `phase`.
-Each complete bin is coherently summed (`Sₖₘ = Σ pᵢ`) and its energy
-`|Sₖₘ|²` folded into the phase's running `mean_bin_energy`; the true phase
-never straddles a data-bit transition, so it keeps full coherent gain on
-every bin while wrong phases lose energy on transition bins. The per-phase
-mean bin energy is therefore the maximum-likelihood timing statistic for
-unknown i.i.d. data in AWGN.
-
-# CFAR confidence
-
-The noise scale is the *bin-to-bin* sample variance of the winning
-phase's own completed-bin energies. The true edge's bins never straddle a
-transition, so their energies vary only with thermal noise and slow
-drift — exactly the run-to-run spread the test must compare the gap
-against. (A within-bin residual would read ~0 on a clean but drifting
-signal and then mistake a tiny systematic cross-phase asymmetry for a real
-edge.) The peak is accepted only when it beats the runner-up by a margin
-significant under that spread:
-
-    z_score = energy_gap / standard_error   ≥   t⁻¹(1 - false_alarm_probability/(blocks_per_bit - 1);  ν = peak_bin_count − 1)
-
-where the standard error combines the peak phase's per-bin energy variance
-over the peak and runner-up bin counts, `false_alarm_probability = 1 - confidence` is Bonferroni-split over the `blocks_per_bit - 1` competing
-phases, and the quantile is the Student-t inverse-CDF [`_t_quantile`](@ref) at
-a nominal `ν = peak_bin_count − 1` d.o.f. — a small-sample penalty for dividing
-by a variance estimated over that few bins, not a claim that `z_score` is exactly
-Student-t (the per-bin energies are χ² and the phases correlated; see
-[`_t_quantile`](@ref)). A real edge has a structural
-gap that dwarfs the thermal bin-to-bin spread, so `z_score` grows like the
-square root of the bin count and crosses the threshold sooner at high C/N₀
-and later in noise — the detector self-paces — while a drift-only asymmetry
-keeps `z_score` bounded and never locks.
+the total number of prompts seen. The maximum-energy hypothesis test — peak
+vs. runner-up, Welford noise scale, and Student-t CFAR threshold — is the
+shared [`_cfar_decide`](@ref) core (the hypothesis here is the bit-edge
+`phase ∈ 0:blocks_per_bit-1`). The detector is O(blocks_per_bit) per call — no
+rescan of history — so it stays cheap on the pre-sync hot path no matter how
+long sync takes.
 
 # Boundary firing
 
@@ -300,101 +444,14 @@ function _detect_bit_edge_cfar(
     confidence::Float64,
     num_blocks::Int,
 )
-    # Need at least two complete bins on some phase before any phase can
-    # serve as a runner-up; below that a transition cannot have been
-    # localized yet.
-    num_blocks < 2 * blocks_per_bit && return SyncResult(false, 0, Int8(0))
-
-    mean_bin_energy = accumulators.mean_bin_energy
-    # Single O(blocks_per_bit) pass: the peak (highest mean bin energy among
-    # phases with ≥ 2 complete bins) and the two highest phases overall. The
-    # runner-up is the higher of those two that isn't the peak. A phase's
-    # completed-bin count is `div(num_blocks - phase, blocks_per_bit)`.
-    peak_phase = -1;
-    peak_energy = -1.0;
-    peak_bin_count = 0          # best, ≥ 2 bins
-    best_phase = -1;
-    best_energy = -1.0;
-    best_bin_count = 0          # highest, ≥ 1 bin
-    second_best_energy = -1.0;
-    second_best_bin_count = 0             # 2nd highest, ≥ 1 bin
-    @inbounds for phase = 0:(blocks_per_bit-1)
-        bin_count = div(num_blocks - phase, blocks_per_bit)
-        bin_count < 1 && continue
-        energy = mean_bin_energy[phase+1]
-        if energy > best_energy
-            second_best_energy = best_energy
-            second_best_bin_count = best_bin_count
-            best_energy = energy
-            best_phase = phase
-            best_bin_count = bin_count
-        elseif energy > second_best_energy
-            second_best_energy = energy
-            second_best_bin_count = bin_count
-        end
-        if bin_count >= 2 && energy > peak_energy
-            peak_energy = energy
-            peak_phase = phase
-            peak_bin_count = bin_count
-        end
-    end
-    # `num_blocks >= 2 * blocks_per_bit` guarantees phase 0 has ≥ 2 bins, so
-    # `peak_phase` is always set.
-    peak_phase < 0 && return SyncResult(false, 0, Int8(0))
-
-    # Runner-up: the highest-energy phase that isn't the peak (any bin count).
-    runner_up_energy, runner_up_bin_count =
-        best_phase == peak_phase ? (second_best_energy, second_best_bin_count) :
-        (best_energy, best_bin_count)
-    runner_up_bin_count < 1 && return SyncResult(false, 0, Int8(0))
-
-    energy_gap = peak_energy - runner_up_energy
-    energy_gap <= 0 && return SyncResult(false, 0, Int8(0))
-
-    # Noise scale: the bin-to-bin variance of the peak phase's own
-    # completed-bin energies, maintained by Welford so it is numerically
-    # stable at any bin count. The true edge has pure (non-straddling) bins,
-    # so this is the genuine run-to-run spread — thermal noise *and* slow
-    # drift / quantization — which a within-bin residual would miss and then
-    # mistake a tiny systematic cross-phase asymmetry for a significant edge.
-    # The runner-up is assumed to share this per-bin variance (it can only be
-    # larger, from its straddling bins, so this is the optimistic —
-    # fastest-locking — choice that still rejects drift-only asymmetries).
-    @inbounds bin_energy_variance =
-        accumulators.bin_energy_sum_of_squared_deviations[peak_phase+1] /
-        (peak_bin_count - 1)
-    standard_error =
-        sqrt(bin_energy_variance * (1 / peak_bin_count + 1 / runner_up_bin_count))
-    z_score =
-        standard_error > 0 ? energy_gap / standard_error : (energy_gap > 0 ? Inf : 0.0)
-
-    # `confidence` is the (1 - false-sync probability) target, Bonferroni-
-    # split over the `blocks_per_bit - 1` competing phases. Clamp the quantile
-    # argument to the open interval (0, 1): otherwise `confidence = 1.0` (or
-    # the rounding of `1 - tiny/(blocks_per_bit-1)` up to 1.0) yields a
-    # `quantile(1) = NaN`, and the `z_score < threshold` gate would silently
-    # pass (NaN comparisons are false), turning "maximum confidence" into "lock
-    # immediately".
-    false_alarm_probability = 1 - confidence
-    quantile_argument = clamp(
-        1 - false_alarm_probability / (blocks_per_bit - 1),
-        nextfloat(0.0),
-        prevfloat(1.0),
+    accepted, peak_phase, _ = _cfar_decide(
+        accumulators.mean_bin_energy,
+        accumulators.bin_energy_sum_of_squared_deviations,
+        num_blocks,
+        blocks_per_bit,
+        confidence,
     )
-    # `standard_error` divides by a variance ESTIMATED from `peak_bin_count`
-    # bins, so a normal threshold is badly overconfident at 1-2 bins (its ~3.9
-    # value is a ~10% per-phase false alarm at 1 d.o.f., not the intended 1e-4),
-    # which let a variance-collapsed 2-bin fluctuation lock ~8 blocks off the true
-    # edge on a fast reacquisition — silent because <10 blocks still decodes by
-    # majority. Apply the Student-t quantile at a nominal `peak_bin_count - 1`
-    # d.o.f. as a small-sample penalty (NOT because `z_score` is exactly Student-t:
-    # the per-bin energies are χ² and the phases correlated, so the nominal d.o.f.
-    # and false-alarm rate are approximate — see `_t_quantile`). It demands z ≈ 6000
-    # at 1 d.o.f. and relaxes to the normal threshold as bins accumulate, forcing
-    # enough integration before a lock (which also lets the carrier settle) while
-    # leaving mature clean locks (many bins ⇒ t ≈ normal) unchanged.
-    z_threshold = _t_quantile(quantile_argument, peak_bin_count - 1)
-    z_score < z_threshold && return SyncResult(false, 0, Int8(0))
+    accepted || return SyncResult(false, 0, Int8(0))
 
     # Fire only at the winning phase's own bit boundary so the upcoming
     # integration starts a new bit.
@@ -408,13 +465,126 @@ end
 """
 $(SIGNATURES)
 
-Generic secondary-code sync detector shared by every signal that locks
-onto a periodic secondary / overlay code — GPS L5I's NH10 and GPS L1C-P's
-1800-chip overlay both route through here. Unlike
-[`_detect_bit_edge_cfar`](@ref) (the soft maximum-energy bit-edge
-detector used for GPS L1 C/A), this runs a full rotation search against a
-*known* overlay code, so it locks after a single secondary-code period in
-the worst case and recovers the true secondary-code phase.
+Fold the `prompt` of the primary-code block at 0-based `block_index` into the
+[`PhaseAccumulators`](@ref) (in place) for a soft, maximum-energy secondary-code
+rotation search of period `N = secondary_code_length`. This is the
+secondary-code analog of [`_update_phase_accumulators!`](@ref): each rotation
+hypothesis `d ∈ 0:N-1` is a candidate secondary-chip alignment whose bins span
+`N` blocks starting at index `d`. Unlike the bit-edge case, each block is
+multiplied by the *known* secondary chip before being summed, so the correct
+rotation wipes the overlay and every block in the bin adds coherently
+(`|Σ p·s|²` large) while wrong rotations straddle the fixed overlay transitions
+and lose energy.
+
+`signal` / `prn` select the secondary code via `secondary_value`; under
+hypothesis `d`, block `i` carries secondary chip `mod(i - d, N)` (`±1`), so the
+bin completes when `chip == N - 1` and chip 0 is anchored to the physical
+secondary-code chip 0 — the same overlay the replica applies post-sync, and the
+same rotation the hard [`_secondary_code_search`](@ref) locks (its bespoke packed
+reference differs only by an overall polarity, which the energy statistic here is
+invariant to). Each completed bin's energy `|bin_sum|²` is folded into that
+rotation's Welford mean / sum-of-squared-deviations and its polarity recorded.
+O(N) per call, allocation-free.
+"""
+function _update_secondary_accumulators!(
+    accumulators::PhaseAccumulators,
+    prompt::ComplexF64,
+    block_index::Int,
+    secondary_code_length::Int,
+    signal::AbstractGNSSSignal,
+    prn::Integer,
+)
+    N = secondary_code_length
+    secondary_code = get_secondary_code(signal)
+    @inbounds for d = 0:(N-1)
+        block_index < d && continue
+        chip = (block_index - d) % N
+        overlay = GNSSSignals.secondary_value(secondary_code, prn, chip)
+        accumulators.open_bin_sum[d+1] += prompt * overlay
+        if chip == N - 1
+            bin_sum = accumulators.open_bin_sum[d+1]
+            bin_energy = abs2(bin_sum)
+            # Welford update of this rotation's completed-bin energy mean / M₂.
+            completed_bin_count = div(block_index + 1 - d, N)
+            energy_delta = bin_energy - accumulators.mean_bin_energy[d+1]
+            accumulators.mean_bin_energy[d+1] += energy_delta / completed_bin_count
+            accumulators.bin_energy_sum_of_squared_deviations[d+1] +=
+                energy_delta * (bin_energy - accumulators.mean_bin_energy[d+1])
+            accumulators.last_bin_polarity[d+1] = real(bin_sum) < 0 ? Int8(-1) : Int8(1)
+            accumulators.open_bin_sum[d+1] = zero(ComplexF64)
+        end
+    end
+    accumulators
+end
+
+"""
+$(SIGNATURES)
+
+Soft-decision, CFAR secondary-code sync detector — the maximum-energy analog of
+[`_detect_bit_edge_cfar`](@ref) for signals carrying a short periodic secondary /
+overlay code (selected by [`uses_soft_secondary_code_detection`](@ref); GPS L5I,
+GPS L5Q, Galileo E1C / E5aI / E5aQ). The per-rotation bin statistics are carried
+in `accumulators` ([`PhaseAccumulators`](@ref), advanced in place by
+[`_update_secondary_accumulators!`](@ref)); `secondary_code_length` (`N`) is both
+the bin length and the number of rotation hypotheses, and `num_blocks` is the
+total number of prompts seen. The peak-vs-runner-up hypothesis test is the shared
+[`_cfar_decide`](@ref) core.
+
+Compared with the hard-decision rotation sweep [`_secondary_code_search`](@ref),
+this uses the *soft* prompt magnitude and a CFAR confidence, so it rejects the
+noise-driven false locks a short (e.g. 10-chip NH10) hard template match is prone
+to and self-paces with C/N₀.
+
+# Boundary firing
+
+Detection is reported only when the most recent block also *ends* the winning
+rotation's known-code period (`num_blocks % N == peak_rotation`), so the upcoming
+integration starts at secondary chip 0 — the true chip-0 boundary, since each
+rotation is anchored to the physical secondary chip 0 (see
+[`_update_secondary_accumulators!`](@ref)). The reported `SyncResult.phase` is
+therefore always `0`, and downstream code-phase snapping
+([`_snap_code_phase_from_synced_signal`](@ref)) anchors on that boundary.
+`polarity` is the sign of the winning period's coherent (overlay-wiped) sum
+(resolved to the data-bit / carrier sign downstream by the navigation preamble).
+"""
+function _detect_secondary_code_cfar(
+    accumulators::PhaseAccumulators,
+    secondary_code_length::Int,
+    confidence::Float64,
+    num_blocks::Int,
+)
+    accepted, peak_rotation, _ = _cfar_decide(
+        accumulators.mean_bin_energy,
+        accumulators.bin_energy_sum_of_squared_deviations,
+        num_blocks,
+        secondary_code_length,
+        confidence,
+    )
+    accepted || return SyncResult(false, 0, Int8(0))
+
+    # Fire only at the winning rotation's own period boundary so the upcoming
+    # integration starts at secondary chip 0.
+    num_blocks % secondary_code_length != peak_rotation &&
+        return SyncResult(false, 0, Int8(0))
+
+    @inbounds polarity =
+        accumulators.last_bin_polarity[peak_rotation+1] < 0 ? Int8(-1) : Int8(+1)
+    SyncResult(true, 0, polarity)
+end
+
+"""
+$(SIGNATURES)
+
+Generic **hard-decision** secondary-code sync detector for signals on the
+hard path — among the currently implemented signals only GPS L1C-P (its
+1800-chip overlay) routes through here. The short-secondary-code signals
+(GPS L5I/L5Q, Galileo E1C/E5aI/E5aQ) were moved to the soft, maximum-energy
+[`_detect_secondary_code_cfar`](@ref) (see
+[`uses_soft_secondary_code_detection`](@ref)); GPS L1 C/A uses the soft
+bit-edge [`_detect_bit_edge_cfar`](@ref). Unlike those, this runs a full
+rotation search against a *known* overlay code, so it locks after a single
+secondary-code period in the worst case and recovers the true
+secondary-code phase.
 
 `received` is the prompt-sign sliding window with the newest block in
 bit 0. `reference` is the secondary code packed in that **same**
@@ -432,7 +602,7 @@ snap ([`_snap_code_phase_from_synced_signal`](@ref)) anchors on. Returns
 `SyncResult(false, 0, 0)` when the best distance exceeds `max_errors`.
 
 Inlined so the per-signal `reference` / `N` constants fold at the call
-site (the L5I window is 10, the L1C-P window 1800).
+site (the L1C-P window is 1800).
 """
 @inline function _secondary_code_search(
     received::B,
@@ -579,12 +749,15 @@ for the GPS L1C-P overlay, etc.). After sync the field is dead state and
 the decoded navigation bits accumulate in the fixed-width
 `buffer::UInt128` instead.
 
-The `phase_acc` field holds the incremental per-phase bin statistics
-([`PhaseAccumulators`](@ref)) consumed by the soft bit-edge detector
-[`_detect_bit_edge_cfar`](@ref). It is seeded and updated only for signals
-whose [`uses_soft_bit_edge_detection`](@ref) trait is `true` (currently
-GPS L1 C/A); for all other signals it stays empty. Its size is bounded
-(one entry per phase), so there is no growing pre-sync history.
+The `phase_acc` field holds the incremental per-hypothesis bin statistics
+([`PhaseAccumulators`](@ref)) consumed by whichever soft CFAR sync detector the
+signal uses — [`_detect_bit_edge_cfar`](@ref) for signals whose
+[`uses_soft_bit_edge_detection`](@ref) is `true` (GPS L1 C/A), or
+[`_detect_secondary_code_cfar`](@ref) for those whose
+[`uses_soft_secondary_code_detection`](@ref) is `true` (GPS L5I/L5Q, Galileo
+E1C/E5aI/E5aQ). It is seeded and updated only for those signals; for all others
+(hard-decision path) it stays empty. Its size is bounded (one entry per
+hypothesis), so there is no growing pre-sync history.
 """
 struct BitBuffer{B<:Unsigned}
     code_block_buffer::B
@@ -682,27 +855,33 @@ end
 """
 $(SIGNATURES)
 
-Width of the sync-search sliding window for `signal`, returned as a
-concrete `Unsigned` subtype.
+Width `B` of the packed prompt-sign buffer (`BitBuffer.code_block_buffer`) for
+`signal`, returned as a concrete `Unsigned` subtype.
 
-Each signal's bit/secondary-code sync detector matches the buffered
-primary-code-block signs against a per-signal template. This trait
-picks the smallest integer width that holds one full search horizon for
-that signal:
+That packed buffer is the sliding-window search horizon **only for the
+hard-decision path** — the rotation/Hamming sweep [`_secondary_code_search`](@ref),
+which among the currently implemented signals is used by GPS L1C-P alone. The
+soft-decision CFAR detectors ([`_detect_bit_edge_cfar`](@ref) for GPS L1 C/A,
+[`_detect_secondary_code_cfar`](@ref) for the short-secondary-code signals) read
+the incremental [`PhaseAccumulators`](@ref) instead, so for those signals the
+packed buffer of this width is built but not consulted for detection — it is
+vestigial (the width could be `UInt8`; it is left at the horizon width below for
+uniformity and so the hard path stays available). The table gives, per signal,
+the returned width and — for the hard path — the horizon it must hold:
 
-| Signal        | Returns    | Window                                       |
-|:------------- |:---------- |:-------------------------------------------- |
-| GPS L1 C/A    | `UInt64`   | 40 blocks (2 × 20 blocks/symbol)             |
-| Galileo E1B   | `UInt8`    | 8 blocks (2 × 4 blocks/symbol)               |
-| GPS L5I       | `UInt32`   | 20 blocks (2 × NH10 length)                  |
-| GPS L5Q       | `UInt32`   | 20-chip NH20 secondary code                  |
-| GPS L1C-D     | `UInt8`    | n/a — symbol = primary period, buffer unused |
-| GPS L1C-P     | `UInt1800` | 1800-chip overlay (added in step 4)          |
-| GPS L2CM      | `UInt8`    | n/a — symbol = primary period, buffer unused |
-| GPS L2CL      | `UInt8`    | n/a — dataless pilot, no sync, buffer unused |
-| Galileo E1C   | `UInt32`   | 25-chip CS25 secondary code                  |
-| Galileo E5a-I | `UInt32`   | 20-chip CS20 secondary code                  |
-| Galileo E5a-Q | `UInt128`  | 100-chip per-PRN CS100 secondary code        |
+| Signal        | Returns    | Detector / buffer role                              |
+|:------------- |:---------- |:--------------------------------------------------- |
+| GPS L1 C/A    | `UInt64`   | soft bit-edge CFAR — packed buffer vestigial        |
+| Galileo E1B   | `UInt8`    | symbol = primary period, buffer unused              |
+| GPS L5I       | `UInt32`   | soft secondary CFAR — packed buffer vestigial       |
+| GPS L5Q       | `UInt32`   | soft secondary CFAR — packed buffer vestigial       |
+| GPS L1C-D     | `UInt8`    | symbol = primary period, buffer unused              |
+| GPS L1C-P     | `UInt1800` | **hard** rotation sweep — 1800-chip overlay horizon |
+| GPS L2CM      | `UInt8`    | symbol = primary period, buffer unused              |
+| GPS L2CL      | `UInt8`    | dataless pilot, no sync, buffer unused              |
+| Galileo E1C   | `UInt32`   | soft secondary CFAR — packed buffer vestigial       |
+| Galileo E5a-I | `UInt32`   | soft secondary CFAR — packed buffer vestigial       |
+| Galileo E5a-Q | `UInt128`  | soft secondary CFAR — packed buffer vestigial       |
 
 The default for any signal not specialized below is `UInt64`. The width
 flows through `BitBuffer{B}` and `TrackedSignal{Sig, B, C, PCF}` so the
@@ -713,50 +892,46 @@ parameter chain stays type-stable at construction.
 """
 $(SIGNATURES)
 
-Per-signal Hamming tolerance used by the secondary-code sync-search
-detector [`_secondary_code_search`](@ref), expressed as a fraction of the
-search window.
+Per-signal Hamming tolerance used by the **hard-decision** rotation/Hamming
+sweep [`_secondary_code_search`](@ref), expressed as a fraction of the search
+window.
 
 Returns the largest **fraction** of bit-flips the per-signal
 `detect_bit_or_secondary_code_sync` accepts before reporting
 `found = true`. Each detector converts this to an integer error budget
 at its call site: `max_errors = floor(Int, tolerance × window_size)`.
 
-Default is `0.025` (2.5 %), which discretizes per-signal as:
+Among the currently implemented signals **only GPS L1C-P reads this trait** — it
+is the sole signal still on the hard path. The short-secondary-code signals (GPS
+L5I/L5Q, Galileo E1C/E5aI/E5aQ) were moved to the soft, confidence-driven
+[`_detect_secondary_code_cfar`](@ref) (selected by
+[`uses_soft_secondary_code_detection`](@ref)) and no longer consult it; likewise
+GPS L1 C/A uses [`_detect_bit_edge_cfar`](@ref). Both soft detectors are tuned by
+[`get_bit_edge_detection_confidence`](@ref) instead. Galileo E1B and GPS L1C-D
+broadcast one channel symbol per primary code period, so their detectors return
+`SyncResult(true, 0, +1)` unconditionally — the trait default applies but the
+value is ignored — and GPS L2CL is a dataless pilot with no sync.
 
-| Signal        | Window (blocks) | Effective `max_errors` |
-|:------------- |:--------------- |:---------------------- |
-| GPS L5I       | 10              | 0 (exact match)        |
-| GPS L5Q       | 20              | 0 (exact match)        |
-| GPS L1C-P     | 1800            | 45                     |
-| Galileo E1C   | 25              | 0 (exact match)        |
-| Galileo E5a-I | 20              | 0 (exact match)        |
-| Galileo E5a-Q | 100             | 2                      |
-| Galileo E1B   | n/a — trivial   | unused                 |
-| GPS L1C-D     | n/a — trivial   | unused                 |
-| GPS L2CM      | n/a — trivial   | unused                 |
-| GPS L2CL      | n/a — no sync   | unused                 |
-
-GPS L1 C/A does **not** use this trait: its bit-edge detector is the
-soft-decision, confidence-driven [`_detect_bit_edge_cfar`](@ref), tuned
-by [`get_bit_edge_detection_confidence`](@ref) instead. Galileo E1B and
-GPS L1C-D broadcast one channel symbol per primary code period, so their
-detectors return `SyncResult(true, 0, +1)` unconditionally — the trait
-default applies but the value is ignored.
+Default is `0.025` (2.5 %). At L1C-P's 1800-chip window that discretizes to
+`max_errors = 45`. (For reference, the same 2.5 % at the now-soft signals' short
+windows would floor to 0–2 errors — an exact or near-exact match — which is
+exactly the noise-driven false-lock exposure the move to the soft detector
+removed.)
 
 # Overriding
 
-To loosen the tolerance for low-C/N₀ work, dispatch the trait on the
+To loosen the tolerance for low-C/N₀ work, dispatch the trait on the (hard-path)
 signal type in your own module:
 
 ```julia
-Tracking.get_bit_edge_or_secondary_code_tolerance(::GPSL5I) = 0.05
+Tracking.get_bit_edge_or_secondary_code_tolerance(::GPSL1C_P) = 0.05
 ```
 
 The override takes effect at the next call to
 `detect_bit_or_secondary_code_sync` — there is no need to rebuild any
 TrackState. The trait is `@inline`'d so the override folds at the
-detector's call site.
+detector's call site. (Overriding it for a soft-detector signal has no effect;
+tune [`get_bit_edge_detection_confidence`](@ref) there instead.)
 """
 @inline get_bit_edge_or_secondary_code_tolerance(::AbstractGNSSSignal) = 0.025
 
@@ -798,12 +973,49 @@ never seed or update `phase_acc`.
 """
 $(SIGNATURES)
 
-Target confidence (one minus the probability of a false bit-edge lock)
-for the GPS L1 C/A soft bit-edge detector [`_detect_bit_edge_cfar`](@ref).
+Whether `signal`'s secondary/overlay code is located with the soft-decision,
+maximum-energy CFAR detector [`_detect_secondary_code_cfar`](@ref) (which reads
+the incremental [`PhaseAccumulators`](@ref)) rather than the hard-decision
+rotation/Hamming sweep [`_secondary_code_search`](@ref).
+
+The soft detector coherently integrates one *full secondary-code period* per bin,
+so it only makes sense while a whole period is a phase-coherent integration
+length. The default therefore enables it for signals with a **short** secondary
+code — `1 < get_secondary_code_length(signal) ≤ 100` — which covers GPS L5I
+(NH10, 10), GPS L5Q (NH20, 20), Galileo E1C (CS25, 25), E5aI (CS20, 20) and E5aQ
+(CS100, 100), whose periods are ≤ 100 ms. GPS L1C-P is deliberately excluded: its
+1800-chip overlay is an 18 s period, far too long to integrate coherently (and
+its long code is not false-lock-prone), so it keeps the hard
+[`_secondary_code_search`](@ref).
+
+Because it locates a periodic overlay, this is mutually exclusive with
+[`uses_soft_bit_edge_detection`](@ref) (which requires *no* secondary code); a
+signal routes to at most one soft detector.
+
+Override per signal type to force the choice, e.g. to disable it:
+
+```julia
+Tracking.uses_soft_secondary_code_detection(::GPSL5I) = false
+```
+
+The result is constant-folded per signal type, so the branch in
+[`_buffer_find_bit`](@ref) compiles away and signals that don't use it never
+seed or update `phase_acc`.
+"""
+@inline uses_soft_secondary_code_detection(signal::AbstractGNSSSignal) =
+    1 < get_secondary_code_length(signal) <= 100
+
+"""
+$(SIGNATURES)
+
+Target confidence (one minus the probability of a false lock) for the
+soft-decision CFAR sync detectors — the GPS L1 C/A bit-edge detector
+[`_detect_bit_edge_cfar`](@ref) and the secondary-code detector
+[`_detect_secondary_code_cfar`](@ref) both read it.
 
 Default `0.999`: the detector keeps integrating primary-code blocks until
-the maximum-energy phase beats its closest competitor with this
-confidence, so a clean signal locks in as little as two bits (~40 ms)
+the maximum-energy hypothesis beats its closest competitor with this
+confidence, so a clean signal locks in as little as two bins
 while a noisy one self-paces to as long as it takes. Lower it to lock
 faster at the cost of more false locks; raise it to be more conservative.
 
@@ -935,11 +1147,14 @@ function _buffer_find_bit(
     code_block_buffer = (bit_buffer.code_block_buffer << 1) + B(real(prompt) > 0)
     code_block_buffer_length = bit_buffer.code_block_buffer_length + 1
 
-    # Signals that detect the bit edge from soft prompts (GPS L1 C/A) fold
-    # each block into the per-phase accumulators and run the maximum-energy
-    # CFAR detector; everything else stays on the hard-decision sliding-window
-    # path. The branch folds at compile time per signal type, so non-soft
-    # signals never update `phase_acc`.
+    # Signals that detect the sync point from soft prompts fold each block into
+    # the per-hypothesis accumulators and run a maximum-energy CFAR detector:
+    # GPS L1 C/A over bit-edge phases, and short-secondary-code signals (GPS
+    # L5I/L5Q, Galileo E1C/E5aI/E5aQ) over overlay rotations. Everything else
+    # stays on the hard-decision sliding-window path. Both soft branches share
+    # the single `phase_acc` buffer (a signal is at most one of them). The
+    # branch folds at compile time per signal type, so non-soft signals never
+    # touch `phase_acc`.
     phase_acc = bit_buffer.phase_acc
     if uses_soft_bit_edge_detection(signal)
         blocks_per_bit = num_code_blocks_that_form_a_bit
@@ -954,6 +1169,24 @@ function _buffer_find_bit(
         sync = _detect_bit_edge_cfar(
             phase_acc,
             blocks_per_bit,
+            get_bit_edge_detection_confidence(signal),
+            code_block_buffer_length,
+        )
+    elseif uses_soft_secondary_code_detection(signal)
+        secondary_code_length = get_secondary_code_length(signal)
+        _is_seeded(phase_acc, secondary_code_length) ||
+            _seed_phase_accumulators!(phase_acc, secondary_code_length)
+        _update_secondary_accumulators!(
+            phase_acc,
+            ComplexF64(prompt),
+            code_block_buffer_length - 1,
+            secondary_code_length,
+            signal,
+            prn,
+        )
+        sync = _detect_secondary_code_cfar(
+            phase_acc,
+            secondary_code_length,
             get_bit_edge_detection_confidence(signal),
             code_block_buffer_length,
         )

--- a/src/gps/l1c_p.jl
+++ b/src/gps/l1c_p.jl
@@ -56,3 +56,11 @@ end
 # `BitIntegers.@define_integers 1800` and is what `BitBuffer{B}` carries
 # for L1C-P throughout the tracker.
 @inline get_code_block_buffer_type(::GPSL1C_P) = UInt1800
+
+# L1C-P keeps the hard-decision rotation sweep: its 1800-chip / 18 s overlay is
+# far too long to integrate coherently per bin (the soft CFAR detector's model),
+# and a 1800-chip code at the 45-error budget is not false-lock-prone anyway.
+# The `uses_soft_secondary_code_detection` default already excludes it (N = 1800
+# exceeds the 100-chip cap); this makes the intent explicit and keeps L1C-P on
+# the hard path even if that default cap were ever widened.
+@inline uses_soft_secondary_code_detection(::GPSL1C_P) = false

--- a/test/bit_buffer.jl
+++ b/test/bit_buffer.jl
@@ -2,7 +2,8 @@ module BitBufferTest
 
 using Test: @test, @testset, @inferred, @test_throws
 using Random: MersenneTwister
-using GNSSSignals: GPSL1CA
+using GNSSSignals:
+    GPSL1CA, GPSL5I, get_secondary_code, secondary_value, get_secondary_code_length
 using Tracking:
     BitBuffer,
     buffer,
@@ -13,9 +14,13 @@ using Tracking:
     PhaseAccumulators,
     _norm_quantile,
     _t_quantile,
+    _cfar_decide,
     _detect_bit_edge_cfar,
+    _detect_secondary_code_cfar,
     _seed_phase_accumulators!,
-    _update_phase_accumulators!
+    _update_phase_accumulators!,
+    _update_secondary_accumulators!,
+    _secondary_code_search
 
 @testset "SyncResult" begin
     r = @inferred SyncResult(false, 0, Int8(0))
@@ -225,6 +230,194 @@ end
             end
         end
         @test !found
+    end
+end
+
+@testset "_cfar_decide" begin
+    # The shared CFAR decision core: peak vs. runner-up, Welford noise scale,
+    # Student-t threshold. `period` is the bin length = hypothesis count.
+    period = 5
+
+    @testset "Needs two bins on some hypothesis" begin
+        # num_blocks < 2 * period ⇒ no runner-up can exist yet.
+        mean = [10.0, 1.0, 1.0, 1.0, 1.0]
+        m2 = zeros(5)
+        @test _cfar_decide(mean, m2, 2 * period - 1, period, 0.999) == (false, -1, 0)
+    end
+
+    @testset "Noiseless separation locks at the peak" begin
+        mean = [10.0, 1.0, 1.0, 1.0, 1.0]
+        m2 = zeros(5)                              # zero variance ⇒ z = Inf
+        accepted, peak, count = _cfar_decide(mean, m2, 2 * period, period, 0.999)
+        @test accepted
+        @test peak == 0                            # hypothesis 0 (0-based) is the peak
+        @test count == 2                           # div(10 - 0, 5)
+    end
+
+    @testset "No separation never locks" begin
+        mean = fill(5.0, 5)                         # every hypothesis equal
+        m2 = zeros(5)
+        accepted, _, _ = _cfar_decide(mean, m2, 2 * period, period, 0.999)
+        @test !accepted
+    end
+
+    @testset "A large peak variance suppresses the lock" begin
+        # Same energy gap, but the peak's own bin-to-bin spread is huge, so the
+        # z-score stays below threshold and it does not lock.
+        mean = [10.0, 1.0, 1.0, 1.0, 1.0]
+        quiet = zeros(5)
+        loud = [1.0e6, 0.0, 0.0, 0.0, 0.0]         # M₂ only on the peak
+        @test _cfar_decide(mean, quiet, 2 * period, period, 0.999)[1]
+        @test !_cfar_decide(mean, loud, 2 * period, period, 0.999)[1]
+    end
+end
+
+# --- Soft secondary-code CFAR detector (GPS L5I NH10 and friends) ------------
+
+# The ±1 secondary chips in time order for `signal`/`prn`.
+_secondary_chips(signal, prn) = [
+    Int(secondary_value(get_secondary_code(signal), prn, k)) for
+    k = 0:(get_secondary_code_length(signal)-1)
+]
+
+# NH10 packed newest-first, as the hard detector references it (see l5.jl).
+_packed_l5i() = UInt32(0x035)
+
+# Build a prompt stream for a secondary-coded signal: block `i` (0-based) carries
+# secondary chip `(i + start_chip) % N` times a per-period data symbol (constant
+# over each period, flipped pseudo-randomly at period boundaries) times `amp`,
+# plus optional complex Gaussian noise.
+function _secondary_stream(
+    signal,
+    prn,
+    nblocks;
+    start_chip = 0,
+    amp = 5.0,
+    noise = 0.0,
+    seed = 1,
+)
+    N = get_secondary_code_length(signal)
+    chips = _secondary_chips(signal, prn)
+    rng = MersenneTwister(seed)
+    data = 1
+    prompts = ComplexF64[]
+    for i = 0:(nblocks-1)
+        chip = mod(i + start_chip, N)
+        chip == 0 && (data = rand(rng, (-1, 1)))
+        p = ComplexF64(amp * data * chips[chip+1])
+        noise > 0 && (p += noise * complex(randn(rng), randn(rng)))
+        push!(prompts, p)
+    end
+    prompts
+end
+
+# Fold a prompt stream into fresh secondary accumulators (mirrors what
+# `_buffer_find_bit` does) and run the detector after each block. `upto = 0`
+# returns the 1-based block index of the first lock (0 if never); otherwise it
+# returns the SyncResult after exactly `upto` blocks.
+function _secondary_detect_over(prompts, signal, prn, confidence; upto = 0)
+    N = get_secondary_code_length(signal)
+    accumulators = PhaseAccumulators()
+    _seed_phase_accumulators!(accumulators, N)
+    local result
+    for (block_number, prompt) in enumerate(prompts)
+        _update_secondary_accumulators!(
+            accumulators,
+            ComplexF64(prompt),
+            block_number - 1,
+            N,
+            signal,
+            prn,
+        )
+        result = _detect_secondary_code_cfar(accumulators, N, confidence, block_number)
+        upto == 0 && result.found && return block_number
+        upto == block_number && return result
+    end
+    return upto == 0 ? 0 : result
+end
+
+@testset "_update_secondary_accumulators!" begin
+    # Feed two clean NH10 periods aligned to chip 0. The correct rotation wipes
+    # the overlay so its bin sums coherently (energy ≈ (N·amp)²); every other
+    # rotation straddles the fixed NH transitions and loses energy.
+    signal = GPSL5I()
+    prn = 1
+    N = get_secondary_code_length(signal)          # 10
+    amp = 5.0
+    accumulators = PhaseAccumulators()
+    _seed_phase_accumulators!(accumulators, N)
+    prompts = _secondary_stream(signal, prn, 2N; amp)   # data constant per period
+    for (i, p) in enumerate(prompts)
+        _update_secondary_accumulators!(accumulators, ComplexF64(p), i - 1, N, signal, prn)
+    end
+    energies = accumulators.mean_bin_energy
+    peak = argmax(energies) - 1                    # 0-based winning rotation
+    # Aligned to chip 0 ⇒ the winning rotation is 0.
+    @test peak == 0
+    @test energies[peak+1] ≈ (N * amp)^2
+    # The peak dwarfs every competitor by a wide margin.
+    runner_up = maximum(energies[2:end])
+    @test energies[1] > 20 * runner_up
+end
+
+@testset "_detect_secondary_code_cfar" begin
+    signal = GPSL5I()
+    prn = 1
+    N = get_secondary_code_length(signal)          # 10
+
+    @testset "Needs at least two periods" begin
+        prompts = _secondary_stream(signal, prn, 2N - 1; amp = 8.0)
+        @test _secondary_detect_over(prompts, signal, prn, 0.999; upto = 2N - 1).found ==
+              false
+    end
+
+    @testset "Clean lock fires at the period boundary with phase 0" begin
+        for start_chip = 0:(N-1)
+            prompts = _secondary_stream(signal, prn, 4N; start_chip, amp = 8.0)
+            synced = _secondary_detect_over(prompts, signal, prn, 0.999)
+            @test synced >= 2N                     # never before two periods
+            # Fires only at a true NH10 boundary: the just-processed block is the
+            # last (chip N-1) of the winning rotation's period.
+            @test (start_chip + synced - 1) % N == N - 1
+            res = _secondary_detect_over(prompts, signal, prn, 0.999; upto = synced)
+            @test res.found
+            @test res.phase == 0                   # upcoming integration at chip 0
+        end
+    end
+
+    @testset "Polarity follows the winning period's sign" begin
+        chips = _secondary_chips(signal, prn)
+        # A period that is exactly +overlay locks at +1; the negated overlay at −1.
+        pos = ComplexF64[8.0 * c for c in chips]
+        neg = ComplexF64[-8.0 * c for c in chips]
+        @test _secondary_detect_over(vcat(pos, pos, pos), signal, prn, 0.999; upto = 3N).polarity ==
+              +1
+        @test _secondary_detect_over(vcat(neg, neg, neg), signal, prn, 0.999; upto = 3N).polarity ==
+              -1
+    end
+
+    @testset "No false lock on pure noise (the TEX-CUP PRN 8 symptom)" begin
+        # The hard sign-template match (NH10, exact-match budget) accepts a random
+        # 10-bit window whenever noise happens to align it with one of the ~20
+        # rotation×polarity templates — a ~2 % per-window chance that accumulates
+        # into false locks over a long pre-lock stretch. The soft CFAR detector,
+        # feeding on the same noise, requires a significant energy gap over many
+        # periods, so it does not lock on noise.
+        hard_false_locks = 0
+        soft_locks = 0
+        for seed = 1:200
+            rng = MersenneTwister(1000 + seed)
+            # Soft: 40 blocks of pure complex-Gaussian noise (no signal).
+            noise = ComplexF64[complex(randn(rng), randn(rng)) for _ = 1:4N]
+            _secondary_detect_over(noise, signal, prn, 0.999) != 0 && (soft_locks += 1)
+            # Hard: a random 10-bit sign window through the rotation sweep.
+            window = rand(rng, UInt32) & UInt32((1 << N) - 1)
+            _secondary_code_search(window, _packed_l5i(), N, 0).found &&
+                (hard_false_locks += 1)
+        end
+        @test soft_locks == 0
+        # Sanity: the hard exact-match detector really is noise-prone here.
+        @test hard_false_locks > 0
     end
 end
 

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -175,14 +175,16 @@ end
 
 # GPS L5I secondary-code (NH10) sync and phase recovery.
 #
-# The L5I detector runs the generic rotation search over NH10, so it locks
-# after a single NH10 period (10 blocks) in the worst case — regardless of
-# where in the NH10 cycle tracking started — and recovers the true
+# The L5I detector runs the soft, maximum-energy CFAR rotation search over NH10
+# (`_detect_secondary_code_cfar`): it accumulates per-rotation overlay-wiped
+# period energies, needs at least two NH10 periods before it can decide, and
+# fires only at the winning rotation's own period boundary — recovering the true
 # secondary-code phase. This test starts the signal at every NH10 phase and
 # checks that:
-#   * sync fires exactly at the 10th block (1x the secondary period), and
-#   * `code_phase` is anchored to the *upcoming* integration's NH10 chip,
-#     which — after exactly 10 blocks — equals the starting chip.
+#   * sync never fires before two NH10 periods (20 blocks),
+#   * it fires on a true NH10 boundary (the just-completed block is chip 9), so
+#     the recovered phase is the actual absolute alignment, and
+#   * `code_phase` is anchored to the upcoming integration's chip 0.
 @testset "GPS L5I secondary-code sync and phase recovery" begin
     gpsl5 = GPSL5I()
     prn = 1
@@ -218,20 +220,29 @@ end
             end
         end
 
-        # Sync locks after exactly one NH10 period (10 blocks), no matter the
-        # starting phase — the rotation search does not wait for a boundary.
-        @test synced_at_block == secondary_code_length
+        # The soft maximum-energy CFAR detector needs at least two completed NH10
+        # periods before a runner-up (and thus a decision) exists, so it never
+        # locks before the 20th block.
+        @test synced_at_block >= 2 * secondary_code_length
 
-        # `code_phase` is anchored to the upcoming integration's NH10 chip.
-        # After 10 blocks the upcoming chip equals the starting chip, so the
-        # phase lands at `start_secondary_chip x primary_code_length` within
-        # the widened (primary x secondary) wrap window. The embedded-LUT
+        # It fires only at the winning rotation's own period boundary, i.e. when
+        # the just-completed block is the last NH10 chip (absolute chip 9), so the
+        # *upcoming* integration starts a fresh NH10 period (absolute chip 0). The
+        # generated block `synced_at_block` carries absolute chip
+        # `(start_secondary_chip + synced_at_block - 1) % 10`; boundary firing
+        # demands that be chip 9 — this is the load-bearing check that the true
+        # secondary-code phase was recovered (the absolute alignment), not merely
+        # that *some* lock happened.
+        @test (start_secondary_chip + synced_at_block - 1) % secondary_code_length ==
+              secondary_code_length - 1
+
+        # Because it fires at that true boundary, `code_phase` is anchored to the
+        # upcoming integration's chip 0 (`SyncResult.phase == 0`). The embedded-LUT
         # generator's fixed-point DDA (~2^-30 chip) lands the phase within ~1e-6
-        # chip of the integer boundary rather than exactly on it, so compare the
-        # circular distance within a sub-sample tolerance.
+        # chip of the integer boundary, so compare the circular distance within a
+        # sub-sample tolerance.
         let wrap = primary_code_length * secondary_code_length,
-            expected = start_secondary_chip * primary_code_length,
-            d = mod(synced_code_phase - expected, wrap)
+            d = mod(synced_code_phase, wrap)
 
             @test min(d, wrap - d) < 1e-3
         end
@@ -278,15 +289,14 @@ end
 
 # GPS L5I post-sync data-bit decoding (issue #125).
 #
-# The NH10 rotation search locks at *any* secondary chip, so the post-sync bit
-# decoder must (a) wipe the NH code from each prompt — at the default 1-block
-# integration the replica covers a single primary period and has to bake the
-# correct NH chip, otherwise a 10-block "bit" sum collapses to
+# The soft NH10 CFAR search fires on an NH10 = data-bit boundary, so the
+# post-sync bit decoder must (a) wipe the NH code from each prompt — at the
+# default 1-block integration the replica covers a single primary period and has
+# to bake the correct NH chip, otherwise a 10-block "bit" sum collapses to
 # `data x Σ(NH signs)` and loses ~14 dB of decision margin — and (b) start its
-# accumulation grid at the recovered secondary phase rather than at the lock
-# instant, so bits are emitted on the NH10 / data-bit boundary. This decodes a
-# known bit sequence through boundary and non-boundary locks at both the default
-# 1-block and a 10-block coherent integration.
+# accumulation grid on that boundary, so bits are emitted on the NH10 / data-bit
+# boundary. This decodes a known bit sequence at several starting chips and at
+# both the default 1-block and a 10-block coherent integration.
 #
 # Note on polarity: locking onto a periodic secondary code carries an inherent
 # ±1 data-polarity ambiguity (the rotation search cannot tell a data "1" period
@@ -344,31 +354,48 @@ end
 
         @test has_bit_or_secondary_code_been_found(track_state)
 
-        # The pre-sync rotation search consumes the first NH10 period (the lead
-        # of the lock data bit); decoding then begins with the remainder of that
-        # same data bit (`data_bits[2]`) and proceeds bit-by-bit. The trailing
-        # data bit may be left mid-integration, so compare the bits that
-        # completed.
+        # The soft CFAR detector is deterministic on this noiseless signal, so the
+        # exact first decoded bit is derivable (no "matches at some offset"
+        # slack). `_cfar_decide` needs ≥ 2 NH10 periods before a runner-up exists,
+        # then `_detect_secondary_code_cfar` fires at the winning rotation's own
+        # period boundary. The winning rotation is `d* = mod(N − start, N)` (the
+        # one whose overlay wipe is coherent), so the lock lands at the smallest
+        # block count `≥ 2N` with `count % N == d*`; the upcoming integration then
+        # starts at absolute chip 0, i.e. data-bit `div(start + lock, N)`.
+        N = secondary_code_length
+        d_star = mod(N - start_secondary_chip, N)
+        lock_block = let m = 2N
+            while m % N != d_star
+                m += 1
+            end
+            m
+        end
+        first_bit = div(start_secondary_chip + lock_block, N) + 1  # 1-based data-bit index
+        expected_from_lock = data_bits[first_bit:end]              # decoded run, in order
+
         soft_bits = get_soft_bits(track_state)
         decoded_bits = [Int(s > 0) for s in soft_bits]
         n_decoded = length(decoded_bits)
-        expected = data_bits[2:(1+n_decoded)]
 
-        # At least every full data bit but the last must have decoded.
-        @test n_decoded >= length(data_bits) - 2
-        # Clean, boundary-aligned decode — up to the global polarity ambiguity.
+        # Every bit from the lock boundary to the end decodes, except at most the
+        # final one (its integration can still be in flight when `track` returns).
+        @test n_decoded in (length(expected_from_lock) - 1, length(expected_from_lock))
+        # Exact, boundary-aligned decode at the derived offset — up to the single
+        # global ±1 polarity ambiguity inherent to secondary-code lock.
+        expected = expected_from_lock[1:n_decoded]
         @test decoded_bits == expected || decoded_bits == 1 .- expected
         # Soft-bit signs are internally consistent with the hard bits.
         @test all((soft_bits .> 0) .== (decoded_bits .== 1))
-        # The NH code is wiped: every *full* post-sync bit (all but a possibly
-        # truncated first one, when the lock lands mid data bit) sums coherently.
-        # A full bit spans `secondary_code_length` primary blocks; the soft bit
-        # sums one unit-magnitude prompt per `preferred_blocks`-block integration,
-        # so its magnitude is ≈ `secondary_code_length / preferred_blocks`. Left
-        # in, the NH signs would nearly cancel (≈2 for NH10 at 1-block), so this
-        # half-of-nominal floor is the load-bearing assertion of the fix.
+        # The NH code is wiped: every post-sync bit sums coherently. A full bit
+        # spans `secondary_code_length` primary blocks; the soft bit sums one
+        # unit-magnitude prompt per `preferred_blocks`-block integration, so its
+        # magnitude is ≈ `secondary_code_length / preferred_blocks`. Because the
+        # detector fires exactly on the data-bit boundary there is no truncated
+        # first bit — *every* emitted bit is full. Left in, the NH signs would
+        # nearly cancel (≈2 for NH10 at 1-block), so this near-nominal floor is
+        # the load-bearing assertion of the fix.
         full_bit_magnitude = secondary_code_length / preferred_blocks
-        @test all(>(0.5 * full_bit_magnitude), abs.(soft_bits[2:end]))
+        @test all(>(0.9 * full_bit_magnitude), abs.(soft_bits))
     end
 end
 

--- a/test/galileo_e1c.jl
+++ b/test/galileo_e1c.jl
@@ -62,6 +62,9 @@ rotl(x::T, r, N) where {T} =
 
     # 25-block CS25 window fits in a UInt32.
     @test @inferred(get_code_block_buffer_type(galileo_e1c)) === UInt32
+
+    # CS25 (25 chips) is short enough for the soft, CFAR secondary-code detector.
+    @test Tracking.uses_soft_secondary_code_detection(galileo_e1c) == true
 end
 
 end

--- a/test/galileo_e5a.jl
+++ b/test/galileo_e5a.jl
@@ -53,6 +53,9 @@ rotl(x::T, r, N) where {T} =
 
     # 20-block CS20 window fits in a UInt32.
     @test @inferred(get_code_block_buffer_type(e5a_i)) === UInt32
+
+    # CS20 (20 chips) is short enough for the soft, CFAR secondary-code detector.
+    @test Tracking.uses_soft_secondary_code_detection(e5a_i) == true
 end
 
 @testset "Galileo E5a-Q" begin
@@ -91,6 +94,9 @@ end
 
     # 100-block CS100 window needs UInt128.
     @test @inferred(get_code_block_buffer_type(e5a_q)) === UInt128
+
+    # CS100 (100 chips) is at the soft CFAR secondary-code detector's length cap.
+    @test Tracking.uses_soft_secondary_code_detection(e5a_q) == true
 end
 
 end

--- a/test/gps_l1c_p.jl
+++ b/test/gps_l1c_p.jl
@@ -22,6 +22,11 @@ const L1C_P_MAX_ERRORS =
 @testset "GPS L1C-P" begin
     gpsl1c_p = GPSL1C_P()
 
+    # L1C-P's 1800-chip / 18 s overlay is far too long to integrate coherently
+    # per bin, so it stays on the hard-decision rotation sweep, not the soft
+    # CFAR secondary-code detector.
+    @test Tracking.uses_soft_secondary_code_detection(gpsl1c_p) == false
+
     # Below the 1800-block horizon, the L1C-P detector returns `found =
     # false` without running the sweep. Above it, the sweep runs against
     # the per-PRN overlay.

--- a/test/gps_l5.jl
+++ b/test/gps_l5.jl
@@ -52,6 +52,9 @@ rotl(x::T, r, N) where {T} =
     # 20-block sync window (2 × NH10) fits in a UInt32.
     @test @inferred(get_code_block_buffer_type(gpsl5)) === UInt32
 
+    # NH10 (10 chips) is short enough for the soft, CFAR secondary-code detector.
+    @test Tracking.uses_soft_secondary_code_detection(gpsl5) == true
+
     @testset "Hamming tolerance" begin
         # 2.5 % ceiling over a 10-block window discretizes to "exact match"
         # (floor(0.025 × 10) = 0) — any single bit-flip rejects.
@@ -111,6 +114,9 @@ end
 
     # 20-block NH20 window fits in a UInt32.
     @test @inferred(get_code_block_buffer_type(gpsl5q)) === UInt32
+
+    # NH20 (20 chips) is short enough for the soft, CFAR secondary-code detector.
+    @test Tracking.uses_soft_secondary_code_detection(gpsl5q) == true
 end
 
 end

--- a/test/track_in_place.jl
+++ b/test/track_in_place.jl
@@ -3,7 +3,8 @@ module TrackInPlaceTest
 using Test: @test, @testset
 using Random: MersenneTwister
 using Unitful: Hz
-using GNSSSignals: GPSL1CA, gen_code, get_code_center_frequency_ratio, get_code_frequency
+using GNSSSignals:
+    GPSL1CA, GPSL5I, gen_code, get_code_center_frequency_ratio, get_code_frequency
 
 using Tracking:
     TrackedSat,
@@ -222,6 +223,38 @@ if VERSION >= v"1.11"
         # threshold are actually scored on every block (see above).
         @test measure_track_alloc(200) == 0
         @test measure_track_alloc(900) == 0
+    end
+
+    # Same guard for the soft *secondary-code* detector (GPS L5I: NH10, 10
+    # blocks/period), which shares `_cfar_decide` / `_t_quantile` but has its own
+    # per-rotation accumulator update `_update_secondary_accumulators!` and
+    # front-end `_detect_secondary_code_cfar`. A `rand` signal carries no real
+    # NH10 structure, so the soft detector never locks (it rejects noise) and the
+    # tracker stays in the pre-sync search, scoring every block past `2 × N`. Both
+    # lengths are past `2 × 10`, so the scoring path (overlay-wiped energy folding,
+    # Welford update, peak/runner-up scan, Student-t threshold) runs on every
+    # block — where an allocation would otherwise hide. `dof = peak_bin_count − 1`
+    # sweeps ≈ 9…19 (200) and ≈ 44…89 (900), the same stretches that caught the
+    # allocating quantile for L1 C/A above.
+    @testset "track! is allocation-free during acquisition (pre-sync secondary-code search)" begin
+        sampling_frequency = 25e6Hz
+        samples_per_block = 25000              # 1 ms GPS L5I code period @ 25 MHz
+        function measure_track_alloc_l5i(nblocks)
+            gpsl5i = GPSL5I()
+            track_state = TrackState(gpsl5i, [TrackedSat(gpsl5i, 1, 10.5, 1000.0Hz)])
+            dc = CPUDownconvertAndCorrelator()
+            signal = rand(MersenneTwister(nblocks), ComplexF32, samples_per_block * nblocks)
+            call() = track!(
+                signal,
+                track_state,
+                sampling_frequency;
+                downconvert_and_correlator = dc,
+            )
+            call()                             # warmup: seat buffers, compile
+            @allocated call()
+        end
+        @test measure_track_alloc_l5i(200) == 0
+        @test measure_track_alloc_l5i(900) == 0
     end
 end
 


### PR DESCRIPTION
Closes #149.

## Summary

Routes short-period secondary/overlay codes (GPS L5I/L5Q, Galileo E1C/E5aI/E5aQ)
through a **soft, maximum-energy CFAR detector** — the direct analog of the GPS
L1 C/A bit-edge detector `_detect_bit_edge_cfar` — instead of the hard-decision
sign-bit rotation/Hamming sweep (`_secondary_code_search`). This makes
secondary-code sync consistent with the L1 C/A path (the ask in #149) and, more
importantly, removes a real false-lock failure mode.

**Why:** the hard rotation sweep matches packed prompt *signs* against the known
overlay and accepts any rotation within a fixed error budget. On a short code
this false-locks on noise — NH10 is only 10 chips, so ~20 rotation×polarity
templates give a ~2 % random-match per window, and a marginal (re)acquisition can
lock the secondary code at the wrong rotation. That mislocks the code phase by an
integer number of primary-code periods, i.e. an integer-millisecond pseudorange
bias, which passes every downstream sanity check (bits still decode) yet corrupts
ranging. The soft detector instead accumulates per-rotation, overlay-wiped,
period-coherent energy and only locks when the peak beats its runner-up with a
CFAR confidence — so it self-paces with C/N₀ and rejects noise-driven locks.

## What changed

- **Factor `_cfar_decide`** out of `_detect_bit_edge_cfar`: the shared decision
  core (peak vs. runner-up, Welford bin-to-bin variance, Bonferroni-split
  Student-t threshold). GPS L1 C/A behaviour is unchanged (regression-safe).
- **Add the secondary-code front-end**: `_update_secondary_accumulators!`
  (per-rotation overlay-wiped period-coherent energy) and
  `_detect_secondary_code_cfar`. It **reuses `PhaseAccumulators`** and the
  existing `BitBuffer.phase_acc` field — no new struct, no constructor churn (a
  signal uses at most one soft detector). It fires only at the winning rotation's
  own period boundary, so the upcoming integration starts at secondary chip 0
  (`SyncResult.phase == 0`), consistent with the existing code-phase snap
  (`_snap_code_phase_from_synced_signal`).
- **New trait `uses_soft_secondary_code_detection`** (`1 < secondary_code_length
  ≤ 100`) selects the path, parallel to `uses_soft_bit_edge_detection`;
  `get_bit_edge_detection_confidence` is reused as its confidence target.
- **GPS L1C-P stays on the hard detector** (explicit override): its 1800-chip /
  18 s overlay is far too long to integrate coherently per bin, and a 1800-chip
  code at the existing error budget is not false-lock-prone.

Signals affected (all others unchanged):

| Signal | Before | After |
|:--|:--|:--|
| GPS L5I (NH10, 10) | hard sweep | **soft CFAR** |
| GPS L5Q (NH20, 20) | hard sweep | **soft CFAR** |
| Galileo E1C (CS25, 25) | hard sweep | **soft CFAR** |
| Galileo E5aI (CS20, 20) | hard sweep | **soft CFAR** |
| Galileo E5aQ (CS100, 100) | hard sweep | **soft CFAR** |
| GPS L1C-P (1800) | hard sweep | hard sweep (unchanged) |
| GPS L1 C/A | soft CFAR | soft CFAR (unchanged) |

## Validation (TEX-CUP `ntlab.bin`, GPS L5I, INT16 backend, PVT @ 100 ms)

With the **unmodified** (hard) detector, GPS L5I **PRN 8** false-locks its NH10 by
~2 primary-code periods (a ~600 km pseudorange bias). Tracking only GPS L5I
(5 SVs, GDOP ≈ 3 while all up), that single bias drags the least-squares fix
**≈ 395 km** off ground truth. With the soft detector — same satellites, only
PRN 8's NH10 lock differs — the fix is **≈ 3 m** (median 3.2 m, residual RMS
~1 m), with **zero code-sync outliers** across the PVT-capable window; the other
four SVs are bit-identical between the two runs, and satellite availability is
unchanged (no tracking regression). Fusing Galileo E5aI as well (12 SVs) gives
**GDOP ≈ 2.0, ~4 m horizontal, ~3 m residuals**.

## Testing

- Full suite passes (1825 assertions), including a **false-lock-on-noise
  regression** (a noise-dominated NH10 stream where the hard sweep locks but the
  soft detector never does), unit tests for `_cfar_decide` /
  `_update_secondary_accumulators!` / `_detect_secondary_code_cfar`, rewritten
  L5I integration tests (boundary-firing, phase 0, clean post-sync decode), and
  the trait on all affected signals.
- **Allocation-free** on the pre-sync hot path (verified by the existing
  `track_in_place.jl` guards; the accumulator update is 0 B and the shared
  `_t_quantile` is allocation-free as of 4.1.2).
- Formatted with the pinned JuliaFormatter (2.8.5).

## Out of scope

During validation I hit an intermittent freeze in **GNSSReceiver's** threaded
reacquisition (`try_to_reacquire_lost_satellites` → full-grid `acquire!`) when a
satellite stays blocked — a multi-threading livelock, reproducible on the
*unmodified* receiver and absent single-threaded. It is unrelated to this change
(not the detector, not the PVT solver) and belongs in a separate GNSSReceiver
issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
