### PR TITLE
fix(track): keep the bit grid and the overlay anchor aligned across a mid-fold sync

### DIFF
--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -1261,6 +1261,45 @@ function _buffer_find_bit(
     )
 end
 
+"""
+$(SIGNATURES)
+
+Walk a just-synced `bit_buffer`'s `secondary_phase` forward by
+`num_code_blocks` primary-code blocks (modulo the secondary-code length). No-op
+for signals without a secondary code, where the field is unused.
+
+`secondary_phase` is the secondary chip the **upcoming** integration aligns to,
+and it is read exactly once: by the code-phase snap
+([`_snap_code_phase_from_synced_signal`](@ref)), which runs after the whole
+chunk has been folded. The detector reports it for the block right after the
+syncing record, so every further record folded in the same chunk — the ones
+`_apply_correlator_output` marks `correlated_pre_sync`, correlated with the
+pre-sync (un-wiped) replica — moves that anchor along by the blocks it covers.
+Without this the snap anchors the replica `num_code_blocks` chips early, the
+post-sync replica bakes the wrong overlay chip into every block, and the
+coherent bit sum collapses to a fraction of its length — the secondary-code
+sibling of the bit-grid slip in issue #219.
+"""
+@inline function _advance_secondary_phase(
+    signal::AbstractGNSSSignal,
+    bit_buffer::BitBuffer{B},
+    num_code_blocks::Integer,
+) where {B<:Unsigned}
+    secondary_code_length = get_secondary_code_length(signal)
+    secondary_code_length > 1 || return bit_buffer
+    BitBuffer{B}(
+        bit_buffer.code_block_buffer,
+        bit_buffer.code_block_buffer_length,
+        bit_buffer.found,
+        mod(bit_buffer.secondary_phase + Int(num_code_blocks), secondary_code_length),
+        bit_buffer.polarity,
+        bit_buffer.prompt_accumulator,
+        bit_buffer.prompt_accumulator_integrated_code_blocks,
+        bit_buffer.soft_bits,
+        bit_buffer.phase_acc,
+    )
+end
+
 function reset(bit_buffer::BitBuffer{B}) where {B<:Unsigned}
     empty!(bit_buffer.soft_bits)
     BitBuffer{B}(

--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -453,6 +453,13 @@ end
         bit_block_count,
         drop_prompt ? zero(bit_prompt) : bit_prompt,
     )
