### PR TITLE
Backport #220 to 4.x: keep the bit grid and the overlay anchor aligned across a mid-fold sync

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - master
+      # Maintenance branch for 4.x backports — matches the semantic-release
+      # maintenance-branch pattern already configured below, so a fix landing
+      # here is released as the next 4.x patch version.
+      - '4.x'
 
 jobs:
   release:

--- a/src/bit_buffer.jl
+++ b/src/bit_buffer.jl
@@ -1290,6 +1290,47 @@ function _buffer_find_bit(
     )
 end
 
+"""
+$(SIGNATURES)
+
+Walk a just-synced `bit_buffer`'s `secondary_phase` forward by
+`num_code_blocks` primary-code blocks (modulo the secondary-code length). No-op
+for signals without a secondary code, where the field is unused.
+
+`secondary_phase` is the secondary chip the **upcoming** integration aligns to,
+and it is read exactly once: by the code-phase snap
+([`_snap_code_phase_from_synced_signal`](@ref)), which runs after the whole
+chunk has been folded. The detector reports it for the block right after the
+syncing record, so every further record folded in the same chunk — the ones
+`_apply_correlator_output` marks `correlated_pre_sync`, correlated with the
+pre-sync (un-wiped) replica — moves that anchor along by the blocks it covers.
+Without this the snap anchors the replica `num_code_blocks` chips early, the
+post-sync replica bakes the wrong overlay chip into every block, and the
+coherent bit sum collapses to a fraction of its length — the secondary-code
+sibling of the bit-grid slip in issue #219.
+"""
+@inline function _advance_secondary_phase(
+    signal::AbstractGNSSSignal,
+    bit_buffer::BitBuffer{B},
+    num_code_blocks::Integer,
+) where {B<:Unsigned}
+    secondary_code_length = get_secondary_code_length(signal)
+    secondary_code_length > 1 || return bit_buffer
+    BitBuffer{B}(
+        bit_buffer.code_block_buffer,
+        bit_buffer.code_block_buffer_length,
+        bit_buffer.found,
+        mod(bit_buffer.secondary_phase + Int(num_code_blocks), secondary_code_length),
+        bit_buffer.polarity,
+        bit_buffer.buffer,
+        bit_buffer.length,
+        bit_buffer.prompt_accumulator,
+        bit_buffer.prompt_accumulator_integrated_code_blocks,
+        bit_buffer.soft_bits,
+        bit_buffer.phase_acc,
+    )
+end
+
 function reset(bit_buffer::BitBuffer{B}) where {B<:Unsigned}
     empty!(bit_buffer.soft_bits)
     BitBuffer{B}(

--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -453,6 +453,13 @@ end
         bit_block_count,
         drop_prompt ? zero(bit_prompt) : bit_prompt,
     )
+    # Such a record also moves the secondary-code anchor: the code-phase snap
+    # runs after this fold and aligns the *upcoming* integration to
+    # `bit_buffer.secondary_phase`, which the detector reported for the block
+    # right after the syncing record.
+    if correlated_pre_sync
+        bit_buffer = _advance_secondary_phase(signal, bit_buffer, bit_block_count)
+    end
     new_signal = TrackedSignal(
         tracked_signal;
         last_fully_integrated_filtered_prompt = prompt,

--- a/src/conventional_pll_and_dll.jl
+++ b/src/conventional_pll_and_dll.jl
@@ -398,19 +398,25 @@ end
 # the record's true integration time, so it only switches when the integration
 # actually lengthened — not already on the fold where sync was detected but the
 # records were still single-block (see `_process_estimator_driver_signal`).
-# `skip_bit_buffer = true` applies everything EXCEPT the bit-buffer update.
-# Used for records that follow a bit/secondary sync detected earlier in the
-# same fold: those records were correlated with pre-sync replicas (no
-# secondary-code wipe-off), so accumulating them as if wiped would feed
-# sign-corrupted prompts into the first post-sync bits. They re-enter cleanly
-# next chunk, correlated at the snapped phase with the overlay in the replica.
+# `correlated_pre_sync = true` marks a record that follows a bit/secondary sync
+# detected earlier in the same fold, i.e. one that was correlated with a
+# pre-sync replica. Its *prompt* is only unusable where sync changed the replica
+# — the secondary-code wipe-off, whose absence would feed sign-corrupted prompts
+# into the first post-sync bits — so it is dropped from the coherent bit
+# accumulation for secondary-coded signals only; a signal without a secondary
+# code (GPS L1 C/A) correlates identically either side of the sync instant and
+# keeps its prompt. The code blocks such a record covers are real either way and
+# are always credited to the accumulator's block count: dropping the count
+# slides the bit window one block off the navigation-bit grid for the rest of
+# the run, which costs ~0.9 dB of bit-decision SNR and makes every coherent
+# window that follows the grid straddle a bit flip (issue #219).
 @inline function _apply_correlator_output(
     tracked_signal::TrackedSignal,
     output::CorrelatorOutput,
     prn::Integer,
     sampling_frequency,
     driver_carrier_phase::Real = 0.0;
-    skip_bit_buffer::Bool = false,
+    correlated_pre_sync::Bool = false,
 )
     signal = tracked_signal.signal
     normalized_correlator =
@@ -436,9 +442,17 @@ end
     # `buffer`, so a quadrature component's data lands on the real axis it is
     # decided on. No-op for the driver and for co-phased pairs.
     bit_prompt = prompt * _carrier_phase_derotation(driver_carrier_phase, signal)
-    bit_buffer =
-        skip_bit_buffer ? tracked_signal.bit_buffer :
-        buffer(signal, prn, tracked_signal.bit_buffer, bit_block_count, bit_prompt)
+    # Keep a pre-sync-correlated record's prompt out of the coherent sum where
+    # the sync changed the replica under it (secondary-code wipe-off), but
+    # always let it advance the accumulator's block count — see above.
+    drop_prompt = correlated_pre_sync && get_secondary_code_length(signal) > 1
+    bit_buffer = buffer(
+        signal,
+        prn,
+        tracked_signal.bit_buffer,
+        bit_block_count,
+        drop_prompt ? zero(bit_prompt) : bit_prompt,
+    )
     new_signal = TrackedSignal(
         tracked_signal;
         last_fully_integrated_filtered_prompt = prompt,
@@ -486,8 +500,9 @@ end
         # Per-record integration time — the block time, NOT the chunk time.
         integration_time = output.integrated_samples / sampling_frequency
         # A record that follows a sync detected earlier in THIS fold was
-        # correlated with pre-sync replicas — keep it out of the bit buffer
-        # (see `_apply_correlator_output`).
+        # correlated with pre-sync replicas — its blocks still count towards the
+        # bit, only its prompt may have to be dropped (see
+        # `_apply_correlator_output`).
         synced_earlier_in_fold =
             !found_before_fold && has_bit_or_secondary_code_been_found(ts.bit_buffer)
         # The driver de-rotates against itself (offset 0), so the derotation is a
@@ -498,7 +513,7 @@ end
             sat.prn,
             sampling_frequency,
             driver_carrier_phase;
-            skip_bit_buffer = synced_earlier_in_fold,
+            correlated_pre_sync = synced_earlier_in_fold,
         )
 
         # The configured bandwidths are referenced to a one-primary-code-period
@@ -600,7 +615,7 @@ end
                 prn,
                 sampling_frequency,
                 driver_carrier_phase;
-                skip_bit_buffer = synced_earlier_in_fold,
+                correlated_pre_sync = synced_earlier_in_fold,
             ),
         )
     end

--- a/src/vector_pll_and_dll.jl
+++ b/src/vector_pll_and_dll.jl
@@ -298,7 +298,7 @@ end
             sat.prn,
             sampling_frequency,
             driver_carrier_phase;
-            skip_bit_buffer = synced_earlier_in_fold,
+            correlated_pre_sync = synced_earlier_in_fold,
         )
 
         # Same 1/N effective-bandwidth scaling as the conventional estimator —

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -5,6 +5,7 @@ using Unitful: Hz, s
 using GNSSSignals:
     GPSL1CA,
     GPSL5I,
+    GPSL5Q,
     GPSL1C_P,
     gen_code,
     get_code_frequency,
@@ -19,6 +20,8 @@ using Tracking:
     get_bits,
     get_num_bits,
     get_soft_bits,
+    get_filtered_prompts,
+    get_last_fully_integrated_filtered_prompt,
     has_bit_or_secondary_code_been_found,
     set_preferred_num_code_blocks_to_integrate!,
     EarlyPromptLateCorrelator