+    # Such a record also moves the secondary-code anchor: the code-phase snap
+    # runs after this fold and aligns the *upcoming* integration to
+    # `bit_buffer.secondary_phase`, which the detector reported for the block
+    # right after the syncing record.
+    if correlated_pre_sync
+        bit_buffer = _advance_secondary_phase(signal, bit_buffer, bit_block_count)
+    end
     new_signal = TrackedSignal(
         tracked_signal;
         last_fully_integrated_filtered_prompt = prompt,

--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -398,19 +398,25 @@ end
 # the record's true integration time, so it only switches when the integration
 # actually lengthened — not already on the fold where sync was detected but the
 # records were still single-block (see `_process_estimator_driver_signal`).
-# `skip_bit_buffer = true` applies everything EXCEPT the bit-buffer update.
-# Used for records that follow a bit/secondary sync detected earlier in the
-# same fold: those records were correlated with pre-sync replicas (no
-# secondary-code wipe-off), so accumulating them as if wiped would feed
-# sign-corrupted prompts into the first post-sync bits. They re-enter cleanly
-# next chunk, correlated at the snapped phase with the overlay in the replica.
+# `correlated_pre_sync = true` marks a record that follows a bit/secondary sync
+# detected earlier in the same fold, i.e. one that was correlated with a
+# pre-sync replica. Its *prompt* is only unusable where sync changed the replica
+# — the secondary-code wipe-off, whose absence would feed sign-corrupted prompts
+# into the first post-sync bits — so it is dropped from the coherent bit
+# accumulation for secondary-coded signals only; a signal without a secondary
+# code (GPS L1 C/A) correlates identically either side of the sync instant and
+# keeps its prompt. The code blocks such a record covers are real either way and
+# are always credited to the accumulator's block count: dropping the count
+# slides the bit window one block off the navigation-bit grid for the rest of
+# the run, which costs ~0.9 dB of bit-decision SNR and makes every coherent
+# window that follows the grid straddle a bit flip (issue #219).
 @inline function _apply_correlator_output(
     tracked_signal::TrackedSignal,
     output::CorrelatorOutput,
     prn::Integer,
     sampling_frequency,
     driver_carrier_phase::Real = 0.0;
-    skip_bit_buffer::Bool = false,
+    correlated_pre_sync::Bool = false,
 )
     signal = tracked_signal.signal
     normalized_correlator =
@@ -436,9 +442,17 @@ end
     # `buffer`, so a quadrature component's data lands on the real axis it is
     # decided on. No-op for the driver and for co-phased pairs.
     bit_prompt = prompt * _carrier_phase_derotation(driver_carrier_phase, signal)
-    bit_buffer =
-        skip_bit_buffer ? tracked_signal.bit_buffer :
-        buffer(signal, prn, tracked_signal.bit_buffer, bit_block_count, bit_prompt)
+    # Keep a pre-sync-correlated record's prompt out of the coherent sum where
+    # the sync changed the replica under it (secondary-code wipe-off), but
+    # always let it advance the accumulator's block count — see above.
+    drop_prompt = correlated_pre_sync && get_secondary_code_length(signal) > 1
+    bit_buffer = buffer(
+        signal,
+        prn,
+        tracked_signal.bit_buffer,
+        bit_block_count,
+        drop_prompt ? zero(bit_prompt) : bit_prompt,
+    )
     new_signal = TrackedSignal(
         tracked_signal;
         last_fully_integrated_filtered_prompt = prompt,
@@ -488,8 +502,9 @@ end
         # Per-record integration time — the block time, NOT the chunk time.
         integration_time = output.integrated_samples / sampling_frequency
         # A record that follows a sync detected earlier in THIS fold was
-        # correlated with pre-sync replicas — keep it out of the bit buffer
-        # (see `_apply_correlator_output`).
+        # correlated with pre-sync replicas — its blocks still count towards the
+        # bit, only its prompt may have to be dropped (see
+        # `_apply_correlator_output`).
         synced_earlier_in_fold =
             !found_before_fold && has_bit_or_secondary_code_been_found(ts.bit_buffer)
         # The driver de-rotates against itself (offset 0), so the derotation is a
@@ -500,7 +515,7 @@ end
             sat.prn,
             sampling_frequency,
             driver_carrier_phase;
-            skip_bit_buffer = synced_earlier_in_fold,
+            correlated_pre_sync = synced_earlier_in_fold,
         )
 
         # The configured bandwidths are referenced to a one-primary-code-period
@@ -602,7 +617,7 @@ end
                 prn,
                 sampling_frequency,
                 driver_carrier_phase;
-                skip_bit_buffer = synced_earlier_in_fold,
+                correlated_pre_sync = synced_earlier_in_fold,
             ),
         )
     end

--- a/src/vector_pll_and_dll.jl
+++ b/src/vector_pll_and_dll.jl
@@ -298,7 +298,7 @@ end
             sat.prn,
             sampling_frequency,
             driver_carrier_phase;
-            skip_bit_buffer = synced_earlier_in_fold,
+            correlated_pre_sync = synced_earlier_in_fold,
         )
 
         # Same 1/N effective-bandwidth scaling as the conventional estimator —

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -5,6 +5,7 @@ using Unitful: Hz, s
 using GNSSSignals:
     GPSL1CA,
     GPSL5I,
+    GPSL5Q,
     GPSL1C_P,
     gen_code,
     get_code_frequency,
@@ -18,6 +19,9 @@ using Tracking:
     get_code_phase,
     get_num_bits,
     get_soft_bits,