@@ -455,6 +458,139 @@ end
         # the load-bearing assertion of the fix.
         full_bit_magnitude = secondary_code_length / preferred_blocks
         @test all(>(0.9 * full_bit_magnitude), abs.(soft_bits))
+    end
+end
+
+# Mid-fold secondary-code sync: the overlay anchor must travel with the fold.
+#
+# Same defect as the L1 C/A bit grid above (issue #219), on the secondary-code
+# path. With a `doppler_update_interval` longer than one code period the records
+# behind the syncing one inside its fold were correlated with the pre-sync (not
+# overlay-wiped) replica: their prompt is dropped, but they still advance both
+# the bit accumulator's block count and — because the code-phase snap runs after
+# the fold — the secondary-chip anchor it aligns the upcoming integration to.
+# Leaving the anchor where the detector reported it makes the post-sync replica
+# bake the wrong NH chip into every block, and the coherent NH10 sum collapses
+# from ~10 to ~0–2 (which is also a coin flip on every decoded bit).
+@testset "mid-fold secondary-code sync keeps the overlay anchor aligned" begin
+    gpsl5 = GPSL5I()
+    prn = 1
+    sampling_frequency = 25e6Hz
+    code_frequency = get_code_frequency(gpsl5)
+    primary_code_length = get_code_length(gpsl5)               # 10230 chips
+    secondary_code_length = get_secondary_code_length(gpsl5)   # 10 (NH10)
+    num_samples = round(Int, 25e6 / 1000)                      # 1 ms = one primary block
+    data_bits = [1, 1, 0, 1, 0, 0, 1, 1, 0, 1]
+
+    # Decode the whole run in a single `track` call at the given chunk interval.
+    function decode(doppler_update_interval, start_secondary_chip)
+        total_blocks = secondary_code_length * length(data_bits) - start_secondary_chip
+        signal = ComplexF32.(
+            gen_code(
+                total_blocks * num_samples,
+                gpsl5,
+                prn,
+                sampling_frequency,
+                code_frequency,
+                start_secondary_chip * primary_code_length,
+            ),
+        )
+        for b = 0:(total_blocks-1)
+            data_bit = data_bits[div(start_secondary_chip+b, secondary_code_length)+1]
+            @views signal[(b*num_samples+1):((b+1)*num_samples)] .*=
+                ComplexF32(2 * data_bit - 1)
+        end
+        track_state = TrackState(
+            gpsl5,
+            [TrackedSat(gpsl5, prn, start_secondary_chip * primary_code_length, 0.0Hz)],
+        )
+        get_soft_bits(
+            track(signal, track_state, sampling_frequency; doppler_update_interval),
+        )
+    end
+
+    @testset "start chip $start_secondary_chip" for start_secondary_chip in (0, 3)
+        # One record per fold: no record can trail the syncing one — the
+        # reference decode. (Magnitudes sit a few 1e-4 below the nominal NH10
+        # length, from the code-amplitude normalisation, hence the 0.99 floors.)
+        full_bit = 0.99 * secondary_code_length
+        reference = copy(decode(1e-3s, start_secondary_chip))
+        @test all(>(full_bit), abs.(reference))
+
+        for doppler_update_interval in (3e-3s, 7e-3s)
+            soft_bits = decode(doppler_update_interval, start_secondary_chip)
+            # Same bits, on the same grid, as the one-record-per-fold reference.
+            @test length(soft_bits) == length(reference)
+            @test sign.(soft_bits) == sign.(reference)
+            # Only the bit the sync lands in is short, and only by the prompts
+            # that were dropped — one block each, one such record at both
+            # intervals here. Every later bit is full. A misaligned overlay
+            # would put all of them near 0–2 instead.
+            @test all(>(full_bit), abs.(soft_bits[2:end]))
+            @test abs(soft_bits[1]) > 0.99 * (secondary_code_length - 1)
+        end
+    end
+end
+
+# Mid-fold secondary-code sync on a *pilot* (GPS L5Q, NH20).
+#
+# A pilot carries no navigation data, so the accumulator part of issue #219 does
+# not apply — `buffer` returns early for it. The overlay anchor does, and it hits
+# harder: the overlay is the only thing a pilot locks, and its whole purpose is
+# coherent integration over a full secondary-code period. Anchored to the chip
+# the detector reported for the syncing record — instead of the one the records
+# behind it moved on to — the replica wipes the wrong NH chip and a 20-block
+# coherent sum cancels toward zero instead of reaching the nominal 1. That is not
+# a degraded prompt: the discriminators then see 0/0 and the loop diverges into a
+# NaN Doppler (an `InexactError` out of the correlator's shift arithmetic), so
+# this testset *errors* rather than fails when the anchor is wrong.
+@testset "mid-fold pilot overlay anchor keeps coherent integration intact" begin
+    gpsl5q = GPSL5Q()
+    prn = 1
+    sampling_frequency = 25e6Hz
+    code_frequency = get_code_frequency(gpsl5q)
+    secondary_code_length = get_secondary_code_length(gpsl5q)   # 20 (NH20)
+    num_samples = round(Int, 25e6 / 1000)                       # 1 ms = one primary block
+    # Long enough for the NH20 detector (≥ 2 periods) plus a good run of
+    # full-period coherent integrations afterwards.
+    num_blocks = 240
+    signal = ComplexF32.(
+        gen_code(
+            num_blocks * num_samples,
+            gpsl5q,
+            prn,
+            sampling_frequency,
+            code_frequency,
+            0.0,
+        ),
+    )
+
+    # 1 ms: one record per fold, nothing can trail the syncing record. 3 / 7 ms:
+    # it can, and does.
+    for doppler_update_interval in (1e-3s, 3e-3s, 7e-3s)
+        track_state = TrackState(gpsl5q, [TrackedSat(gpsl5q, prn, 0.0, 0.0Hz)])
+        # Coherently integrate one full NH20 period — the point of a pilot lock.
+        set_preferred_num_code_blocks_to_integrate!(track_state, prn, secondary_code_length)
+        track_state =
+            track(signal, track_state, sampling_frequency; doppler_update_interval)
+
+        @test has_bit_or_secondary_code_been_found(track_state)
+        # The long integration is really in effect: until sync every record is
+        # clamped to a single block, afterwards each spans a full NH20 period,
+        # so this noiseless run produces ~40 + (240 − 40)/20 = 50 records — a
+        # run stuck at one block per record would produce ~240. (v4 has no
+        # `get_last_fully_integrated_num_code_blocks` to read the count
+        # directly.)
+        prompts = get_filtered_prompts(track_state, prn)
+        @test length(prompts) < 60
+        # The overlay is wiped across all 20 blocks of it, so the
+        # sample-count-normalised prompt keeps its full magnitude. A one-chip
+        # anchor error would put this near 1/20 of that.
+        @test abs(get_last_fully_integrated_filtered_prompt(track_state, prn)) > 0.99
+        # Not just the final record: every full-period integration after sync
+        # holds up. Sync needs ≥ 2 NH20 periods, so the tail of the prompt
+        # record covers post-sync integrations only.
+        @test all(>(0.99), abs.(prompts[(end-4):end]))
     end
 end
 