+    get_filtered_prompts,
+    get_last_fully_integrated_filtered_prompt,
+    get_last_fully_integrated_num_code_blocks,
     has_bit_or_secondary_code_been_found,
     set_preferred_num_code_blocks_to_integrate!,
     EarlyPromptLateCorrelator
@@ -449,6 +453,135 @@ end
         # the load-bearing assertion of the fix.
         full_bit_magnitude = secondary_code_length / preferred_blocks
         @test all(>(0.9 * full_bit_magnitude), abs.(soft_bits))
+    end
+end
+
+# Mid-fold secondary-code sync: the overlay anchor must travel with the fold.
+#
+# Same defect as the L1 C/A bit grid above (issue #219), on the secondary-code
+# path. With a `doppler_update_interval` longer than one code period the records
+# behind the syncing one inside its fold were correlated with the pre-sync (not
+# overlay-wiped) replica: their prompt is dropped, but they still advance both
+# the bit accumulator's block count and — because the code-phase snap runs after
+# the fold — the secondary-chip anchor it aligns the upcoming integration to.
+# Leaving the anchor where the detector reported it makes the post-sync replica
+# bake the wrong NH chip into every block, and the coherent NH10 sum collapses
+# from ~10 to ~0–2 (which is also a coin flip on every decoded bit).
+@testset "mid-fold secondary-code sync keeps the overlay anchor aligned" begin
+    gpsl5 = GPSL5I()
+    prn = 1
+    sampling_frequency = 25e6Hz
+    code_frequency = get_code_frequency(gpsl5)
+    primary_code_length = get_code_length(gpsl5)               # 10230 chips
+    secondary_code_length = get_secondary_code_length(gpsl5)   # 10 (NH10)
+    num_samples = round(Int, 25e6 / 1000)                      # 1 ms = one primary block
+    data_bits = [1, 1, 0, 1, 0, 0, 1, 1, 0, 1]
+
+    # Decode the whole run in a single `track` call at the given chunk interval.
+    function decode(doppler_update_interval, start_secondary_chip)
+        total_blocks = secondary_code_length * length(data_bits) - start_secondary_chip
+        signal = ComplexF32.(
+            gen_code(
+                total_blocks * num_samples,
+                gpsl5,
+                prn,
+                sampling_frequency,
+                code_frequency,
+                start_secondary_chip * primary_code_length,
+            ),
+        )
+        for b = 0:(total_blocks-1)
+            data_bit = data_bits[div(start_secondary_chip+b, secondary_code_length)+1]
+            @views signal[(b*num_samples+1):((b+1)*num_samples)] .*=
+                ComplexF32(2 * data_bit - 1)
+        end
+        track_state = TrackState(
+            gpsl5,
+            [TrackedSat(gpsl5, prn, start_secondary_chip * primary_code_length, 0.0Hz)],
+        )
+        get_soft_bits(
+            track(signal, track_state, sampling_frequency; doppler_update_interval),
+        )
+    end
+
+    @testset "start chip $start_secondary_chip" for start_secondary_chip in (0, 3)
+        # One record per fold: no record can trail the syncing one — the
+        # reference decode. (Magnitudes sit a few 1e-4 below the nominal NH10
+        # length, from the code-amplitude normalisation, hence the 0.99 floors.)
+        full_bit = 0.99 * secondary_code_length
+        reference = copy(decode(1e-3s, start_secondary_chip))
+        @test all(>(full_bit), abs.(reference))
+
+        for doppler_update_interval in (3e-3s, 7e-3s)
+            soft_bits = decode(doppler_update_interval, start_secondary_chip)
+            # Same bits, on the same grid, as the one-record-per-fold reference.
+            @test length(soft_bits) == length(reference)
+            @test sign.(soft_bits) == sign.(reference)
+            # Only the bit the sync lands in is short, and only by the prompts
+            # that were dropped — one block each, one such record at both
+            # intervals here. Every later bit is full. A misaligned overlay
+            # would put all of them near 0–2 instead.
+            @test all(>(full_bit), abs.(soft_bits[2:end]))
+            @test abs(soft_bits[1]) > 0.99 * (secondary_code_length - 1)
+        end
+    end
+end
+
+# Mid-fold secondary-code sync on a *pilot* (GPS L5Q, NH20).
+#
+# A pilot carries no navigation data, so the accumulator part of issue #219 does
+# not apply — `buffer` returns early for it. The overlay anchor does, and it hits
+# harder: the overlay is the only thing a pilot locks, and its whole purpose is
+# coherent integration over a full secondary-code period. Anchored to the chip
+# the detector reported for the syncing record — instead of the one the records
+# behind it moved on to — the replica wipes the wrong NH chip and a 20-block
+# coherent sum cancels toward zero instead of reaching the nominal 1. That is not
+# a degraded prompt: the discriminators then see 0/0 and the loop diverges into a
+# NaN Doppler (an `InexactError` out of the correlator's shift arithmetic), so
+# this testset *errors* rather than fails when the anchor is wrong.
+@testset "mid-fold pilot overlay anchor keeps coherent integration intact" begin
+    gpsl5q = GPSL5Q()
+    prn = 1
+    sampling_frequency = 25e6Hz
+    code_frequency = get_code_frequency(gpsl5q)
+    secondary_code_length = get_secondary_code_length(gpsl5q)   # 20 (NH20)
+    num_samples = round(Int, 25e6 / 1000)                       # 1 ms = one primary block
+    # Long enough for the NH20 detector (≥ 2 periods) plus a good run of
+    # full-period coherent integrations afterwards.
+    num_blocks = 240
+    signal = ComplexF32.(
+        gen_code(
+            num_blocks * num_samples,
+            gpsl5q,
+            prn,
+            sampling_frequency,
+            code_frequency,
+            0.0,
+        ),
+    )
+
+    # 1 ms: one record per fold, nothing can trail the syncing record. 3 / 7 ms:
+    # it can, and does.
+    for doppler_update_interval in (1e-3s, 3e-3s, 7e-3s)
+        track_state = TrackState(gpsl5q, [TrackedSat(gpsl5q, prn, 0.0, 0.0Hz)])
+        # Coherently integrate one full NH20 period — the point of a pilot lock.
+        set_preferred_num_code_blocks_to_integrate!(track_state, prn, secondary_code_length)
+        track_state =
+            track(signal, track_state, sampling_frequency; doppler_update_interval)
+
+        @test has_bit_or_secondary_code_been_found(track_state)
+        # The long integration is really in effect...
+        @test get_last_fully_integrated_num_code_blocks(track_state, prn) ==
+              secondary_code_length
+        # ...and the overlay is wiped across all 20 blocks of it, so the
+        # sample-count-normalised prompt keeps its full magnitude. A one-chip
+        # anchor error would put this near 1/20 of that.
+        @test abs(get_last_fully_integrated_filtered_prompt(track_state, prn)) > 0.99
+        # Not just the final record: every full-period integration after sync
+        # holds up. Sync needs ≥ 2 NH20 periods, so the tail of the prompt
+        # record covers post-sync integrations only.
+        prompts = get_filtered_prompts(track_state, prn)
+        @test all(>(0.99), abs.(prompts[(end-4):end]))
     end
 end
 

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -1,7 +1,7 @@
 module BitDetectionIntegrationTest
 
 using Test: @test, @testset
-using Unitful: Hz
+using Unitful: Hz, s
 using GNSSSignals:
     GPSL1CA,
     GPSL5I,
@@ -165,6 +165,65 @@ end
     @test sign.(multi_soft) == sign.(single_soft)
     @test all(x -> abs(x) ≈ 5, multi_soft[4:end])
     @test all(x -> abs(x) ≈ 20, single_soft[4:end])
+end
+
+# Mid-fold bit sync: the accumulation window must stay on the bit grid.
+#
+# With a `doppler_update_interval` longer than one code period a chunk's fold
+# covers several records, so bit sync is generally detected on a record that is
+# NOT the last of its fold. The records behind it were correlated with pre-sync
+# replicas — their prompt may be unusable — but the code blocks they cover are
+# real: dropping them from the accumulator's block count slides every following
+# bit window `k` blocks off the navigation-bit grid, where `k` is the number of
+# trailing records, permanently (issue #219).
+#
+# The data bit flips every 20 blocks here, so a window `k` blocks off the grid
+# sums 20 − k blocks of its own bit against k of the neighbour's and lands at
+# magnitude 20 − 2k instead of 20 — the misalignment is read straight off the
+# soft bits, with no dependence on where the detector happened to lock.
+@testset "mid-fold bit sync keeps the accumulation on the bit grid" begin
+    gpsl1 = GPSL1CA()
+    sampling_frequency = 5e6Hz
+    num_samples = 5000
+    code_frequency = get_code_frequency(gpsl1)
+    num_blocks = 140
+
+    signal = ComplexF32[]
+    for index = 1:num_blocks
+        # ±1 data bit, flipping every 20 code blocks.
+        data_bit_sign = iseven(div(index - 1, 20)) ? 1.0 : -1.0
+        code_phase = (index - 1) * num_samples * code_frequency / sampling_frequency
+        append!(
+            signal,
+            ComplexF32.(
+                data_bit_sign .* gen_code(
+                    num_samples,
+                    gpsl1,
+                    1,
+                    sampling_frequency,
+                    code_frequency,
+                    code_phase,
+                ),
+            ),
+        )
+    end
+
+    # 1 ms: one record per fold, so no record can ever trail the syncing one —
+    # the baseline. 7 ms / 13 ms: this near-noiseless signal locks at block 60,
+    # which is the 4th of the 57..63 fold and the 8th of the 53..65 fold, so 3
+    # respectively 5 records trail it. Before the fix those runs lost a bit and
+    # decoded the rest at magnitude 14 / 10.
+    for doppler_update_interval in (1e-3s, 3e-3s, 7e-3s, 13e-3s)
+        track_state = TrackState(gpsl1, [TrackedSat(gpsl1, 1, 0, 0.0Hz)])
+        track_state =
+            track(signal, track_state, sampling_frequency; doppler_update_interval)
+        soft_bits = get_soft_bits(track_state, 1)
+        # 3 bits replayed from the pre-sync sign window at the block-60 lock
+        # plus one per completed 20-block bit for the rest of the run.
+        @test length(soft_bits) == 3 + div(num_blocks - 60, 20)
+        # Every bit sums a full, unstraddled 20 blocks.
+        @test all(x -> abs(x) ≈ 20, soft_bits)
+    end
 end
 
 # GPS L5I secondary-code (NH10) sync and phase recovery.