--- a/test/bit_integration_test.jl
+++ b/test/bit_integration_test.jl
@@ -1,7 +1,7 @@
 module BitDetectionIntegrationTest
 
 using Test: @test, @testset
-using Unitful: Hz
+using Unitful: Hz, s
 using GNSSSignals:
     GPSL1CA,
     GPSL5I,
@@ -171,6 +171,65 @@ end
     @test sign.(multi_soft) == sign.(single_soft)
     @test all(x -> abs(x) ≈ 5, multi_soft[4:end])
     @test all(x -> abs(x) ≈ 20, single_soft[4:end])
+end
+
+# Mid-fold bit sync: the accumulation window must stay on the bit grid.
+#
+# With a `doppler_update_interval` longer than one code period a chunk's fold
+# covers several records, so bit sync is generally detected on a record that is
+# NOT the last of its fold. The records behind it were correlated with pre-sync
+# replicas — their prompt may be unusable — but the code blocks they cover are
+# real: dropping them from the accumulator's block count slides every following
+# bit window `k` blocks off the navigation-bit grid, where `k` is the number of
+# trailing records, permanently (issue #219).
+#
+# The data bit flips every 20 blocks here, so a window `k` blocks off the grid
+# sums 20 − k blocks of its own bit against k of the neighbour's and lands at
+# magnitude 20 − 2k instead of 20 — the misalignment is read straight off the
+# soft bits, with no dependence on where the detector happened to lock.
+@testset "mid-fold bit sync keeps the accumulation on the bit grid" begin
+    gpsl1 = GPSL1CA()
+    sampling_frequency = 5e6Hz
+    num_samples = 5000
+    code_frequency = get_code_frequency(gpsl1)
+    num_blocks = 140
+
+    signal = ComplexF32[]
+    for index = 1:num_blocks
+        # ±1 data bit, flipping every 20 code blocks.
+        data_bit_sign = iseven(div(index - 1, 20)) ? 1.0 : -1.0
+        code_phase = (index - 1) * num_samples * code_frequency / sampling_frequency
+        append!(
+            signal,
+            ComplexF32.(
+                data_bit_sign .* gen_code(
+                    num_samples,
+                    gpsl1,
+                    1,
+                    sampling_frequency,
+                    code_frequency,
+                    code_phase,
+                ),
+            ),
+        )
+    end
+
+    # 1 ms: one record per fold, so no record can ever trail the syncing one —
+    # the baseline. 7 ms / 13 ms: this near-noiseless signal locks at block 60,
+    # which is the 4th of the 57..63 fold and the 8th of the 53..65 fold, so 3
+    # respectively 5 records trail it. Before the fix those runs lost a bit and
+    # decoded the rest at magnitude 14 / 10.
+    for doppler_update_interval in (1e-3s, 3e-3s, 7e-3s, 13e-3s)
+        track_state = TrackState(gpsl1, [TrackedSat(gpsl1, 1, 0, 0.0Hz)])
+        track_state =
+            track(signal, track_state, sampling_frequency; doppler_update_interval)
+        soft_bits = get_soft_bits(track_state, 1)
+        # 3 bits replayed from the pre-sync sign window at the block-60 lock
+        # plus one per completed 20-block bit for the rest of the run.
+        @test length(soft_bits) == 3 + div(num_blocks - 60, 20)
+        # Every bit sums a full, unstraddled 20 blocks.
+        @test all(x -> abs(x) ≈ 20, soft_bits)
+    end
 end
 
 # GPS L5I secondary-code (NH10) sync and phase recovery.