### PR DESCRIPTION
Closes #219.

## The issue is valid, with one of its two candidate mechanisms

Instrumenting the reproduction's worst run (seed 20) shows the bit-sync fold held **two** records, sync fired on the first, and the second was dropped:

```
(call = 200, nrec = 1, cumulative_records = 199, buflen = 199, found = false, acc = 0)
(call = 201, nrec = 2, cumulative_records = 201, buflen = 200, found = true,  acc = 0)   ← record 201 dropped
```

`buflen = 200` is a clean multiple of 20, so the CFAR detector picked the right phase and fired on a true bit boundary — **candidate 1 (a one-block-off bit-edge decision) is innocent**. Candidate 2 is real, but not as a fractional record: `_apply_correlator_output` passed `skip_bit_buffer = true` for records behind a mid-fold sync, which dropped the record's *block count* along with its prompt. That count is the bit grid, so the loss puts every later bit window one block late permanently.

Seed 20: ratio 0.905 → 1.002, C/N₀ 37.7 → 45.8 dB-Hz against a true 45.

**Two of the three flagged runs were not misaligned.** Seeds 29 and 46 dropped nothing at their sync folds, and their ratios rest on 13 and 27 bits — 1.8σ and 2.2σ below 1, while seeds 1 and 5 sit 2.2σ and 1.5σ *above* 1, which a straddle cannot produce. The real rate is 1/58 at 45 dB-Hz.