### PR DESCRIPTION
Backport of #220 (issue #219) to the 4.x line, targeting the new `4.x` maintenance branch cut from `v4.4.0`.

## Why

v4.4.0 has the identical defect: `_apply_correlator_output` passed `skip_bit_buffer = true` for records correlated before a mid-fold sync, dropping their *block count* along with their prompt and sliding every later bit window off the navigation-bit grid; the secondary-code anchor was likewise left behind by those records. Verified with the reproduction from #219 on `v4.4.0`:

```
                     v4.4.0        this branch
seed 20: ratio =     0.905   →     1.002
seed 29: ratio =     0.916         0.916   (not misaligned, see #220)
seed 46: ratio =     0.932         0.932   (not misaligned, see #220)
```

and both halves of the regression testset fail/error on plain `v4.4.0` exactly as they did pre-fix on `master` (the L1 C/A mid-fold decode loses a bit and lands at magnitude 14/10; the L5Q pilot testset throws the `InexactError` NaN-Doppler divergence).

## What was adapted

Both commits cherry-pick almost cleanly (`-x` provenance in the messages). Two v4-specific adaptations, folded into the second commit:

- `_advance_secondary_phase` passes the `buffer`/`length` fields of v4's `BitBuffer`, which v5 removed in the soft-bits-only rework (#211).
- The L5Q pilot testset asserts the full-period integration via the record count (`length(get_filtered_prompts(...)) < 60` over a 240-block run) instead of `get_last_fully_integrated_num_code_blocks`, which does not exist on 4.x.

A third commit adds `4.x` to `Release.yml`'s push trigger so semantic-release cuts `v4.4.1` (and notifies JuliaRegistrator) when this lands.

## Tests

Full suite green on this branch (Julia 1.12): `Pkg.test()` equivalent via `test/runtests.jl`, including the three backported mid-fold testsets. Formatted with the CI-pinned JuliaFormatter 2.8.5 (no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