The issue's suggestion to compare against `mod(record - 1, 20)` is indeed invalid, but not for the reason given: records don't drift against physical blocks (the code loop pins them), they get **relabelled** by one when the code-phase error crosses zero, which is also what puts two record ends inside a single 1 ms chunk. And a fractional post-sync record cannot occur at all — `stop_before_partial` means every post-sync integration starts *and* ends on a block boundary, so `calc_num_code_blocks_for_bit_buffer` never rounds to 0 or 2.

## The fix

**1. Separate the prompt from the count** (`correlated_pre_sync`, was `skip_bit_buffer`). `buffer` is now always called so the blocks are credited; only the prompt is dropped, and only for secondary-coded signals, where sync actually changed the replica underneath. GPS L1 C/A correlates identically either side of the sync instant and keeps full magnitude on its first bit.

**2. Advance the secondary-code anchor** (`_advance_secondary_phase`). Found while testing: the code-phase snap runs after the fold and anchors to the chip the detector reported for the block after the *syncing* record, so trailing records must move it along. Without this the replica bakes the wrong overlay chip into every block.

## Which signals were affected

| Signal | blocks/bit | sec_len | Symptom |
|:--|--:|--:|:--|
| GPS L1 C/A | 20 | 1 | bit-grid slip (the reported bug) |
| GPS L5I, Galileo E5a-I | 10, 20 | 10, 20 | bit-grid slip + overlay anchor |
| GPS L5Q, Galileo E1C / E5a-Q, GPS L1C-P | pilot | 20…1800 | overlay anchor → divergence |
| Galileo E1B, GPS L1C-D, L2CM | 1 | 1 | silent symbol loss at the start of tracking |
| GPS L2CL | — | 1 | unaffected (dataless pilot, no sync) |

Measured before → after:

```
Galileo E1B, 40 transmitted symbols       GPS L5Q, |20-block coherent prompt|
  4 ms (default)  40/40  →  40/40           1 ms   1.0                    →  1.0
  8 ms            39/40  →  40/40           3 ms   InexactError: Int64(NaN) →  1.0
  20 ms           36/40  →  40/40           7 ms   (never reached)        →  1.0
  40 ms           31/40  →  40/40
```

Exactly `records_per_fold − 1` symbols lost on E1B. On L5Q the cancelled coherent sum feeds 0/0 into the discriminators and the loop diverges into a NaN Doppler — a crash, not a degradation. L5Q has no bit accumulation, so that one isolates the anchor half of the fix.

## Tests

Three testsets in `test/bit_integration_test.jl`, each forcing the mid-fold condition deterministically via `doppler_update_interval` and each failing (or erroring) on the pre-fix tree:

- **L1 C/A bit grid** — data bit flips every 20 blocks, so misalignment is read off the soft-bit magnitudes. Every bit must be 20 at 1/3/7/13 ms folds; before, 7 ms gave 14 and 13 ms gave 10 (= `20 − 2k` for 3 and 5 trailing records) plus a lost bit.
- **L5I overlay anchor** — chunked decode must match the one-record-per-fold reference in sign and count, all bits ≈10 except the sync bit at ≥9; before, ~0–2.
- **L5Q pilot** — full-period coherent prompt stays at 1.0 across intervals; before, `InexactError`.

Both commits were run against the whole suite individually (the branch is rebase-merged, so each lands on `master` verbatim); both green, including the `track_in_place.jl` pre-sync allocation guards. Formatted with the CI-pinned JuliaFormatter 2.8.5.

## Not changed

`calc_num_code_blocks_for_bit_buffer` still uses `round`, and `_reset_inflight_integration` still runs on every sync snap. Both guard a fractional-block record the chunk architecture cannot currently produce; a `ceil`-with-tolerance there would be speculative. If a future change lets a partial integration survive a chunk boundary, that is where a zero-credit slip would reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
