### PR TITLE
Share the despread path, and run the noise measurement in parallel

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -406,7 +406,7 @@ function bench_track(;
         downconvert_and_correlator = $downconvert_and_correlator,
     )
 end
-SUITE["track"]["GPS L1CA, 1 sat, 2K @ 5 MHz – out-of-place"] = bench_track()
+SUITE["track"]["GPS L1CA, 1 sat, 2K @ 5 MHz – out-of-place, Float32"] = bench_track()
 
 # In-place track! (only on branches that define it). Mirrors bench_track so
 # the comparison report shows them side by side.
@@ -427,7 +427,8 @@ function bench_track_inplace(;
     )
 end
 if isdefined(Tracking, :track!)
-    SUITE["track"]["GPS L1CA, 1 sat, 2K @ 5 MHz – in-place"] = bench_track_inplace()
+    SUITE["track"]["GPS L1CA, 1 sat, 2K @ 5 MHz – in-place, Float32"] =
+        bench_track_inplace()
 end
 
 # Fused kernel microbenchmarks (only available on branches with the fused kernel)
@@ -787,12 +788,18 @@ end
 #   <constellation>, <Nsats> sats[, <extra>], <Nsamp> @ <rate> – <variant>
 #
 # where `<variant>` is `out-of-place` (`track`, returns a new state) or
-# `in-place` (`track!`), optionally followed by `, threaded` or by a non-default
-# sample backend (`, Int16` / `, OneBit` / `, TwoBit`). Both entry points are
-# named rather than leaving `track`'s rows bare: an unsuffixed row reads as "the
+# `in-place` (`track!`), then the backend (`Float32` / `Int16` / `OneBit` /
+# `TwoBit`), then `, threaded` on the rows that are. Both entry points are named
+# rather than leaving `track`'s rows bare: an unsuffixed row reads as "the
 # default" instead of "the other variant", which is the ambiguity the suffix is
-# there to remove in the first place. Float32 is the default backend and so goes
-# unmarked, the same way single-threaded does.
+# there to remove in the first place.
+#
+# The **backend is always named**, `Float32` included, for the same reason one
+# level down: it has four values and no reading of a bare label says which one a
+# row measured, so "the default" is knowledge the label was relying on the reader
+# already having. Threading stays marked only when on — there the pair is a
+# binary, both halves of it sit adjacent in the table, and an unmarked row
+# genuinely does read as "the other one".
 #
 # The scenario carries the satellite count, the sample count and the sampling
 # rate, because the comparison table is read by people who have not opened this
@@ -806,6 +813,12 @@ end
 # because " " precedes "0". Numbering added nothing the text does not, drifted
 # out of order as cases were added (two different cases both called themselves
 # "7."), and read as a rank rather than as an index.
+#
+# Naming the backend also fixes the sort: `– in-place, threaded` used to land
+# *after* `– in-place, TwoBit` (lowercase `t` sorts above the uppercase backend
+# names), so a scenario's Float32 pair was split by three other backends. As
+# `– in-place, Float32` / `– in-place, Float32, threaded` they lead the group and
+# stay adjacent.
 #
 # The one place a lexicographic sort still reads oddly is sample counts of
 # different digit lengths: "500K" precedes "5K", so the 8-sat rows list the long
@@ -848,12 +861,14 @@ const _TRACK_BENCH_CASES = let gpsl1 = GPSL1CA(), gal = GalileoE1B()
 end
 
 for (key, kw) in _TRACK_BENCH_CASES
-    SUITE["track"]["$key – out-of-place"] = bench_track_steady_state(false, false; kw...)
-    SUITE["track"]["$key – out-of-place, threaded"] =
+    SUITE["track"]["$key – out-of-place, Float32"] =
+        bench_track_steady_state(false, false; kw...)
+    SUITE["track"]["$key – out-of-place, Float32, threaded"] =
         bench_track_steady_state(false, true; kw...)
     if isdefined(Tracking, :track!)
-        SUITE["track"]["$key – in-place"] = bench_track_steady_state(true, false; kw...)
-        SUITE["track"]["$key – in-place, threaded"] =
+        SUITE["track"]["$key – in-place, Float32"] =
+            bench_track_steady_state(true, false; kw...)
+        SUITE["track"]["$key – in-place, Float32, threaded"] =
             bench_track_steady_state(true, true; kw...)
     end
 end
@@ -939,7 +954,7 @@ if _HAS_TRACKED_SIGNAL
         ts, signal =
             _make_multi_signal_track_state(; n_signals, nsamp = 5000, sfreq = 5e6Hz)
         dc = _make_cpu_dc(5e6Hz)
-        SUITE["track"]["$prefix – out-of-place"] = @benchmarkable Tracking.track(
+        SUITE["track"]["$prefix – out-of-place, Float32"] = @benchmarkable Tracking.track(
             $signal,
             $ts,
             $(5e6Hz);
@@ -949,7 +964,7 @@ if _HAS_TRACKED_SIGNAL
             ts_ip, signal_ip =
                 _make_multi_signal_track_state(; n_signals, nsamp = 5000, sfreq = 5e6Hz)
             dc_ip = _make_cpu_dc(5e6Hz)
-            SUITE["track"]["$prefix – in-place"] = @benchmarkable Tracking.track!(
+            SUITE["track"]["$prefix – in-place, Float32"] = @benchmarkable Tracking.track!(
                 $signal_ip,
                 $ts_ip,
                 $(5e6Hz);
@@ -996,7 +1011,7 @@ if _HAS_TRACKED_SIGNAL && isdefined(Tracking, :track!)
             nsamp = samples_per_block * n_blocks
             sig = rand(ComplexF32, nsamp)
             dc = _make_cpu_dc(sfreq)
-            SUITE["track"]["GPS L1CA, 1 sat, bit sync pending, $(n_blocks) blk @ 5 MHz – in-place"] = @benchmarkable(
+            SUITE["track"]["GPS L1CA, 1 sat, bit sync pending, $(n_blocks) blk @ 5 MHz – in-place, Float32"] = @benchmarkable(
                 Tracking.track!($sig, ts, $sfreq; downconvert_and_correlator = $dc),
                 setup = (
                     ts = first(
@@ -1013,7 +1028,7 @@ if _HAS_TRACKED_SIGNAL && isdefined(Tracking, :track!)
             # The synced rows stay short: post-sync there is no per-block search
             # to leak from, so the extra length would only cost runtime.
             n_blocks == 200 && continue
-            SUITE["track"]["GPS L1CA, 1 sat, bit sync found, $(n_blocks) blk @ 5 MHz – in-place"] = @benchmarkable(
+            SUITE["track"]["GPS L1CA, 1 sat, bit sync found, $(n_blocks) blk @ 5 MHz – in-place, Float32"] = @benchmarkable(
                 Tracking.track!($sig, ts, $sfreq; downconvert_and_correlator = $dc),
                 setup = (
                     ts = first(

--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -185,11 +185,14 @@ parent.
 The per-sat correlation loop, per-group body, and public
 `downconvert_and_correlate(!)` entry points are defined once on this abstract
 type (see `downconvert_and_correlate_cpu.jl`); a subtype customises behaviour by
-overriding the dispatch hooks it needs — `_correlate_signals` / `_scratch_buffers`
-(kernel + scratch), `_threading` (serial vs. Polyester `@batch`, default serial),
-and `_check_sample_type` (per-backend sample-type check, default no-op). A
-subtype that overrides none inherits the single-threaded CPU plumbing rather
-than getting a `MethodError`.
+overriding the dispatch hooks it needs — `_despread_one_signal!` (the one
+correlation primitive, which both the per-satellite path and the noise reference
+go through), `_correlate_signals` / `_scratch_buffers` (multi-signal kernel +
+scratch), `_threading` (serial vs. Polyester `@batch`, default serial), and
+`_check_sample_type` (per-backend sample-type check, default no-op). A subtype
+that overrides none inherits the single-threaded CPU plumbing rather than getting
+a `MethodError`; one that overrides only `_despread_one_signal!` gets a working
+single-signal path, satellites and noise measurement alike.
 """
 abstract type AbstractDownconvertAndCorrelator end
 

--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -264,12 +264,31 @@ entry only where its C/N₀ estimator reads a noise density (see
 [`requires_noise_density`](@ref)); signals with no such estimator get none, and
 then the noise measurement costs exactly nothing. Each estimator averages **in
 place**, so `TrackState` itself is never rebuilt for a noise update.
+
+`noise_descriptor` is per-call **scratch**, not state: one reusable heap cell in
+which the correlate step parks the chunk's noise descriptors so that a threaded
+backend's parallel loop can reach them through a single pointer instead of a
+by-value copy (see `_park_noise_items!`). It is shared — not copied — by every
+`TrackState` derived from this one, exactly as the per-satellite scratch vectors
+are, and nothing outside one `downconvert_and_correlate!` call reads it.
 """
 struct TrackState{G<:SignalGroups,DE<:AbstractDopplerEstimator,NE<:NoiseEstimators}
     groups::G
     doppler_estimator::DE
     noise_estimators::NE
+    noise_descriptor::Base.RefValue{Any}
 end
+
+# Three-argument construction: the descriptor cell is scratch, so a freshly built
+# `TrackState` starts with an empty one and fills it on its first correlate call.
+# Every *derived* state (`TrackState(track_state; …)` and the in-place mutators)
+# threads the existing cell through instead, which is what keeps the box inside it
+# alive across `track!`'s copies and the steady state allocation-free.
+TrackState(
+    groups::SignalGroups,
+    doppler_estimator::AbstractDopplerEstimator,
+    noise_estimators::NoiseEstimators,
+) = TrackState(groups, doppler_estimator, noise_estimators, Base.RefValue{Any}(nothing))
 
 include("sample_parameters.jl")
 include("downconvert_and_correlate.jl")

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -832,8 +832,11 @@ end
 """
 $(SIGNATURES)
 
-Downconvert and correlate all available satellites on the CPU (both the
-single-threaded and the multi-threaded backend). Returns a new
+Downconvert and correlate all available satellites. Defined on
+`AbstractDownconvertAndCorrelator`, so every backend — the CPU ones, the Int16
+one and both bit-wise ones — is served by this method; a backend customises
+what happens inside it through `_despread_one_signal!`, `_dc_one_group!`,
+`_check_sample_type` and `_threading`. Returns a new
 `TrackState` whose slot *values* are detached from the input (the input's
 per-sat tracking values are left untouched), but whose key set
 (`Indices`) is *shared* with the input — this step never changes the key
@@ -891,15 +894,14 @@ band sign planes). `track!` passes it on every chunk after the first so the
 pack happens once per call; leave it `false` (the default) whenever the
 buffers may have been refilled.
 
-It has a **second meaning** for the per-band noise measurement, which is worth
-knowing before passing it by hand: an *unchunked* call
-(`chunk_duration === nothing`) that also claims the samples are unchanged is
-taken to be a re-pass over a buffer that has already been measured, and its
-noise measurement is skipped. That is what keeps `track!`'s final drain pass —
-which sees the whole buffer as one chunk — from measuring everything a second
-time. A direct caller who truthfully passes `samples_unchanged = true` on an
-unchunked call therefore gets no noise observation from it; pass `false`, or
-chunk the call, to measure.
+`measure_noise = false` skips the per-signal noise measurement for this call,
+leaving every configured [`CorrelatorNoiseEstimator`](@ref)'s window untouched.
+Pass it on a call that re-covers samples an earlier call already measured —
+which is exactly what `track!` does on its final drain pass, where the whole
+buffer arrives as one unchunked chunk. Measuring there would enter every sample
+of the buffer into the window a second time. It has no effect on a
+`TrackState` whose C/N₀ estimators read no noise density, since nothing is
+measured on those at all.
 """
 function downconvert_and_correlate!(
     dc::AbstractDownconvertAndCorrelator,
@@ -909,6 +911,7 @@ function downconvert_and_correlate!(
     chunk_duration = nothing,
     stop_before_partial::Bool = false,
     samples_unchanged::Bool = false,
+    measure_noise::Bool = true,
 )
     _update_signal_noise!(
         dc,
@@ -916,7 +919,7 @@ function downconvert_and_correlate!(
         measurements,
         chunk_index,
         chunk_duration,
-        samples_unchanged,
+        measure_noise,
     )
     _foreach_group!(
         _dc_one_group!,
@@ -949,32 +952,28 @@ end
 # every chunk. Recursion unrolls it and each `update_noise!` devirtualises. A
 # signal with no entry does no work at all.
 #
-# **When to skip.** `samples_unchanged` alone must not gate this: `track!` passes
-# `samples_unchanged = chunk_index > 0`, so gating on it would measure chunk 0
-# and then freeze the window for the rest of the buffer. The call that does need
-# skipping is `track!`'s final drain pass, which passes neither `chunk_index` nor
-# `chunk_duration` — with `chunk_duration === nothing` the range defaults to the
-# whole buffer, so measuring there would re-measure everything already covered.
-# The discriminating condition needs no per-band sample pointer (which would be
-# the scalar state that has no anchor):
+# **When to skip.** Whether a call re-covers samples an earlier one already
+# measured is the caller's knowledge, not something to infer here, so it arrives
+# as `measure_noise`. The one caller that has to say no is `track!`'s final drain
+# pass: it passes neither `chunk_index` nor `chunk_duration`, so the range
+# defaults to the whole buffer and measuring there would enter every sample into
+# the window a second time. The cost is that a buffer's trailing partial never
+# reaches the window — at most one chunk per `track!` call, and omitting an entry
+# biases `σ̂²` not at all.
 #
-# | call                            | `chunk_duration` | `samples_unchanged` | measure? |
-# |---------------------------------|------------------|---------------------|----------|
-# | chunked call `k`                | set              | `k > 0`             | yes      |
-# | `track!`'s final drain pass     | `nothing`        | `true`              | no       |
-# | direct unchunked single call    | `nothing`        | `false`             | yes      |
-#
-# The cost is that a buffer's trailing partial never reaches the window — at most
-# one chunk per `track!` call, and omitting an entry biases `σ̂²` not at all.
+# `samples_unchanged` is deliberately *not* what decides it. It answers a
+# different question — may the backend reuse a sample-derived cache — and `track!`
+# passes it on every chunk after the first, so gating on it would measure chunk 0
+# and then freeze the window for the rest of the buffer.
 @inline function _update_signal_noise!(
     dc::AbstractDownconvertAndCorrelator,
     track_state::TrackState,
     measurements::BandMeasurements,
     chunk_index::Int,
     chunk_duration,
-    samples_unchanged::Bool,
+    measure_noise::Bool,
 )
-    isnothing(chunk_duration) && samples_unchanged && return nothing
+    measure_noise || return nothing
     noise_estimators = track_state.noise_estimators
     _update_signal_noise_walk!(
         Val(keys(noise_estimators)),
@@ -1034,13 +1033,13 @@ end
     chunk_index::Int,
     chunk_duration,
 ) where {K}
-    # The groups tracking signal `K`, and the signal instance itself. A key
+    # An instance of signal `K`, from whichever group happens to carry it. A key
     # naming a signal no group tracks measures nothing — that is the
     # correlator-ingest case, where the window is filled by
     # `append_noise_observation!` instead.
-    signal_groups = _groups_with_signal(Tuple(groups), Val(K))
-    isempty(signal_groups) && return nothing
-    signal = first(_signals_with_id(first(signal_groups).signals, Val(K)))
+    found = _first_signal_with_id(Tuple(groups), Val(K))
+    isempty(found) && return nothing
+    signal = first(found)
     # The samples are still a *band* property — one front end feeds every signal
     # on it. Only the despreading code, and therefore the measured floor, is per
     # signal.
@@ -1063,21 +1062,27 @@ end
     nothing
 end
 
-# The groups tracking signal `K`, as a tuple, and that signal within a group's
-# signal tuple. Both fold at compile time: a group's signal ids are constants of
-# its type.
-@inline _groups_with_signal(::Tuple{}, ::Val) = ()
-@inline function _groups_with_signal(t::Tuple, v::Val)
-    g = first(t)
-    rest = _groups_with_signal(Base.tail(t), v)
-    isempty(_signals_with_id(g.signals, v)) ? rest : (g, rest...)
+# An instance of signal `K`, searched groups-then-signals and returned as a 0- or
+# 1-tuple so the not-found case stays type-stable instead of widening to
+# `Union{Nothing,…}`. The instance is all anyone wants: the band it is measured on
+# comes from the signal *type* (`_signal_band_id`) and the estimator is already in
+# hand, so *which* group carries the signal — and how many do — changes nothing.
+# Folds at compile time; a group's signal ids are constants of its type.
+@inline _first_signal_with_id(::Tuple{}, ::Val) = ()
+@inline function _first_signal_with_id(
+    groups::Tuple{SignalGroup,Vararg{SignalGroup}},
+    v::Val,
+)
+    found = _first_signal_with_id(first(groups).signals, v)
+    isempty(found) ? _first_signal_with_id(Base.tail(groups), v) : found
 end
-
-@inline _signals_with_id(::Tuple{}, ::Val) = ()
-@inline function _signals_with_id(t::Tuple, v::Val{K}) where {K}
-    s = first(t)
-    rest = _signals_with_id(Base.tail(t), v)
-    get_signal_id(typeof(s)) === K ? (s, rest...) : rest
+@inline function _first_signal_with_id(
+    signals::Tuple{AbstractGNSSSignal,Vararg{AbstractGNSSSignal}},
+    ::Val{K},
+) where {K}
+    s = first(signals)
+    get_signal_id(typeof(s)) === K ? (s,) :
+    _first_signal_with_id(Base.tail(signals), Val(K))
 end
 
 # Last sample index (inclusive) this satellite may integrate up to in the

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -80,31 +80,40 @@ blocks in the chunk rather than staying flat per `track!` call. With a single
 thread or the single-threaded `CPUDownconvertAndCorrelator` there is no such
 residual.
 
-The residual measures ~80 B per launch for satellites alone. A `TrackState`
-whose C/N₀ estimators read a measured noise density adds the chunk's noise
-despreads to the same loop as extra work items — see `_dc_group_loop!` — which
-gives the closure the descriptor tuple to root as well and takes the launch to
-~240 B; it also means a **single**-satellite state pays a residual where it
+The residual measures ~96 B per launch, and a `TrackState` whose C/N₀ estimators
+read a measured noise density measures the **same** ~96 B: the chunk's noise
+despreads ride the same loop as extra work items (see `_dc_group_loop!`), but the
+loop reaches their descriptors through one pointer into a reusable box rather than
+by value — see `_park_noise_items!` for why by-value copies cost 152 B of
+Polyester argument tuple and a pointer costs 8. The one thing the noise reference
+still changes is that a **single**-satellite state pays the residual where it
 previously paid none, because the loop then has two items rather than one. What
 that buys is the despread's wall time: as one more item in the parallel loop it
 usually costs a fraction of the ~1.75 µs it costs as a serial pass, and full
-price only when it happens to open a new scheduling step. Both figures are per
-launch and bounded; neither scales with the input buffer.
+price only when it happens to open a new scheduling step. The figure is per launch
+and bounded; it does not scale with the input buffer.
 
-Why it allocates at all — Polyester's `@batch` roots only *bare* `Array`s and
-`isbits` values into its worker tasks for free (that is why a `Vector{Float64}`
-kernel allocates nothing). It pays a small per-launch allocation to root any
-**non-`isbits` struct** referenced inside the region — and it is the struct-ness
-that costs, not the contents: capturing even a plain struct whose only fields
-are `Matrix`es and isbits scalars measures the same ~64 B/launch, whereas
-capturing those same bare arrays measures 0. The culprit here is the GNSS
-**signal**: `GPSL1CA`, for instance, is not `isbits` — it wraps a `Matrix{Int16}`
-code table and a (also non-`isbits`) `SignalLUT`. Each satellite's code-replica
-generation needs its signal, so every `@batch` launch touches that non-`isbits`
-object once. (The per-satellite `TrackedSat` is likewise non-`isbits` — it
-carries the signal plus the CN0/bit buffers — and the loop reaches the signal
-through it, so iterating `Vector{TrackedSat}` is not free the way iterating a
-`Vector{Float64}` is.)
+Why it allocates at all — Polyester copies everything the `@batch` region
+references into **one** argument tuple per launch and heap-allocates that tuple
+(`ManualMemory.Reference`) so the worker tasks can read it. Two rules decide what
+that costs:
+
+  - A tuple whose every member is `isbits` (bare `Array`s become `PtrArray`s, so
+    they qualify) does not escape and is elided outright — that is why a
+    `Vector{Float64}` kernel allocates nothing.
+  - As soon as one member is not, the whole tuple is allocated at its `sizeof`,
+    and each member is copied by *value* if it is an immutable struct, or as a
+    single pointer if it is a mutable object.
+
+Which is why "capture a struct or its bare arrays" is not a wash: a plain struct
+whose fields are `Matrix`es and isbits scalars costs its own `sizeof` in the
+tuple, where the same arrays passed separately cost 0. The culprit here is the
+GNSS **signal**: `GPSL1CA`, for instance, is not `isbits` — it wraps a
+`Matrix{Int16}` code table and a (also non-`isbits`) `SignalLUT` — and each
+satellite's code-replica generation needs it. (The per-satellite `TrackedSat` is
+likewise non-`isbits`, but it is reached *through* `Vector{TrackedSat}`, which is
+mutable and so costs one pointer; it is the loop's other captures that put the
+tuple over the isbits line.)
 
 Note that merely *hoisting* the `SignalLUT` out of the signal does not help — a
 `SignalLUT` is itself a non-`isbits` struct (it wraps `Matrix{Int8}` fields), so
@@ -122,7 +131,7 @@ the region (reconstructing one there sends the generator dynamic and allocates
 far more). Absent that, the only in-tree way to reach 0 is a serial code-gen
 pre-pass, which is allocation-free but serializes ~30 % of the work and slows
 the threaded pipeline — the inferior fallback. Neither is currently worth
-~64 B/block, which is bounded per call and dwarfed by the caller's input buffer.
+~96 B/block, which is bounded per call and dwarfed by the caller's input buffer.
 
 For real-time loops, construct the correlator **once outside** the
 `track!` loop and pass it via the `downconvert_and_correlator` keyword
@@ -928,7 +937,7 @@ function downconvert_and_correlate!(
     _dc_groups!(
         Tuple(track_state.groups),
         noise_items,
-        measure_noise ? length(noise_items) : 0,
+        measure_noise ? _num_noise_items(noise_items) : 0,
         dc,
         measurements,
         chunk_index,
@@ -997,7 +1006,7 @@ end
 # which is what keeps `_check_sample_type` in front of every kernel (so a wrong
 # sample type still throws the curated `ArgumentError` rather than surfacing as a
 # `MethodError` from a worker), and keeps what the `@batch` closure captures down
-# to one tuple.
+# to one pointer (see `_park_noise_items!`).
 #
 # Resolution is per *signal*, keyed off `noise_estimators`, which is what makes
 # "exactly once" structural: two groups carrying the same signal share the one
@@ -1023,16 +1032,81 @@ end
     chunk_duration,
 )
     noise_estimators = track_state.noise_estimators
-    _noise_items_walk(
-        Val(keys(noise_estimators)),
-        Tuple(noise_estimators),
-        dc,
-        track_state.groups,
-        measurements,
-        chunk_index,
-        chunk_duration,
+    _park_noise_items!(
+        track_state.noise_descriptor,
+        _noise_items_walk(
+            Val(keys(noise_estimators)),
+            Tuple(noise_estimators),
+            dc,
+            track_state.groups,
+            measurements,
+            chunk_index,
+            chunk_duration,
+        ),
     )
 end
+
+# Park the descriptors in the `TrackState`'s reusable cell and hand back the box
+# holding them — because *how* the parallel loop reaches its descriptors is what
+# the launch costs, not what they contain.
+#
+# Polyester copies every value the `@batch` region references into one argument
+# tuple it heap-allocates per launch, and the copy is by *value* for an immutable
+# struct: a descriptor carrying a `CorrelatorNoiseEstimator` (48 B), the band's
+# `BandMeasurement` (24 B) and the signal instance (`GPSL1CA` is 56 B) is 152 B of
+# argument tuple, which measured as a rise from ~96 B to 240 B per launch. A
+# *mutable* object is copied as a pointer instead — 8 B whatever it holds — so
+# handing the loop one box costs the launch 8 B and nothing per descriptor.
+#
+# The box has to outlive the launch and be reused across launches, or its own
+# allocation would cost more than the copy it replaces. It cannot be provisioned
+# up front: its type names the caller's `BandMeasurement`, which the `TrackState`
+# does not know until the first correlate call. So the cell is a type-erased
+# `Base.RefValue{Any}` filled on that call and reused thereafter; the *box* inside
+# it is concretely typed, so both the write here and the read in the loop are
+# type-stable, and a caller who changes sample types simply gets a new box once.
+#
+# Writing a descriptor tuple into the box is a store into an existing object —
+# allocation-free — and the box roots everything the descriptors point at, so
+# nothing here relies on the caller keeping anything alive. The flip side is that
+# the box keeps the *last* chunk's `BandMeasurement` — and so the caller's sample
+# buffer — reachable until the next call overwrites it. That is one buffer, and a
+# caller who hands `track!` a fresh buffer per chunk was holding this one anyway.
+#
+# Nothing to measure stays `()`: an empty descriptor set gives the loop nothing to
+# root at all, so a `TrackState` whose C/N₀ estimators read no noise density pays
+# exactly the launch cost it paid before any of this existed.
+@inline _park_noise_items!(::Base.RefValue{Any}, ::Tuple{}) = ()
+@inline function _park_noise_items!(
+    cell::Base.RefValue{Any},
+    items::T,
+) where {T<:Tuple{Any,Vararg{Any}}}
+    box = cell[]
+    box isa Base.RefValue{T} || return _new_noise_items_box!(cell, items)
+    box[] = items
+    box
+end
+
+# First call with this descriptor type (or the first after the caller changed one).
+# `@noinline` so the hot path above stays a load, a type check and a store.
+@noinline function _new_noise_items_box!(
+    cell::Base.RefValue{Any},
+    items::T,
+) where {T<:Tuple}
+    box = Base.RefValue{T}(items)
+    cell[] = box
+    box
+end
+
+# How many work items the loop must add to the satellites' range. A property of the
+# descriptor set's *type*, so it folds to a literal at every call site.
+@inline _num_noise_items(::Tuple{}) = 0
+@inline _num_noise_items(::Base.RefValue{<:Tuple{Vararg{Any,N}}}) where {N} = N
+
+# What a group loop is handed for the chunk's noise work: `()` when there is nothing
+# to measure — including for every group after the one that carries it — and
+# otherwise the single box the descriptors were parked in.
+const _NoiseWork = Union{Tuple{},Base.RefValue{<:Tuple}}
 
 @inline _noise_items_walk(
     ::Val{()},
@@ -1128,7 +1202,11 @@ end
 # Run the `j`-th descriptor. `j` is a runtime index into a heterogeneous tuple, so
 # the walk is a chain of compile-time-known steps rather than an index — it unrolls
 # to `n` comparisons for `n` measured signals, which is one or two in practice.
+# Reading the box is the one dereference the whole scheme costs, and it happens
+# inside the parallel region, on the thread that runs the item.
 @inline _run_noise_item!(::Int, ::Tuple{}, ::Any) = nothing
+@inline _run_noise_item!(j::Int, box::Base.RefValue{<:Tuple}, dc) =
+    _run_noise_item!(j, box[], dc)
 @inline _run_noise_item!(j::Int, items::Tuple, dc) =
     j == 1 ? _apply_noise_item!(first(items), dc) :
     _run_noise_item!(j - 1, Base.tail(items), dc)
@@ -1136,6 +1214,7 @@ end
 # All of them, in order — the serial backends' path, where there is no parallel
 # region to hide the despread in.
 @inline _run_noise_items!(::Tuple{}, ::Any) = nothing
+@inline _run_noise_items!(box::Base.RefValue{<:Tuple}, dc) = _run_noise_items!(box[], dc)
 @inline _run_noise_items!(items::Tuple, dc) =
     (_apply_noise_item!(first(items), dc); _run_noise_items!(Base.tail(items), dc))
 
@@ -1218,7 +1297,7 @@ end
     # The float backends derive nothing from the raw samples worth caching;
     # only the bit-wise backends act on `samples_unchanged`.
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -194,55 +194,96 @@ end
     end
 end
 
-# Per-signal correlation kernel, shared by both CPU backends: generate
-# the code replica into the supplied `code_replica` buffer (from the
-# calling correlator's `ScratchBuffers`), then run the fused kernel via
-# `_fused_with_tile_scratch!` (which supplies SoA tile scratch when the
-# shifts are a runtime-sized `AbstractVector`). Returns a value of the
-# same correlator type as `correlator`.
+# THE per-backend correlation primitive: one despread of one signal over one
+# range of samples, accumulating into `correlator` and returning a value of the
+# same correlator type. Every despread in the package goes through it — the
+# per-satellite single-signal path (`_correlate_signals`) and the open-loop noise
+# reference (`update_noise!`) alike.
 #
-# Args are per-signal scalars: the caller is responsible for picking the
-# right `signal_type`, `correlator`, `code_phase` (modded into the signal's
-# primary period), `code_frequency`, and `sample_shifts` for this signal.
-@inline function _correlate_one_signal!(
+# That is what makes the noise measurement **model-free** structurally rather
+# than by agreement: the reference traverses the identical quantise →
+# downconvert → despread → accumulate path as the prompt because there is only
+# one path to traverse, so the measured `N₀` already carries the quantisation
+# loss, the quantiser's operating point under load and the code amplitude with no
+# per-backend correction. It is also the only thing that *can* work: the one- and
+# two-bit accumulators are popcount **counts** rather than sample sums, so a
+# float-kernel reference would compare `|P|²` and `N̂₀` on incompatible scales.
+# Four adapters kept in step by hand would have had to be re-verified on every
+# kernel change; one primitive cannot drift.
+#
+# Args are per-signal scalars: the caller picks the `signal_type`, `correlator`,
+# `code_phase` (modded into the signal's primary period), `code_frequency` and
+# `sample_shifts`. `carrier_phase` is where the caller's carrier stands — the
+# per-satellite path continues its NCO, the open-loop reference passes `0.0`.
+#
+# `code_replica_size` is what the backend needs *if* it generates a code replica
+# at all: the CPU kernels do, while the Int16 and bit-wise kernels pack the code
+# sign plane inside the kernel and ignore the argument. Size it against the whole
+# sample buffer plus the tap spread, not the slice — `gen_code_replica!` writes
+# *at* `start_sample` while the kernel reads the replica offset by
+# `start_sample - 1`.
+#
+# The CPU method draws that buffer from the calling backend's per-thread
+# `ScratchBuffers`, so one buffer serves the satellites and the noise reference
+# instead of one being held per noise estimator. The two never overlap: the noise
+# pass runs to completion at the top of `downconvert_and_correlate!`, before the
+# per-group satellite loop that reuses the slot, and the threaded backends index
+# the slot by `threadid()`.
+#
+# `use_band_cache` is the other half of that ordering, and the one thing the two
+# callers genuinely disagree about: the bit-wise backends pack a band's
+# measurement sign planes once per group and share them across its satellites, so
+# the per-satellite path may read that cache while the noise reference — running
+# *before* any group packs — must not, since the planes belong to whichever group
+# ran last, possibly on another band or another buffer. Backends without such a
+# cache ignore it.
+@inline function _despread_one_signal!(
     dc::Union{CPUDownconvertAndCorrelator,CPUThreadedDownconvertAndCorrelator},
-    code_replica,
-    signal_type,
     correlator,
-    signal,
+    samples,
+    signal_type,
+    prn,
     sample_shifts,
     code_phase,
     carrier_phase,
     code_frequency,
     carrier_frequency,
     sampling_frequency,
-    signal_start_sample,
-    signal_samples_to_integrate,
-    prn,
+    start_sample,
+    num_samples,
+    code_replica_size,
+    use_band_cache::Bool = true,
 )
-    gen_code_replica!(
-        code_replica,
-        signal_type,
-        code_frequency,
-        sampling_frequency,
-        code_phase,
-        signal_start_sample,
-        signal_samples_to_integrate,
-        sample_shifts,
-        prn,
-    )
-    _fused_with_tile_scratch!(
-        dc,
-        correlator,
-        signal,
-        code_replica,
-        sample_shifts,
-        carrier_frequency,
-        sampling_frequency,
-        carrier_phase,
-        signal_start_sample,
-        signal_samples_to_integrate,
-    )::typeof(correlator)
+    # GNSSSignals' embedded-LUT `gen_code!` is Int8-only (the legacy fixed-point
+    # generator that emitted `get_code_type(s)` — Int16/Float32 — was removed),
+    # so the code replica buffer is `Int8`. The fused kernel reads the replica as
+    # generic `CT = eltype(code_replica)` and widens to Float32, so Int8 works
+    # unchanged; CBOC (Galileo E1B) is the Int8 integer-amplitude approximation.
+    _with_code_replica_buffer(dc, Int8, code_replica_size) do code_replica
+        gen_code_replica!(
+            code_replica,
+            signal_type,
+            code_frequency,
+            sampling_frequency,
+            code_phase,
+            start_sample,
+            num_samples,
+            sample_shifts,
+            prn,
+        )
+        _fused_with_tile_scratch!(
+            dc,
+            correlator,
+            samples,
+            code_replica,
+            sample_shifts,
+            carrier_frequency,
+            sampling_frequency,
+            carrier_phase,
+            start_sample,
+            num_samples,
+        )::typeof(correlator)
+    end
 end
 
 # Dispatch helper for the fused kernel that hands SoA tile buffers from
@@ -592,11 +633,16 @@ end
     (; code_frequency, sample_shifts, code_replica_size, n_blocks, signal_code_phase)
 end
 
-# Single-signal path: gen one code replica + run the in-register fused
-# kernel. Returns a one-tuple of `(new_correlator, is_integration_completed)`.
-# This is the hot path for N=1 — the fused kernel keeps downconverted
-# samples in registers and is ~24% faster than the tile-share kernel
-# below at N=1.
+# Single-signal path, shared by **every** backend: derive this signal's replica
+# parameters, then hand them to the one despread primitive. Returns a one-tuple
+# of `(new_correlator, is_integration_completed)`. This is the hot path for N=1 —
+# on the CPU backends the fused kernel keeps downconverted samples in registers
+# and is ~24% faster than the tile-share kernel below at N=1.
+#
+# Untyped `dc`: the per-backend difference is entirely inside
+# `_despread_one_signal!`, so there is nothing left for a backend to override
+# here. Only the multi-signal method below is still per-backend, because the
+# tile-share kernels take all N signals at once and have no single-signal form.
 @inline function _correlate_signals(
     signals::Tuple{TrackedSignal},
     per_signal_completed::Tuple{Bool},
@@ -613,7 +659,6 @@ end
     num_samples_signal,
 )
     head = signals[1]
-    s = head.signal
     p = _signal_replica_params(
         head,
         code_doppler,
@@ -621,29 +666,22 @@ end
         sampling_frequency,
         num_samples_signal,
     )
-    # GNSSSignals' embedded-LUT `gen_code!` is Int8-only (the legacy fixed-point
-    # generator that emitted `get_code_type(s)` — Int16/Float32 — was removed),
-    # so the code replica buffer is `Int8`. The fused kernel reads the replica as
-    # generic `CT = eltype(code_replica)` and widens to Float32, so Int8 works
-    # unchanged; CBOC (Galileo E1B) is the Int8 integer-amplitude approximation.
-    new_corr = _with_code_replica_buffer(dc, Int8, p.code_replica_size) do code_replica
-        _correlate_one_signal!(
-            dc,
-            code_replica,
-            s,
-            head.correlator,
-            signal,
-            p.sample_shifts,
-            p.signal_code_phase,
-            carrier_phase,
-            p.code_frequency,
-            carrier_frequency,
-            sampling_frequency,
-            signal_start_sample,
-            samples_to_integrate,
-            prn,
-        )
-    end
+    new_corr = _despread_one_signal!(
+        dc,
+        head.correlator,
+        signal,
+        head.signal,
+        prn,
+        p.sample_shifts,
+        p.signal_code_phase,
+        carrier_phase,
+        p.code_frequency,
+        carrier_frequency,
+        sampling_frequency,
+        signal_start_sample,
+        samples_to_integrate,
+        p.code_replica_size,
+    )
     ((new_corr, per_signal_completed[1]),)
 end
 
@@ -1040,68 +1078,6 @@ end
     s = first(t)
     rest = _signals_with_id(Base.tail(t), v)
     get_signal_id(typeof(s)) === K ? (s, rest...) : rest
-end
-
-# One open-loop despread of the noise reference, on this backend's own kernel.
-# This is the only per-backend work the noise reference needs, and it is what
-# makes the measurement **model-free**: the reference traverses the identical
-# quantise → downconvert → despread → accumulate path as the prompt, so the
-# measured `N₀` already carries the quantisation loss, the quantiser's operating
-# point under load and the code amplitude, with no per-backend correction. It
-# also has to: the one- and two-bit accumulators are popcount *counts*, not
-# sample sums, so a float-kernel reference would compare `|P|²` and `N̂₀` on
-# incompatible scales.
-#
-# Returns the correlator's raw accumulators for one slice — every tap, which the
-# caller then pools (at ≥1 chip spacing they are independent looks at one
-# scalar, and nothing about their relative values means anything here).
-#
-# The CPU form is the single-satellite template's body: `gen_code_replica!` plus
-# the fused kernel and nothing else, on a replica buffer owned by the estimator
-# rather than borrowed from the backend's `ScratchBuffers` — so the reference can
-# never alias the per-signal replica path. `gen_code_replica!` writes *at*
-# `start_sample` while the kernel reads the replica offset by `start_sample - 1`,
-# which is why the buffer is sized against the whole measurement rather than the
-# slice.
-@inline function _correlate_noise_reference!(
-    dc::Union{CPUDownconvertAndCorrelator,CPUThreadedDownconvertAndCorrelator},
-    code_replica::Vector{Int8},
-    samples,
-    correlator::AbstractCorrelator,
-    signal_type,
-    prn::Integer,
-    sample_shifts,
-    code_phase,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample::Integer,
-    num_samples::Integer,
-)
-    gen_code_replica!(
-        code_replica,
-        signal_type,
-        code_frequency,
-        sampling_frequency,
-        code_phase,
-        start_sample,
-        num_samples,
-        sample_shifts,
-        prn,
-    )
-    get_accumulators(
-        _fused_standalone!(
-            correlator,
-            samples,
-            code_replica,
-            sample_shifts,
-            carrier_frequency,
-            sampling_frequency,
-            0.0,
-            start_sample,
-            num_samples,
-        ),
-    )
 end
 
 # Last sample index (inclusive) this satellite may integrate up to in the

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -74,11 +74,22 @@ state.
 
 One `@batch` is launched per code block (once per `downconvert_and_correlate!`
 call inside `track!`'s inner loop). When the process runs with more than one
-thread *and* the group has more than one satellite, each launch keeps a small
-Polyester allocation (~64 B), so the total scales with the number of completed
-code blocks in the chunk rather than staying flat per `track!` call. With a
-single thread, a single satellite, or the single-threaded
-`CPUDownconvertAndCorrelator`, there is no such residual.
+thread *and* the loop has more than one work item, each launch keeps a small
+Polyester allocation, so the total scales with the number of completed code
+blocks in the chunk rather than staying flat per `track!` call. With a single
+thread or the single-threaded `CPUDownconvertAndCorrelator` there is no such
+residual.
+
+The residual measures ~80 B per launch for satellites alone. A `TrackState`
+whose C/N₀ estimators read a measured noise density adds the chunk's noise
+despreads to the same loop as extra work items — see `_dc_group_loop!` — which
+gives the closure the descriptor tuple to root as well and takes the launch to
+~240 B; it also means a **single**-satellite state pays a residual where it
+previously paid none, because the loop then has two items rather than one. What
+that buys is the despread's wall time: as one more item in the parallel loop it
+usually costs a fraction of the ~1.75 µs it costs as a serial pass, and full
+price only when it happens to open a new scheduling step. Both figures are per
+launch and bounded; neither scales with the input buffer.
 
 Why it allocates at all — Polyester's `@batch` roots only *bare* `Array`s and
 `isbits` values into its worker tasks for free (that is why a `Vector{Float64}`
@@ -913,17 +924,11 @@ function downconvert_and_correlate!(
     samples_unchanged::Bool = false,
     measure_noise::Bool = true,
 )
-    _update_signal_noise!(
-        dc,
-        track_state,
-        measurements,
-        chunk_index,
-        chunk_duration,
-        measure_noise,
-    )
-    _foreach_group!(
-        _dc_one_group!,
-        track_state.groups,
+    noise_items = _noise_items(dc, track_state, measurements, chunk_index, chunk_duration)
+    _dc_groups!(
+        Tuple(track_state.groups),
+        noise_items,
+        measure_noise ? length(noise_items) : 0,
         dc,
         measurements,
         chunk_index,
@@ -934,48 +939,91 @@ function downconvert_and_correlate!(
     return track_state
 end
 
-# Measure each *signal's* noise floor over the current chunk, before the
-# per-group correlate loop. Defined once on `AbstractDownconvertAndCorrelator`
-# and called from all three `downconvert_and_correlate!` entry points — those are
-# the only places that see `measurements` whole, and therefore the only
-# per-signal-exactly-once sites. `_dc_one_group!` would fire once per *group*, so
-# a signal carried by two groups would be measured twice.
+# Walk the groups, handing the chunk's noise work to the first of them. The items
+# do not *belong* to that group — each carries its own band measurement and its own
+# signal — they only ride its per-satellite loop, which is the whole point: on a
+# threaded backend the despread then runs *alongside* the satellite correlations
+# instead of serially in front of them, and its cost is hidden wherever that loop
+# has a spare thread. Any group would serve equally; the first is the one that
+# needs no runtime choice over a heterogeneous tuple.
 #
-# Walking `noise_estimators` (keyed by signal id) rather than the groups is what
-# makes "exactly once" structural: two groups carrying the same signal share the
-# one estimator that key names, so the reference is despread once for it however
-# the satellites are grouped.
+# Exactly-once still holds, and more simply than before: the items are resolved
+# once from `noise_estimators` (keyed by signal) and executed in one group's loop,
+# so a signal carried by two groups is still despread once however the satellites
+# are grouped. That is why the noise work is not simply pushed into every
+# `_dc_one_group!` — that fires once per *group*.
+#
+# A `TrackState` with no groups has no noise estimators either (they are derived
+# from the groups' slot types), so nothing is dropped here.
+@inline _dc_groups!(::Tuple{}, args::Vararg{Any,8}) = nothing
+@inline function _dc_groups!(
+    groups::Tuple{SignalGroup,Vararg{SignalGroup}},
+    noise_items,
+    n_noise::Int,
+    dc,
+    measurements,
+    chunk_index,
+    chunk_duration,
+    stop_before_partial,
+    samples_unchanged,
+)
+    _dc_one_group!(
+        first(groups),
+        dc,
+        measurements,
+        chunk_index,
+        chunk_duration,
+        stop_before_partial,
+        samples_unchanged,
+        noise_items,
+        n_noise,
+    )
+    _dc_groups!(
+        Base.tail(groups),
+        (),
+        0,
+        dc,
+        measurements,
+        chunk_index,
+        chunk_duration,
+        stop_before_partial,
+        samples_unchanged,
+    )
+end
+
+# The chunk's noise work, resolved once: one descriptor per measured signal,
+# carrying everything the despread needs and nothing it does not. Resolved here,
+# on the caller's thread, rather than inside the parallel region it will run in —
+# which is what keeps `_check_sample_type` in front of every kernel (so a wrong
+# sample type still throws the curated `ArgumentError` rather than surfacing as a
+# `MethodError` from a worker), and keeps what the `@batch` closure captures down
+# to one tuple.
+#
+# Resolution is per *signal*, keyed off `noise_estimators`, which is what makes
+# "exactly once" structural: two groups carrying the same signal share the one
+# estimator that key names, so one descriptor is produced for it however the
+# satellites are grouped.
 #
 # The NamedTuple is walked by tuple recursion rather than by
 # `for (k, v) in pairs(...)`: different signals may hold different estimator
 # types, so a runtime loop over the values is type-unstable and would allocate on
-# every chunk. Recursion unrolls it and each `update_noise!` devirtualises. A
-# signal with no entry does no work at all.
+# every chunk. Recursion unrolls it and each `update_noise!` devirtualises, and the
+# resulting tuple's *length* is a property of the types alone — a signal with no
+# estimator, and a key naming a signal no group tracks, both contribute nothing.
 #
-# **When to skip.** Whether a call re-covers samples an earlier one already
-# measured is the caller's knowledge, not something to infer here, so it arrives
-# as `measure_noise`. The one caller that has to say no is `track!`'s final drain
-# pass: it passes neither `chunk_index` nor `chunk_duration`, so the range
-# defaults to the whole buffer and measuring there would enter every sample into
-# the window a second time. The cost is that a buffer's trailing partial never
-# reaches the window — at most one chunk per `track!` call, and omitting an entry
-# biases `σ̂²` not at all.
-#
-# `samples_unchanged` is deliberately *not* what decides it. It answers a
-# different question — may the backend reuse a sample-derived cache — and `track!`
-# passes it on every chunk after the first, so gating on it would measure chunk 0
-# and then freeze the window for the rest of the buffer.
-@inline function _update_signal_noise!(
+# Note what is deliberately *not* decided here: whether to measure at all. An
+# out-of-range chunk is left to `update_noise!`'s own `num_samples > 0` guard, and
+# `measure_noise` is applied by the caller as a count, because either one folded in
+# here would make the tuple's type depend on a runtime value.
+@inline function _noise_items(
     dc::AbstractDownconvertAndCorrelator,
     track_state::TrackState,
     measurements::BandMeasurements,
     chunk_index::Int,
     chunk_duration,
-    measure_noise::Bool,
 )
-    measure_noise || return nothing
     noise_estimators = track_state.noise_estimators
-    _update_signal_noise_walk!(
+    _noise_items_walk(
         Val(keys(noise_estimators)),
         Tuple(noise_estimators),
         dc,
@@ -986,7 +1034,7 @@ end
     )
 end
 
-@inline _update_signal_noise_walk!(
+@inline _noise_items_walk(
     ::Val{()},
     ::Tuple{},
     ::AbstractDownconvertAndCorrelator,
@@ -994,8 +1042,8 @@ end
     ::BandMeasurements,
     ::Int,
     _,
-) = nothing
-@inline function _update_signal_noise_walk!(
+) = ()
+@inline function _noise_items_walk(
     ::Val{K},
     estimators::Tuple,
     dc::AbstractDownconvertAndCorrelator,
@@ -1004,27 +1052,31 @@ end
     chunk_index::Int,
     chunk_duration,
 ) where {K}
-    _update_one_signal_noise!(
-        first(estimators),
-        Val(first(K)),
-        dc,
-        groups,
-        measurements,
-        chunk_index,
-        chunk_duration,
-    )
-    _update_signal_noise_walk!(
-        Val(Base.tail(K)),
-        Base.tail(estimators),
-        dc,
-        groups,
-        measurements,
-        chunk_index,
-        chunk_duration,
+    (
+        _noise_item(
+            first(estimators),
+            Val(first(K)),
+            dc,
+            groups,
+            measurements,
+            chunk_index,
+            chunk_duration,
+        )...,
+        _noise_items_walk(
+            Val(Base.tail(K)),
+            Base.tail(estimators),
+            dc,
+            groups,
+            measurements,
+            chunk_index,
+            chunk_duration,
+        )...,
     )
 end
 
-@inline function _update_one_signal_noise!(
+# One signal's descriptor, as a 0- or 1-tuple so the "nothing to measure" case is
+# an empty tuple in the *type* domain rather than a `Nothing` to branch on later.
+@inline function _noise_item(
     estimator::AbstractNoiseEstimator,
     ::Val{K},
     dc::AbstractDownconvertAndCorrelator,
@@ -1038,29 +1090,54 @@ end
     # correlator-ingest case, where the window is filled by
     # `append_noise_observation!` instead.
     found = _first_signal_with_id(Tuple(groups), Val(K))
-    isempty(found) && return nothing
+    isempty(found) && return ()
     signal = first(found)
     # The samples are still a *band* property — one front end feeds every signal
     # on it. Only the despreading code, and therefore the measured floor, is per
     # signal.
     m = measurements[_signal_band_id(typeof(signal))]
-    # Same check the group loop runs, and it has to happen here too: the noise
-    # measurement is the *first* thing to touch a band's samples, so without it
-    # a wrong sample type would surface as a `MethodError` from inside a kernel
-    # instead of the curated `ArgumentError`.
     _check_sample_type(dc, m)
     num_samples = get_num_samples(m)
-    last_sample =
-        _chunk_last_sample(chunk_duration, chunk_index, m.sampling_frequency, num_samples)
-    first_sample =
-        _chunk_first_sample(chunk_duration, chunk_index, m.sampling_frequency, num_samples)
-    first_sample > last_sample && return nothing
     # No tracked-PRN set is threaded through: the reference randomises its code
     # phase, so it has no reason to know which PRNs are in use.
-    context = NoiseUpdateContext(signal, chunk_index, dc)
-    update_noise!(estimator, m, first_sample, last_sample, context)
-    nothing
+    ((
+        estimator,
+        m,
+        _chunk_first_sample(chunk_duration, chunk_index, m.sampling_frequency, num_samples),
+        _chunk_last_sample(chunk_duration, chunk_index, m.sampling_frequency, num_samples),
+        signal,
+        chunk_index,
+    ),)
 end
+
+# The `NoiseUpdateContext` is built here rather than stored in the descriptor: the
+# backend is one of the things it carries, and the backend is already captured by
+# the loop this runs in, so storing it would give the `@batch` closure a second
+# reference to root for nothing.
+@inline _apply_noise_item!(item::Tuple, dc) = (
+    update_noise!(
+        item[1],
+        item[2],
+        item[3],
+        item[4],
+        NoiseUpdateContext(item[5], item[6], dc),
+    );
+    nothing
+)
+
+# Run the `j`-th descriptor. `j` is a runtime index into a heterogeneous tuple, so
+# the walk is a chain of compile-time-known steps rather than an index — it unrolls
+# to `n` comparisons for `n` measured signals, which is one or two in practice.
+@inline _run_noise_item!(::Int, ::Tuple{}, ::Any) = nothing
+@inline _run_noise_item!(j::Int, items::Tuple, dc) =
+    j == 1 ? _apply_noise_item!(first(items), dc) :
+    _run_noise_item!(j - 1, Base.tail(items), dc)
+
+# All of them, in order — the serial backends' path, where there is no parallel
+# region to hide the despread in.
+@inline _run_noise_items!(::Tuple{}, ::Any) = nothing
+@inline _run_noise_items!(items::Tuple, dc) =
+    (_apply_noise_item!(first(items), dc); _run_noise_items!(Base.tail(items), dc))
 
 # An instance of signal `K`, searched groups-then-signals and returned as a 0- or
 # 1-tuple so the not-found case stays type-stable instead of widening to
@@ -1119,13 +1196,18 @@ end
 # `_validate_measurements` (band-set/shape/duration check in `track`).
 @inline _check_sample_type(::AbstractDownconvertAndCorrelator, m) = nothing
 
-# Per-group body shared by every backend. Pulled out so `_foreach_group!` can
-# call it on each `SignalGroup` in the (possibly heterogeneous) `groups` tuple
-# without dynamic dispatch / boxing. Routes to this group's band's
-# `BandMeasurement` for the signal buffer and front-end metadata; the
-# serial-vs-`@batch` loop choice is dispatched via `_threading` in
-# `_dc_group_loop!`, and any backend-specific sample-type check runs in
-# `_check_sample_type`.
+# Per-group body shared by every backend. Pulled out so `_dc_groups!` can call it
+# on each `SignalGroup` in the (possibly heterogeneous) `groups` tuple without
+# dynamic dispatch / boxing. Routes to this group's band's `BandMeasurement` for
+# the signal buffer and front-end metadata; the serial-vs-`@batch` loop choice is
+# dispatched via `_threading` in `_dc_group_loop!`, and any backend-specific
+# sample-type check runs in `_check_sample_type`.
+#
+# `noise_items` / `n_noise` are the chunk's noise despreads, non-empty for exactly
+# one group (see `_dc_groups!`). They ride this group's loop without belonging to
+# it: each item carries its own band measurement, so a group's `m` below has
+# nothing to do with them. An empty group still runs when it carries them — there
+# would otherwise be no loop for the despread to ride.
 @inline function _dc_one_group!(
     g::SignalGroup,
     dc::AbstractDownconvertAndCorrelator,
@@ -1136,9 +1218,11 @@ end
     # The float backends derive nothing from the raw samples worth caching;
     # only the bit-wise backends act on `samples_unchanged`.
     samples_unchanged::Bool,
+    noise_items::Tuple,
+    n_noise::Int,
 )
     vals = g.satellites.values
-    isempty(vals) && return nothing
+    isempty(vals) && n_noise == 0 && return nothing
     m = measurements[get_band_id(g.band)]
     _check_sample_type(dc, m)
     num_samples = get_num_samples(m)
@@ -1147,6 +1231,8 @@ end
     _dc_group_loop!(
         dc,
         vals,
+        noise_items,
+        n_noise,
         m.samples,
         num_samples,
         chunk_last_sample,
@@ -1167,19 +1253,61 @@ struct _BatchLoop end
 @inline _threading(::AbstractDownconvertAndCorrelator) = _SerialLoop()
 @inline _threading(::CPUThreadedDownconvertAndCorrelator) = _BatchLoop()
 
-@inline _dc_group_loop!(dc::AbstractDownconvertAndCorrelator, vals, args::Vararg{Any,6}) =
-    _dc_group_loop!(_threading(dc), dc, vals, args...)
+@inline _dc_group_loop!(
+    dc::AbstractDownconvertAndCorrelator,
+    vals,
+    noise_items,
+    n_noise::Int,
+    args::Vararg{Any,6},
+) = _dc_group_loop!(_threading(dc), dc, vals, noise_items, n_noise, args...)
 
-@inline function _dc_group_loop!(::_SerialLoop, dc, vals, args::Vararg{Any,6})
+# Serial: nothing to hide the despread behind, so run it first — the order it had
+# when the measurement was a pass of its own.
+@inline function _dc_group_loop!(
+    ::_SerialLoop,
+    dc,
+    vals,
+    noise_items,
+    n_noise::Int,
+    args::Vararg{Any,6},
+)
+    n_noise > 0 && _run_noise_items!(noise_items, dc)
     @inbounds for i in eachindex(vals)
         vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
     end
     return nothing
 end
 
-@inline function _dc_group_loop!(::_BatchLoop, dc, vals, args::Vararg{Any,6})
-    @batch for i = 1:length(vals)
-        @inbounds vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
+# Threaded: the noise despreads are extra work items on the end of the satellites'
+# index range, so `@batch` schedules them across the same threads. A despread of one
+# chunk costs about what one satellite's correlation does, so they are well-sized
+# items rather than stragglers — and wherever the satellite range does not already
+# fill every thread, the despread costs close to nothing in wall time.
+#
+# The branch is on a runtime `i` but is loop-invariant per thread block and
+# perfectly predicted; both arms are compiled, and `_run_noise_item!` resolves its
+# heterogeneous tuple by an unrolled walk rather than an index.
+#
+# Thread-safety rests on two things already true: each item is the only writer of
+# its own estimator's window, `totals` and RNG stream — so no two threads touch one
+# estimator, and the seeded draw order within an item is unchanged, keeping runs
+# reproducible — and `_despread_one_signal!` takes its replica scratch from the
+# backend's per-thread slot, which `@batch` pins for the duration of an iteration.
+@inline function _dc_group_loop!(
+    ::_BatchLoop,
+    dc,
+    vals,
+    noise_items,
+    n_noise::Int,
+    args::Vararg{Any,6},
+)
+    n = length(vals)
+    @batch for i = 1:(n+n_noise)
+        if i <= n
+            @inbounds vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
+        else
+            _run_noise_item!(i - n, noise_items, dc)
+        end
     end
     return nothing
 end

--- a/src/downconvert_and_correlate_int16.jl
+++ b/src/downconvert_and_correlate_int16.jl
@@ -1197,63 +1197,60 @@ end
     map(tuple, new_corrs, per_signal_completed)
 end
 
-# Per-signal correlate for the integer backend: single signal, static tap count,
-# any antenna count M. Returns the one-tuple
-# `((new_correlator, is_integration_completed),)` matching the Float32 backend's
-# `_correlate_signals` contract.
-@inline function _correlate_signals(
-    signals::Tuple{TrackedSignal},
-    per_signal_completed::Tuple{Bool},
+# The despread primitive on this backend's kernel — see `_despread_one_signal!`
+# in downconvert_and_correlate_cpu.jl for the contract and for why the noise
+# reference must go through the same kernel as the prompt. Serves the
+# per-satellite single-signal path and the open-loop noise reference alike; the
+# shared `_correlate_signals` above it needs no `_Int16DC` method of its own.
+#
+# `code_replica_size` is ignored: this backend packs the code sign plane inside
+# the kernel, so there is no replica buffer to size (which is also why it costs
+# the noise reference nothing here). So is `use_band_cache` — the shared band
+# sign planes are a bit-wise-backend thing; this kernel packs per call.
+@inline _despread_one_signal!(
     dc::_Int16DC,
-    signal,
-    code_doppler,
-    code_phase,
-    carrier_frequency,
-    carrier_phase,
-    sampling_frequency,
-    signal_start_sample,
-    samples_to_integrate,
+    correlator,
+    samples,
+    signal_type,
     prn,
-    num_samples_signal,
-)
-    head = signals[1]
-    s = head.signal
-    correlator = head.correlator
-    p = _signal_replica_params(
-        head,
-        code_doppler,
-        code_phase,
-        sampling_frequency,
-        num_samples_signal,
-    )
-    new_acc = _int16_hybrid_blocked!(
+    sample_shifts,
+    code_phase,
+    carrier_phase,
+    code_frequency,
+    carrier_frequency,
+    sampling_frequency,
+    start_sample,
+    num_samples,
+    ::Any,
+    ::Bool = true,
+) = update_accumulator(
+    correlator,
+    get_accumulators(correlator) .+ _int16_hybrid_blocked!(
         dc,
-        signal,
+        samples,
         _num_ants_val(correlator),
-        s,
+        signal_type,
         prn,
-        p.sample_shifts,
-        p.signal_code_phase,
+        sample_shifts,
+        code_phase,
         carrier_phase,
-        p.code_frequency,
+        code_frequency,
         carrier_frequency,
         sampling_frequency,
-        signal_start_sample,
-        samples_to_integrate,
-    )
-    prev = get_accumulators(correlator)
-    new_corr = update_accumulator(correlator, prev .+ new_acc)
-    ((new_corr, per_signal_completed[1]),)
-end
+        start_sample,
+        num_samples,
+    ),
+)
 
 # ── Group/measurement plumbing ────────────────────────────────────────────────
 # The per-sat loop (`_update_tracked_sat_correlator`), the group body
 # (`_dc_one_group!`), and the public `downconvert_and_correlate(!)` entry points
 # are all backend-agnostic and inherited from the CPU backend
 # (`downconvert_and_correlate_cpu.jl`) via `AbstractDownconvertAndCorrelator` —
-# the integer-specific work already routes through `_correlate_signals` and
-# `_scratch_buffers` dispatch. This backend only supplies the two hooks the
-# shared plumbing dispatches on: a sample-type check and a threading trait.
+# the integer-specific work already routes through `_despread_one_signal!` /
+# `_correlate_signals` and `_scratch_buffers` dispatch. This backend only supplies
+# the two hooks the shared plumbing dispatches on: a sample-type check and a
+# threading trait.
 
 # Reject non-`Complex{Int16}` sample buffers up front (12-bit ADC contract).
 @inline _check_sample_type(::_Int16DC, m) =
@@ -1269,49 +1266,3 @@ end
     )
 
 @inline _threading(::Int16ThreadedDownconvertAndCorrelator) = _BatchLoop()
-
-# Open-loop despread of the band's noise reference on this backend's kernel —
-# see `_correlate_noise_reference!` in downconvert_and_correlate_cpu.jl for why
-# the reference must go through the same kernel as the prompt. The bit-wise
-# accumulators are popcount counts rather than sample sums, so a float-kernel
-# reference would put `|P|²` and `N̂₀` on incompatible scales.
-#
-# `code_replica` goes unused here: this backend packs the code sign plane inside
-# the kernel.
-@inline _correlate_noise_reference!(
-    dc::_Int16DC,
-    ::Vector{Int8},
-    samples,
-    correlator::AbstractCorrelator,
-    signal_type,
-    prn::Integer,
-    sample_shifts,
-    code_phase,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample::Integer,
-    num_samples::Integer,
-) = _int16_hybrid_blocked!(
-    dc,
-    samples,
-    _num_ants_val(correlator),
-    signal_type,
-    prn,
-    sample_shifts,
-    code_phase,
-    0.0,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample,
-    num_samples,
-)
-
-# This backend packs the code sign plane inside its own kernel, so the noise
-# reference's `code_replica` scratch goes unread — see `_grow_noise_code_replica!`
-# in noise_estimators/correlator.jl. Leave it empty rather than sizing it to the
-# measurement: that byte-per-sample buffer would be allocated and held per signal
-# for something never looked at.
-@inline _grow_noise_code_replica!(::_Int16DC, code_replica::Vector{Int8}, ::Integer) =
-    code_replica

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1258,7 +1258,7 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1258,11 +1258,17 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
+    noise_items::Tuple,
+    n_noise::Int,
 )
     vals = g.satellites.values
-    isempty(vals) && return nothing
+    isempty(vals) && n_noise == 0 && return nothing
     m = measurements[get_band_id(g.band)]
     _check_sample_type(dc, m)
+    # The pack below is sized by the *satellite* count alone: a noise item riding
+    # this loop passes `use_band_cache = false` (its band may not even be this one),
+    # so it neither reads the planes nor should influence whether they are built.
+    #
     # Pack the band's measurement sign planes ONCE, shared across sats — but only for >1 sat:
     # for a single sat the shared pack + per-sat realign copy is slower than packing that one sat
     # directly, so empty the band buffer to select the kernel's per-sat path.
@@ -1293,6 +1299,8 @@ end
     _dc_group_loop!(
         dc,
         vals,
+        noise_items,
+        n_noise,
         m.samples,
         num_samples,
         chunk_last_sample,

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1324,56 +1324,12 @@ end
     return nothing
 end
 
-"""
-$(SIGNATURES)
-
-Downconvert and correlate all satellites with the one-bit bit-wise backend.
-"""
-function downconvert_and_correlate(
-    dc::_OneBitDC,
-    measurements::BandMeasurements,
-    track_state::TrackState;
-    kwargs...,
-)
-    new_track_state =
-        TrackState(track_state; groups = _copy_groups_slot_vectors(track_state.groups))
-    downconvert_and_correlate!(dc, measurements, new_track_state; kwargs...)
-end
-
-"""
-$(SIGNATURES)
-
-In-place one-bit downconvert and correlate. Returns the same `track_state`.
-"""
-function downconvert_and_correlate!(
-    dc::_OneBitDC,
-    measurements::BandMeasurements,
-    track_state::TrackState;
-    chunk_index::Int = 0,
-    chunk_duration = nothing,
-    stop_before_partial::Bool = false,
-    samples_unchanged::Bool = false,
-)
-    _update_signal_noise!(
-        dc,
-        track_state,
-        measurements,
-        chunk_index,
-        chunk_duration,
-        samples_unchanged,
-    )
-    _foreach_group!(
-        _dc_one_group!,
-        track_state.groups,
-        dc,
-        measurements,
-        chunk_index,
-        chunk_duration,
-        stop_before_partial,
-        samples_unchanged,
-    )
-    return track_state
-end
+# The public `downconvert_and_correlate(!)` entry points are the backend-agnostic
+# ones in downconvert_and_correlate_cpu.jl, inherited via
+# `AbstractDownconvertAndCorrelator`: this backend's methods were byte-identical to
+# them, so the only thing they added was a third copy of the noise pass's call
+# site. Everything one-bit-specific is reached through `_despread_one_signal!`,
+# `_dc_one_group!`, `_check_sample_type` and `_dc_group_loop!`.
 
 # Reject non-`Complex{Int16}` sample buffers up front (12-bit ADC contract).
 # Defined as the shared `_check_sample_type` hook rather than inline in

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -388,10 +388,17 @@ const _OneBitDC =
 @inline _ob_num_ants_val(::AbstractCorrelator{M}) where {M} = NumAnts{M}()
 
 # ── The one-bit hybrid-blocked kernel ─────────────────────────────────────────
-# Returns this integration's correlation contribution: `Vector` of `NC` complex
+# Returns this integration's correlation contribution: `SVector{NC}` of complex
 # sums (one per tap) — `ComplexF64` (M=1) or `SVector{M,ComplexF64}` (M>1) — to be
 # added to the correlator's running accumulators. `@generated` over (NC, M): the
 # per-(antenna, tap) popcount accumulators live in named locals and unroll.
+#
+# `SVector` and not `Vector` because `NC` is a parameter here, so the result needs
+# no heap cell at all — matching `_int16_hybrid_blocked!`. It used to be a
+# `Vector`, which the compiler elided at the per-satellite call site but *not* at
+# the noise reference's, leaving that one call 112 B per despread (and so ~1 kB per
+# chunk at ten sub-integrations) on these two backends alone. This kernel's dynamic
+# fallback below, where `NC` is a runtime value, still returns a `Vector`.
 @generated function _onebit_hybrid_blocked!(
     dc::_OneBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -461,9 +468,7 @@ const _OneBitDC =
             :(SVector{$M,ComplexF64}(tuple($(ant...))))
         end
     end
-    ret =
-        M == 1 ? :(ComplexF64[$([tapval(k) for k = 1:NC]...)]) :
-        :(SVector{M,ComplexF64}[$([tapval(k) for k = 1:NC]...)])
+    ret = :(SVector{$NC}(tuple($([tapval(k) for k = 1:NC]...))))
 
     quote
         # Bit-wise correlation keeps only the code's SIGN, so it needs a binary (±1,
@@ -638,9 +643,12 @@ end
 # at runtime and horizontally sums each popcount chunk into per-(antenna, tap) Int64
 # totals. Not the hot path (it allocates the offset/total scratch and sums per chunk),
 # but bit-identical to the `@generated` kernel: `sum` over chunks of `sum(count_ones)`
-# equals `sum(count_ones)` over all chunks. Returns `Vector{ComplexF64}` (M=1) or
-# `Vector{SVector{M,ComplexF64}}` (M>1). `SVector` shifts are more specific and
-# dispatch to the `@generated` method above, so EPL/VEPL keep the fast unrolled path.
+# equals `sum(count_ones)` over all chunks. Returns a `Vector` — of `ComplexF64` (M=1)
+# or `SVector{M,ComplexF64}` (M>1) — rather than the `@generated` method's
+# `SVector{NC}`, because here the tap count is only known at runtime; the caller
+# broadcasts either shape onto the correlator's accumulators. `SVector` shifts are more
+# specific and dispatch to the `@generated` method above, so EPL/VEPL keep the fast
+# unrolled path.
 function _onebit_hybrid_blocked!(
     dc::_OneBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -1052,8 +1060,11 @@ end
         push!(sigs.args, signal_block(i))
     end
 
-    # Finalize: per signal, a Vector of NCᵢ tap sums — Iₓ = 2N − 2(A+B), Qₓ = 2(E − C)
-    # (matching the single-signal kernel's return so `_correlate_signals` is shared).
+    # Finalize: per signal, a Vector of NCᵢ tap sums — Iₓ = 2N − 2(A+B), Qₓ = 2(E − C).
+    # A `Vector` and not the single-signal kernel's `SVector{NC}`: these are consumed by
+    # the multi-signal `_correlate_signals`, which broadcasts each onto its signal's
+    # accumulators and lets the compiler elide the cell — which, unlike at the noise
+    # reference's call site, it does (measured 0 B for a two-signal satellite).
     function tapval(i, k)
         A(j) = s(Symbol("A_$(i)_$(j)_$k"))
         B(j) = s(Symbol("B_$(i)_$(j)_$k"))

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1302,27 +1302,7 @@ end
     )
 end
 
-@inline function _dc_group_loop!(
-    dc::OneBitDownconvertAndCorrelator,
-    vals,
-    args::Vararg{Any,6},
-)
-    @inbounds for i in eachindex(vals)
-        vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
-    end
-    return nothing
-end
-
-@inline function _dc_group_loop!(
-    dc::OneBitThreadedDownconvertAndCorrelator,
-    vals,
-    args::Vararg{Any,6},
-)
-    @batch for i = 1:length(vals)
-        @inbounds vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
-    end
-    return nothing
-end
+@inline _threading(::OneBitThreadedDownconvertAndCorrelator) = _BatchLoop()
 
 # The public `downconvert_and_correlate(!)` entry points are the backend-agnostic
 # ones in downconvert_and_correlate_cpu.jl, inherited via

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1142,49 +1142,55 @@ end
 end
 
 # ── Correlate / plumbing (mirrors the CPU/Int16 backends) ─────────────────────
-# Single signal per sat: one kernel call.
-@inline function _correlate_signals(
-    signals::Tuple{TrackedSignal},
-    per_signal_completed::Tuple{Bool},
+# The despread primitive on this backend's kernel — see `_despread_one_signal!`
+# in downconvert_and_correlate_cpu.jl for the contract and for why the noise
+# reference must go through the same kernel as the prompt (here it is not merely
+# desirable: the one-bit accumulators are popcount counts rather than sample sums,
+# so a float-kernel reference would put `|P|²` and `N̂₀` on incompatible scales).
+# Serves the per-satellite single-signal path and the open-loop noise reference
+# alike, so the shared `_correlate_signals` needs no `_OneBitDC` method.
+#
+# `code_replica_size` is ignored: this backend packs the code sign plane inside
+# the kernel, so there is no replica buffer to size. `use_band_cache` is the one
+# it does read — `_dc_one_group!` packs the band's measurement sign planes once
+# per group and the per-satellite path reads them, while the noise reference,
+# running before any group packs, must pass `false` (the planes would be whichever
+# group ran last).
+@inline _despread_one_signal!(
     dc::_OneBitDC,
-    signal,
-    code_doppler,
-    code_phase,
-    carrier_frequency,
-    carrier_phase,
-    sampling_frequency,
-    signal_start_sample,
-    samples_to_integrate,
+    correlator,
+    samples,
+    signal_type,
     prn,
-    num_samples_signal,
-)
-    head = signals[1]
-    p = _signal_replica_params(
-        head,
-        code_doppler,
-        code_phase,
-        sampling_frequency,
-        num_samples_signal,
-    )
-    new_acc = _onebit_hybrid_blocked!(
+    sample_shifts,
+    code_phase,
+    carrier_phase,
+    code_frequency,
+    carrier_frequency,
+    sampling_frequency,
+    start_sample,
+    num_samples,
+    ::Any,
+    use_band_cache::Bool = true,
+) = update_accumulator(
+    correlator,
+    get_accumulators(correlator) .+ _onebit_hybrid_blocked!(
         dc,
-        signal,
-        _ob_num_ants_val(head.correlator),
-        head.signal,
+        samples,
+        _ob_num_ants_val(correlator),
+        signal_type,
         prn,
-        p.sample_shifts,
-        p.signal_code_phase,
+        sample_shifts,
+        code_phase,
         carrier_phase,
-        p.code_frequency,
+        code_frequency,
         carrier_frequency,
         sampling_frequency,
-        signal_start_sample,
-        samples_to_integrate,
-    )
-    new_corr =
-        update_accumulator(head.correlator, get_accumulators(head.correlator) .+ new_acc)
-    ((new_corr, per_signal_completed[1]),)
-end
+        start_sample,
+        num_samples,
+        use_band_cache,
+    ),
+)
 
 # Multiple signals per sat: share one carrier + measurement downconvert across the
 # sat's signals via the tile-share kernel. Returns the per-signal
@@ -1369,46 +1375,6 @@ function downconvert_and_correlate!(
     return track_state
 end
 
-# Open-loop despread of the band's noise reference on this backend's kernel —
-# see `_correlate_noise_reference!` in downconvert_and_correlate_cpu.jl for why
-# the reference must go through the same kernel as the prompt. The bit-wise
-# accumulators are popcount counts rather than sample sums, so a float-kernel
-# reference would put `|P|²` and `N̂₀` on incompatible scales.
-#
-# `code_replica` goes unused here: this backend packs the code sign plane inside
-# the kernel.
-@inline _correlate_noise_reference!(
-    dc::_OneBitDC,
-    ::Vector{Int8},
-    samples,
-    correlator::AbstractCorrelator,
-    signal_type,
-    prn::Integer,
-    sample_shifts,
-    code_phase,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample::Integer,
-    num_samples::Integer,
-) = _onebit_hybrid_blocked!(
-    dc,
-    samples,
-    _ob_num_ants_val(correlator),
-    signal_type,
-    prn,
-    sample_shifts,
-    code_phase,
-    0.0,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample,
-    num_samples,
-    false,   # never the shared band pack: it belongs to whichever
-    # group ran last, which may be another band or another buffer
-)
-
 # Reject non-`Complex{Int16}` sample buffers up front (12-bit ADC contract).
 # Defined as the shared `_check_sample_type` hook rather than inline in
 # `_dc_one_group!` so the per-band noise measurement — which runs before the
@@ -1425,11 +1391,3 @@ end
             ),
         ),
     )
-
-# This backend packs the code sign plane inside its own kernel, so the noise
-# reference's `code_replica` scratch goes unread — see `_grow_noise_code_replica!`
-# in noise_estimators/correlator.jl. Leave it empty rather than sizing it to the
-# measurement: that byte-per-sample buffer would be allocated and held per signal
-# for something never looked at.
-@inline _grow_noise_code_replica!(::_OneBitDC, code_replica::Vector{Int8}, ::Integer) =
-    code_replica

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1743,7 +1743,7 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1813,56 +1813,12 @@ end
     return nothing
 end
 
-"""
-$(SIGNATURES)
-
-Downconvert and correlate all satellites with the two-bit bit-wise backend.
-"""
-function downconvert_and_correlate(
-    dc::_TwoBitDC,
-    measurements::BandMeasurements,
-    track_state::TrackState;
-    kwargs...,
-)
-    new_track_state =
-        TrackState(track_state; groups = _copy_groups_slot_vectors(track_state.groups))
-    downconvert_and_correlate!(dc, measurements, new_track_state; kwargs...)
-end
-
-"""
-$(SIGNATURES)
-
-In-place two-bit downconvert and correlate. Returns the same `track_state`.
-"""
-function downconvert_and_correlate!(
-    dc::_TwoBitDC,
-    measurements::BandMeasurements,
-    track_state::TrackState;
-    chunk_index::Int = 0,
-    chunk_duration = nothing,
-    stop_before_partial::Bool = false,
-    samples_unchanged::Bool = false,
-)
-    _update_signal_noise!(
-        dc,
-        track_state,
-        measurements,
-        chunk_index,
-        chunk_duration,
-        samples_unchanged,
-    )
-    _foreach_group!(
-        _dc_one_group!,
-        track_state.groups,
-        dc,
-        measurements,
-        chunk_index,
-        chunk_duration,
-        stop_before_partial,
-        samples_unchanged,
-    )
-    return track_state
-end
+# The public `downconvert_and_correlate(!)` entry points are the backend-agnostic
+# ones in downconvert_and_correlate_cpu.jl, inherited via
+# `AbstractDownconvertAndCorrelator`: this backend's methods were byte-identical to
+# them, so the only thing they added was a third copy of the noise pass's call
+# site. Everything two-bit-specific is reached through `_despread_one_signal!`,
+# `_dc_one_group!`, `_check_sample_type` and `_dc_group_loop!`.
 
 # Reject non-`Complex{Int16}` sample buffers up front (12-bit ADC contract).
 # Defined as the shared `_check_sample_type` hook rather than inline in

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -738,10 +738,17 @@ const _TwoBitDC =
 end
 
 # ── The two-bit hybrid-blocked kernel ─────────────────────────────────────────
-# Returns this integration's correlation contribution: `Vector` of `NC` complex sums (one
+# Returns this integration's correlation contribution: `SVector{NC}` of complex sums (one
 # per tap) — `ComplexF64` (M=1) or `SVector{M,ComplexF64}` (M>1) — to be added to the
 # correlator's running accumulators. `@generated` over (NC, M): the per-(antenna, tap)
 # IS/IF/QS/QF and per-antenna GXA accumulators live in named locals and unroll.
+#
+# `SVector` and not `Vector` because `NC` is a parameter here, so the result needs no heap
+# cell at all — matching `_int16_hybrid_blocked!`. It used to be a `Vector`, which the
+# compiler elided at the per-satellite call site but *not* at the noise reference's,
+# leaving that one call 112 B per despread (and so ~1 kB per chunk at ten
+# sub-integrations) on this backend and the one-bit one alone. This kernel's dynamic
+# fallback below, where `NC` is a runtime value, still returns a `Vector`.
 @generated function _twobit_hybrid_blocked!(
     dc::_TwoBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -858,9 +865,7 @@ end
             :(SVector{$M,ComplexF64}(tuple($([cplx(j) for j = 1:M]...))))
         end
     end
-    ret =
-        M == 1 ? :(ComplexF64[$([tapval(k) for k = 1:NC]...)]) :
-        :(SVector{M,ComplexF64}[$([tapval(k) for k = 1:NC]...)])
+    ret = :(SVector{$NC}(tuple($([tapval(k) for k = 1:NC]...))))
 
     quote
         _tb_check_modulation(signal_type)
@@ -1038,8 +1043,10 @@ end
 # runtime-sized `AbstractVector`. Mirrors the one-bit dynamic method: same block
 # pipeline, but loops taps/antennas at runtime and horizontally sums each popcount chunk
 # into per-(antenna, tap) Int64 totals. Not the hot path, but bit-identical to the
-# `@generated` kernel. `SVector` shifts dispatch to the `@generated` method above, so
-# EPL/VEPL keep the fast unrolled path.
+# `@generated` kernel. Returns a `Vector` rather than that kernel's `SVector{NC}`,
+# because here the tap count is only known at runtime; the caller broadcasts either
+# shape onto the correlator's accumulators. `SVector` shifts dispatch to the
+# `@generated` method above, so EPL/VEPL keep the fast unrolled path.
 function _twobit_hybrid_blocked!(
     dc::_TwoBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1743,11 +1743,16 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
+    noise_items::Tuple,
+    n_noise::Int,
 )
     vals = g.satellites.values
-    isempty(vals) && return nothing
+    isempty(vals) && n_noise == 0 && return nothing
     m = measurements[get_band_id(g.band)]
     _check_sample_type(dc, m)
+    # The pack below is sized by the *satellite* count alone: a noise item riding
+    # this loop passes `use_band_cache = false` (its band may not even be this one),
+    # so it neither reads the planes nor should influence whether they are built.
     # Pack the band's measurement planes ONCE, shared across sats — but only for >1 sat:
     # for a single sat the shared pack + per-sat realign copy is slower than packing that
     # one sat directly, so empty the band buffer to select the kernel's per-sat path.
@@ -1782,6 +1787,8 @@ end
     _dc_group_loop!(
         dc,
         vals,
+        noise_items,
+        n_noise,
         m.samples,
         num_samples,
         chunk_last_sample,

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1791,27 +1791,7 @@ end
     )
 end
 
-@inline function _dc_group_loop!(
-    dc::TwoBitDownconvertAndCorrelator,
-    vals,
-    args::Vararg{Any,6},
-)
-    @inbounds for i in eachindex(vals)
-        vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
-    end
-    return nothing
-end
-
-@inline function _dc_group_loop!(
-    dc::TwoBitThreadedDownconvertAndCorrelator,
-    vals,
-    args::Vararg{Any,6},
-)
-    @batch for i = 1:length(vals)
-        @inbounds vals[i] = _update_tracked_sat_correlator(vals[i], dc, args...)
-    end
-    return nothing
-end
+@inline _threading(::TwoBitThreadedDownconvertAndCorrelator) = _BatchLoop()
 
 # The public `downconvert_and_correlate(!)` entry points are the backend-agnostic
 # ones in downconvert_and_correlate_cpu.jl, inherited via

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1627,49 +1627,55 @@ end
 end
 
 # ── Correlate / plumbing (mirrors the one-bit backend) ────────────────────────
-# Single signal per sat: one kernel call.
-@inline function _correlate_signals(
-    signals::Tuple{TrackedSignal},
-    per_signal_completed::Tuple{Bool},
+# The despread primitive on this backend's kernel — see `_despread_one_signal!`
+# in downconvert_and_correlate_cpu.jl for the contract and for why the noise
+# reference must go through the same kernel as the prompt (here it is not merely
+# desirable: the two-bit accumulators are popcount counts rather than sample sums,
+# so a float-kernel reference would put `|P|²` and `N̂₀` on incompatible scales).
+# Serves the per-satellite single-signal path and the open-loop noise reference
+# alike, so the shared `_correlate_signals` needs no `_TwoBitDC` method.
+#
+# `code_replica_size` is ignored: this backend packs the code sign plane inside
+# the kernel, so there is no replica buffer to size. `use_band_cache` is the one
+# it does read — `_dc_one_group!` packs the band's measurement sign planes once
+# per group and the per-satellite path reads them, while the noise reference,
+# running before any group packs, must pass `false` (the planes would be whichever
+# group ran last).
+@inline _despread_one_signal!(
     dc::_TwoBitDC,
-    signal,
-    code_doppler,
-    code_phase,
-    carrier_frequency,
-    carrier_phase,
-    sampling_frequency,
-    signal_start_sample,
-    samples_to_integrate,
+    correlator,
+    samples,
+    signal_type,
     prn,
-    num_samples_signal,
-)
-    head = signals[1]
-    p = _signal_replica_params(
-        head,
-        code_doppler,
-        code_phase,
-        sampling_frequency,
-        num_samples_signal,
-    )
-    new_acc = _twobit_hybrid_blocked!(
+    sample_shifts,
+    code_phase,
+    carrier_phase,
+    code_frequency,
+    carrier_frequency,
+    sampling_frequency,
+    start_sample,
+    num_samples,
+    ::Any,
+    use_band_cache::Bool = true,
+) = update_accumulator(
+    correlator,
+    get_accumulators(correlator) .+ _twobit_hybrid_blocked!(
         dc,
-        signal,
-        _tb_num_ants_val(head.correlator),
-        head.signal,
+        samples,
+        _tb_num_ants_val(correlator),
+        signal_type,
         prn,
-        p.sample_shifts,
-        p.signal_code_phase,
+        sample_shifts,
+        code_phase,
         carrier_phase,
-        p.code_frequency,
+        code_frequency,
         carrier_frequency,
         sampling_frequency,
-        signal_start_sample,
-        samples_to_integrate,
-    )
-    new_corr =
-        update_accumulator(head.correlator, get_accumulators(head.correlator) .+ new_acc)
-    ((new_corr, per_signal_completed[1]),)
-end
+        start_sample,
+        num_samples,
+        use_band_cache,
+    ),
+)
 
 # Multiple signals per sat: share one carrier + measurement downconvert across the
 # sat's signals via the tile-share kernel. Returns the per-signal
@@ -1858,46 +1864,6 @@ function downconvert_and_correlate!(
     return track_state
 end
 
-# Open-loop despread of the band's noise reference on this backend's kernel —
-# see `_correlate_noise_reference!` in downconvert_and_correlate_cpu.jl for why
-# the reference must go through the same kernel as the prompt. The bit-wise
-# accumulators are popcount counts rather than sample sums, so a float-kernel
-# reference would put `|P|²` and `N̂₀` on incompatible scales.
-#
-# `code_replica` goes unused here: this backend packs the code sign plane inside
-# the kernel.
-@inline _correlate_noise_reference!(
-    dc::_TwoBitDC,
-    ::Vector{Int8},
-    samples,
-    correlator::AbstractCorrelator,
-    signal_type,
-    prn::Integer,
-    sample_shifts,
-    code_phase,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample::Integer,
-    num_samples::Integer,
-) = _twobit_hybrid_blocked!(
-    dc,
-    samples,
-    _tb_num_ants_val(correlator),
-    signal_type,
-    prn,
-    sample_shifts,
-    code_phase,
-    0.0,
-    code_frequency,
-    carrier_frequency,
-    sampling_frequency,
-    start_sample,
-    num_samples,
-    false,   # never the shared band pack: it belongs to whichever
-    # group ran last, which may be another band or another buffer
-)
-
 # Reject non-`Complex{Int16}` sample buffers up front (12-bit ADC contract).
 # Defined as the shared `_check_sample_type` hook rather than inline in
 # `_dc_one_group!` so the per-band noise measurement — which runs before the
@@ -1914,11 +1880,3 @@ end
             ),
         ),
     )
-
-# This backend packs the code sign plane inside its own kernel, so the noise
-# reference's `code_replica` scratch goes unread — see `_grow_noise_code_replica!`
-# in noise_estimators/correlator.jl. Leave it empty rather than sizing it to the
-# measurement: that byte-per-sample buffer would be allocated and held per signal
-# for something never looked at.
-@inline _grow_noise_code_replica!(::_TwoBitDC, code_replica::Vector{Int8}, ::Integer) =
-    code_replica

--- a/src/noise_estimators/correlator.jl
+++ b/src/noise_estimators/correlator.jl
@@ -148,13 +148,6 @@ interferer resolves. On an FPGA an arbitrary code phase is *easier* than phase 0
     to write back and the struct is never rebuilt — which is what lets per-signal
     state live in an immutable [`TrackState`](@ref).
 
-  - `code_replica` — scratch for the software despread, grown once and reused.
-    Held here rather than borrowed from the backend's `ScratchBuffers` so the
-    reference can never alias the per-signal replica path. Grown only on the
-    backends that read it: the Int16 and bit-wise kernels pack the code sign
-    plane themselves, so on those it stays empty rather than costing a byte per
-    sample of every buffer.
-
   - `totals` — the window's running sums (span, `M`-weighted density, looks),
     maintained as entries are pushed and dropped. They are what keeps both
     `append_noise_observation!` and `get_noise_density` **O(1)**; recomputing
@@ -186,7 +179,6 @@ struct CorrelatorNoiseEstimator{D,T,R<:AbstractRNG} <: AbstractNoiseEstimator
     tap_code_shift::Float64
     carrier_dither::typeof(1.0Hz)
     buffered::Vector{NoiseObservation{D,T}}
-    code_replica::Vector{Int8}
     totals::Base.RefValue{NoiseWindowTotals{D,T}}
     rng::R
 end
@@ -233,7 +225,6 @@ function CorrelatorNoiseEstimator(;
         Float64(tap_code_shift),
         uconvert(Hz, float(carrier_dither)),
         buffered,
-        Int8[],
         Ref(NoiseWindowTotals{NoiseDensity,typeof(1.0s)}()),
         rng,
     )
@@ -451,14 +442,11 @@ function update_noise!(
     prn = _next_noise_prn(estimator, signal_type)
     # `gen_code_replica!` writes *at* `start_sample` while the kernel reads the
     # replica offset by `start_sample - 1`, so the buffer spans the whole
-    # measurement rather than one slice.
+    # measurement rather than one slice. Only the software backends read it at
+    # all; `_despread_one_signal!` sizes it from this on those that do and ignores
+    # it on the ones that pack the code plane in-kernel.
     replica_size =
         get_num_samples(measurement) + maximum(sample_shifts) - minimum(sample_shifts)
-    _grow_noise_code_replica!(
-        context.downconvert_and_correlator,
-        estimator.code_replica,
-        replica_size,
-    )
 
     rng = estimator.rng
     code_length = get_code_length(signal_type)
@@ -477,20 +465,29 @@ function update_noise!(
         # a standing bias. See the type's docstring.
         code_phase = rand(rng) * code_length
         carrier_frequency = intermediate_frequency + (2 * rand(rng) - 1) * carrier_dither
-        accumulators = _correlate_noise_reference!(
-            context.downconvert_and_correlator,
-            estimator.code_replica,
-            samples,
-            zero(correlator),
-            signal_type,
-            prn,
-            sample_shifts,
-            code_phase,
-            code_frequency,
-            carrier_frequency,
-            sampling_frequency,
-            slice_start,
-            slice_samples,
+        # The same despread primitive the per-satellite path runs, which is what
+        # keeps the measurement model-free: `carrier_phase = 0.0` because the
+        # reference is open-loop and has no NCO to continue from, and
+        # `use_band_cache = false` because this runs before any group has packed
+        # the bit-wise backends' shared sign planes.
+        accumulators = get_accumulators(
+            _despread_one_signal!(
+                context.downconvert_and_correlator,
+                zero(correlator),
+                samples,
+                signal_type,
+                prn,
+                sample_shifts,
+                code_phase,
+                0.0,
+                code_frequency,
+                carrier_frequency,
+                sampling_frequency,
+                slice_start,
+                slice_samples,
+                replica_size,
+                false,
+            ),
         )
         # Pool the taps. At ≥1 chip spacing they are independent looks at one
         # scalar, so nothing about their relative values means anything — the
@@ -522,22 +519,6 @@ function update_noise!(
     end
     estimator
 end
-
-# Grow the reference's replica scratch so `_correlate_noise_reference!` can write
-# a whole measurement's worth of code into it.
-#
-# Backend-dispatched because only the software kernels read the buffer at all:
-# the Int16 and bit-wise backends pack the code sign plane inside their own
-# kernel and take the `Vector{Int8}` purely to share one signature. Sizing it
-# there would allocate — and then keep alive — one byte per sample of the largest
-# buffer ever passed, per signal, for something never read; on a 500 k-sample
-# buffer that is half a megabyte of pure waste. They override this to leave it
-# empty.
-@inline _grow_noise_code_replica!(
-    ::AbstractDownconvertAndCorrelator,
-    code_replica::Vector{Int8},
-    replica_size::Integer,
-) = length(code_replica) < replica_size ? resize!(code_replica, replica_size) : code_replica
 
 # The antenna the reference despreads. `DefaultPostCorrFilter` is `last(x)`, so
 # an antenna array's noise must be measured on its last column too.

--- a/src/track.jl
+++ b/src/track.jl
@@ -222,11 +222,18 @@ function track!(
     # the final chunk's Doppler), so the integration carries into the next
     # `track!` call. A boundary landing exactly on the buffer end completes
     # here, so fold once more; a no-op (per-sat early return) otherwise.
+    #
+    # `measure_noise = false` unless this is the only pass: unchunked, this call
+    # sees the whole buffer as one chunk, so measuring here would enter every
+    # sample into the noise window a second time. When no chunk ran at all
+    # (`chunk_index == 0`, a buffer shorter than one chunk) this *is* the pass
+    # that measures it.
     downconvert_and_correlate!(
         downconvert_and_correlator,
         measurements,
         track_state;
         samples_unchanged = chunk_index > 0,
+        measure_noise = chunk_index == 0,
     )
     estimate_dopplers_and_filter_prompt!(track_state, measurements)
     return track_state

--- a/src/track.jl
+++ b/src/track.jl
@@ -129,14 +129,20 @@ After one warmup call (which seats each satellite's `filtered_prompts`
 buffer capacity), the single-threaded path is fully allocation-free.
 
 The threaded path (`CPUThreadedDownconvertAndCorrelator`) keeps a small
-residual — about 64 B per **completed code-block integration** per group —
-but only when the process runs with more than one thread *and* the group
-holds more than one satellite (so Polyester's `@batch` actually distributes
-work). `track!` launches one `@batch` per code block, so this residual
-scales with the chunk length rather than staying flat per call; for a
+residual — about 96 B per **completed code-block integration** per group —
+but only when the process runs with more than one thread *and* the group's
+loop holds more than one work item (so Polyester's `@batch` actually
+distributes work). `track!` launches one `@batch` per code block, so this
+residual scales with the chunk length rather than staying flat per call; for a
 real-time loop with fixed-size chunks it is bounded per call and, in
 practice, dwarfed by the input sample buffer the caller allocates each
 chunk. The single-threaded backend has none of it.
+
+A `TrackState` whose C/N₀ estimators read a measured noise density pays the
+**same** ~96 B, even though its per-signal noise despread rides that same
+parallel loop: the loop reaches the despread's descriptor through one pointer
+rather than by value. It does mean a group with a *single* satellite now has
+two work items, so it pays the residual where it previously paid none.
 
 The root cause is not the per-satellite state per se — it is that the
 GNSS **signal** object is not an `isbits` type: `GPSL1CA`, for example, holds

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -355,6 +355,7 @@ function TrackState(
         isnothing(groups) ? track_state.groups : groups,
         isnothing(doppler_estimator) ? track_state.doppler_estimator : doppler_estimator,
         isnothing(noise_estimators) ? track_state.noise_estimators : noise_estimators,
+        track_state.noise_descriptor,
     )
 end
 
@@ -506,7 +507,12 @@ function merge_sats(
     _assert_sats_match_slot_type(g, new_sats_dict, group_idx)
     new_group = SignalGroup(g; satellites = merge(g.satellites, new_sats_dict))
     new_groups = @set groups[group_idx] = new_group
-    TrackState{G,DE,NE}(new_groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        new_groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 function merge_sats(
@@ -598,7 +604,12 @@ function add_satellite!(
     # identical object (the contract guarantees the concrete type either
     # way), and then the input `track_state` is handed back unchanged.
     new_estimator === track_state.doppler_estimator && return track_state
-    TrackState{G,DE,NE}(track_state.groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        track_state.groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 # Verify that `sat` has exactly the concrete type the group's
@@ -698,7 +709,12 @@ function add_satellite(
     new_dict = merge(g.satellites, dictionary((sat.prn => sat,)))
     new_group = SignalGroup(g; satellites = new_dict)
     new_groups = @set groups[group] = new_group
-    TrackState{G,DE,NE}(new_groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        new_groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 """
@@ -764,6 +780,7 @@ function remove_satellite(
         new_groups,
         track_state.doppler_estimator,
         track_state.noise_estimators,
+        track_state.noise_descriptor,
     )
 end
 

--- a/test/downconvert_and_correlate.jl
+++ b/test/downconvert_and_correlate.jl
@@ -673,15 +673,16 @@ Tracking.get_correlator_sample_shifts(
     )
     @test get_accumulators(public_result) ≈ ref_accumulators rtol = 1e-4
 
-    # Both backends' per-signal kernel
+    # Both backends' despread primitive — the one every despread goes through,
+    # satellites and noise reference alike. It draws its replica buffer from the
+    # backend's own scratch, so the size is all the caller supplies.
     for dc in (CPUDownconvertAndCorrelator(), CPUThreadedDownconvertAndCorrelator())
-        backend_code_replica = zeros(Int8, code_replica_length)
-        backend_result = Tracking._correlate_one_signal!(
+        backend_result = Tracking._despread_one_signal!(
             dc,
-            backend_code_replica,
-            gpsl1,
             correlator,
             signal,
+            gpsl1,
+            prn,
             dynamic_shifts,
             window_code_phase,
             0.0,
@@ -690,7 +691,7 @@ Tracking.get_correlator_sample_shifts(
             sampling_frequency,
             start_sample,
             num_samples,
-            prn,
+            code_replica_length,
         )
         @test get_accumulators(backend_result) ≈ ref_accumulators rtol = 1e-4
     end

--- a/test/noise_estimators/correlator.jl
+++ b/test/noise_estimators/correlator.jl
@@ -391,10 +391,11 @@ end
 end
 
 @testset "a signal carried by two groups is measured once" begin
-    # `_dc_one_group!` was rejected as the measurement site precisely because it
-    # fires once per group: two groups may carry the same signal, and a per-group
-    # site would double its window. Walking the `noise_estimators` NamedTuple —
-    # one entry per signal — makes once-per-signal structural instead.
+    # The despread rides *one* group's per-satellite loop, and which group that is
+    # must not change how often it runs. Resolving the work per signal off the
+    # `noise_estimators` NamedTuple — one entry per signal — and executing it in a
+    # single group's loop is what keeps once-per-signal structural; pushing it into
+    # every `_dc_one_group!` would double the window of a signal two groups carry.
     one_group = TrackState(;
         signals = (legacy_gps = (GPSL1,),),
         noise_estimators = (GPSL1CA = CorrelatorNoiseEstimator(),),
@@ -412,6 +413,42 @@ end
     end
     @test Base.length(one_group.noise_estimators.GPSL1CA) ==
           Base.length(two_groups.noise_estimators.GPSL1CA)
+end
+
+@testset "the group whose loop carries the despread may be empty" begin
+    # The despread rides the *first* group's loop, and that group can legitimately
+    # hold no satellites — the items do not belong to it, they only need a loop to
+    # run in. Before the fold every group with no satellites returned early, which
+    # would now drop the measurement entirely.
+    ts = TrackState(;
+        signals = (empty_first = (GPSL1,), with_sats = (GPSL1,)),
+        noise_estimators = (GPSL1CA = CorrelatorNoiseEstimator(),),
+    )
+    add_satellite!(ts; prn = 1, group = :with_sats, carrier_doppler = 0.0Hz)
+    @test isempty(Tracking.get_sat_states(ts, :empty_first))
+    track!((L1 = BandMeasurement(_sky(-Inf; seed = 11), FS),), ts)
+    @test Base.length(ts.noise_estimators.GPSL1CA) == 10
+    @test ustrip(Hz^-1, get_noise_density(ts.noise_estimators.GPSL1CA)) ≈ 1.0 rtol = 0.3
+end
+
+@testset "the serial and threaded loops measure bit-identically" begin
+    # The despread is a work item in the threaded backend's `@batch` and a straight
+    # call on the serial one. Nothing about it depends on which: one item is the only
+    # writer of its estimator's window and RNG stream, so the seeded draw order is
+    # the same either way and the two windows must agree to the last bit — not merely
+    # to a tolerance. This is the regression that would catch a shared-state slip in
+    # the parallel path.
+    signal = ComplexF32.(_sky(45.0; seed = 12))
+    densities =
+        map((CPUDownconvertAndCorrelator(), CPUThreadedDownconvertAndCorrelator()),) do dc
+            ts = _tracked(signal, dc)
+            (
+                Base.length(ts.noise_estimators.GPSL1CA),
+                get_noise_density(ts.noise_estimators.GPSL1CA),
+            )
+        end
+    @test densities[1][1] == densities[2][1]
+    @test densities[1][2] === densities[2][2]
 end
 
 @testset "an unchunked call measures once, and a re-pass says so" begin

--- a/test/noise_estimators/correlator.jl
+++ b/test/noise_estimators/correlator.jl
@@ -414,10 +414,11 @@ end
           Base.length(two_groups.noise_estimators.GPSL1CA)
 end
 
-@testset "an unchunked call measures once, and a re-pass does not" begin
-    # The gate is `chunk_duration === nothing && samples_unchanged`, and it is
-    # reachable from a direct caller as well as from `track!`'s drain pass — which
-    # is why `downconvert_and_correlate!`'s docstring says so.
+@testset "an unchunked call measures once, and a re-pass says so" begin
+    # `measure_noise` is what decides, and `samples_unchanged` — which answers the
+    # unrelated question of whether a backend may reuse a sample-derived cache —
+    # must not. `track!`'s drain pass is the caller that needs `false`; a direct
+    # caller re-passing over a measured buffer is the same situation.
     signal = _sky(-Inf; seed = 6)
     measurements = (L1 = BandMeasurement(signal, FS),)
     ts = TrackState(
@@ -425,14 +426,18 @@ end
         [TrackedSat(GPSL1, 1, 0.0, 0.0Hz; cn0_estimator = NoiseRefCN0Estimator())],
     )
     dc = CPUDownconvertAndCorrelator()
-    # Unchunked, samples not promised unchanged: the whole buffer in `num_sub`
-    # slices — 10 ms against a 1 ms code period.
+    # Unchunked: the whole buffer in `num_sub` slices — 10 ms against a 1 ms code
+    # period.
     downconvert_and_correlate!(dc, measurements, ts)
     @test Base.length(ts.noise_estimators.GPSL1CA) == 10
-    # The same call promising the samples are unchanged is a re-pass, and must not
-    # re-measure what has already been covered.
-    downconvert_and_correlate!(dc, measurements, ts; samples_unchanged = true)
+    # A declared re-pass must not re-measure what has already been covered.
+    downconvert_and_correlate!(dc, measurements, ts; measure_noise = false)
     @test Base.length(ts.noise_estimators.GPSL1CA) == 10
+    # `samples_unchanged` on its own no longer suppresses anything: promising the
+    # backend its cache is still valid says nothing about whether these samples
+    # have been measured.
+    downconvert_and_correlate!(dc, measurements, ts; samples_unchanged = true)
+    @test Base.length(ts.noise_estimators.GPSL1CA) == 20
 end
 
 @testset "a signal without a consumer is never despread" begin

--- a/test/noise_estimators/correlator.jl
+++ b/test/noise_estimators/correlator.jl
@@ -562,35 +562,43 @@ end
     @test (@allocated Tracking.append_noise_observation!(estimator, observation)) == 0
 end
 
-@testset "the replica scratch is grown only where it is read ($(nameof(DC)))" for (
+@testset "the reference owns no scratch of its own ($(nameof(DC)))" for (
     DC,
     build,
     quantise,
-    reads_replica,
 ) in (
-    (CPUDownconvertAndCorrelator, () -> CPUDownconvertAndCorrelator(), false, true),
-    (
-        Int16DownconvertAndCorrelator,
-        () -> Int16DownconvertAndCorrelator(NUM_SAMPLES),
-        true,
-        false,
-    ),
-    (OneBitDownconvertAndCorrelator, () -> OneBitDownconvertAndCorrelator(), true, false),
-    (TwoBitDownconvertAndCorrelator, () -> TwoBitDownconvertAndCorrelator(), true, false),
+    (CPUDownconvertAndCorrelator, () -> CPUDownconvertAndCorrelator(), false),
+    (Int16DownconvertAndCorrelator, () -> Int16DownconvertAndCorrelator(NUM_SAMPLES), true),
+    (OneBitDownconvertAndCorrelator, () -> OneBitDownconvertAndCorrelator(), true),
+    (TwoBitDownconvertAndCorrelator, () -> TwoBitDownconvertAndCorrelator(), true),
 )
-    # The Int16 and bit-wise kernels pack the code sign plane themselves and take
-    # the `Vector{Int8}` only to share one signature. Sizing it for them held a
-    # byte per sample of the whole measurement, per signal, for something never
-    # read — half a megabyte on a 500 k-sample buffer.
+    # The estimator holds no replica buffer at all: `_despread_one_signal!` draws
+    # one from the backend's own scratch on the kernels that generate a replica and
+    # ignores the size on the ones that pack the code sign plane themselves. That
+    # removes a byte per sample of the whole measurement, per signal, on *every*
+    # backend rather than on the three that never read it — half a megabyte per
+    # signal on a 500 k-sample buffer.
+    @test :code_replica ∉ fieldnames(CorrelatorNoiseEstimator)
     signal = _sky(45.0; seed = 5)
     ts = _tracked(quantise ? _to_int16(signal) : ComplexF32.(signal), build())
     estimator = ts.noise_estimators.GPSL1CA
     @test get_noise_density(estimator) !== nothing      # it still measured
-    if reads_replica
-        @test Base.length(estimator.code_replica) >= NUM_SAMPLES
-    else
-        @test isempty(estimator.code_replica)
-    end
+end
+
+@testset "the reference and the satellites despread out of one scratch slot" begin
+    # The other half of that: the buffer the software reference writes its replica
+    # into is the backend's shared per-thread slot — the same one the per-satellite
+    # path uses — so there is exactly one, however many signals are measured. Safe
+    # because the noise pass runs to completion before the per-group satellite loop
+    # that reuses the slot, and the threaded backends index it by `threadid()`.
+    dc = CPUDownconvertAndCorrelator()
+    @test isempty(Tracking._scratch_buffers(dc).code_replica)
+    ts = _tracked(ComplexF32.(_sky(45.0; seed = 5)), dc)
+    @test get_noise_density(ts.noise_estimators.GPSL1CA) !== nothing
+    # Sized against the whole buffer plus the tap spread, not the slice:
+    # `gen_code_replica!` writes *at* `start_sample`, and a slice can start
+    # anywhere in the measurement.
+    @test length(Tracking._scratch_buffers(dc).code_replica) >= NUM_SAMPLES
 end
 
 end

--- a/test/noise_estimators/correlator.jl
+++ b/test/noise_estimators/correlator.jl
@@ -498,23 +498,51 @@ end
 # 1.11+ get zero. Asserting `== 0` unconditionally would either fail on a
 # supported version or have to be weakened into something that no longer catches
 # a real regression.
+#
+# Asserted on **every** backend, because the despread is the same primitive on each
+# and only the kernel behind it differs — and the kernel is where this last went
+# wrong. The one-bit and two-bit `@generated` kernels used to return their per-tap
+# sums in a heap `Vector`; the compiler elided it at the per-satellite call site but
+# not at the reference's, so the measurement alone allocated ~112 B per
+# sub-integration (about 1 kB per 10 ms chunk) on those two backends while every
+# other path measured 0. They now return an `SVector{NC}`, as the integer kernel
+# always did, so `NC` being a compile-time constant means no heap cell at all.
 if VERSION >= v"1.11"
-    @testset "the software measurement is allocation-free in steady state" begin
+    @testset "the software measurement is allocation-free in steady state ($(nameof(DC)))" for (
+        DC,
+        build,
+        quantise,
+    ) in (
+        (CPUDownconvertAndCorrelator, () -> CPUDownconvertAndCorrelator(), false),
+        (
+            Int16DownconvertAndCorrelator,
+            () -> Int16DownconvertAndCorrelator(NUM_SAMPLES),
+            true,
+        ),
+        (OneBitDownconvertAndCorrelator, () -> OneBitDownconvertAndCorrelator(), true),
+        (TwoBitDownconvertAndCorrelator, () -> TwoBitDownconvertAndCorrelator(), true),
+    )
         function measure(dc, measurements, ts)
             for _ = 1:8
                 downconvert_and_correlate!(dc, measurements, ts; chunk_index = 0)
             end
             @allocated downconvert_and_correlate!(dc, measurements, ts; chunk_index = 0)
         end
-        signal = ComplexF32.(_sky(45.0; seed = 8))
+        raw = _sky(45.0; seed = 8)
+        signal = quantise ? _to_int16(raw) : ComplexF32.(raw)
         measurements = (L1 = BandMeasurement(signal, FS),)
-        ts = TrackState(
-            GPSL1,
-            [TrackedSat(GPSL1, 1, 0.0, 0.0Hz; cn0_estimator = NoiseRefCN0Estimator())],
-        )
-        dc = CPUDownconvertAndCorrelator()
+        # Measured against the same state without a reference, so the assertion is
+        # about the *measurement* rather than about the correlate stage as a whole.
+        state(cn0) =
+            TrackState(GPSL1, [TrackedSat(GPSL1, 1, 0.0, 0.0Hz; cn0_estimator = cn0())])
+        ts = state(NoiseRefCN0Estimator)
+        plain_ts = state(() -> NWPRCN0Estimator(GPSL1))
+        dc = build()
+        plain_dc = build()
         track!(measurements, ts; downconvert_and_correlator = dc)
+        track!(measurements, plain_ts; downconvert_and_correlator = plain_dc)
         @test measure(dc, measurements, ts) == 0
+        @test measure(plain_dc, measurements, plain_ts) == 0
     end
 end
 

--- a/test/track_in_place.jl
+++ b/test/track_in_place.jl
@@ -215,6 +215,85 @@ end
     end
 end
 
+# What the noise reference costs the *threaded* backend at launch, which the loose
+# cap above cannot see. Polyester heap-allocates one argument tuple per `@batch`
+# launch, sized by what the region references and copying an immutable struct into
+# it by value — so a noise descriptor reached by value put the estimator (48 B), the
+# band measurement (24 B) and the signal instance (56 B) in there and took the
+# launch from ~96 B to 240 B. Reached through one box it costs a pointer, and the
+# contract is that it costs nothing measurable at all.
+#
+# Asserted as equality against an otherwise identical state whose C/N₀ estimator
+# reads no density, not against a byte count: the count is Polyester's and Julia's
+# to change, "the reference is free at launch" is ours. Two satellites, so the
+# comparison is not made at the one satellite count where the loop has a single
+# item and no residual to speak of.
+@static if VERSION >= v"1.11"
+    @testset "the noise reference adds nothing to the threaded launch residual" begin
+        sampling_frequency = 4e6Hz
+        signal, gpsl1, carrier_doppler, start_code_phase = make_signal(sampling_frequency)
+        make_state(make_cn0_estimator) = TrackState(
+            gpsl1,
+            [
+                TrackedSat(
+                    gpsl1,
+                    prn,
+                    start_code_phase,
+                    carrier_doppler - 20Hz;
+                    cn0_estimator = make_cn0_estimator(),
+                ) for prn = 1:2
+            ],
+        )
+        plain_state = make_state(() -> NWPRCN0Estimator(gpsl1))
+        noise_state = make_state(NoiseRefCN0Estimator)
+        @test keys(plain_state.noise_estimators) == ()
+        @test keys(noise_state.noise_estimators) == (:GPSL1CA,)
+
+        plain_dc = CPUThreadedDownconvertAndCorrelator()
+        noise_dc = CPUThreadedDownconvertAndCorrelator()
+        for _ = 1:8
+            track!(
+                signal,
+                plain_state,
+                sampling_frequency;
+                downconvert_and_correlator = plain_dc,
+            )
+            track!(
+                signal,
+                noise_state,
+                sampling_frequency;
+                downconvert_and_correlator = noise_dc,
+            )
+        end
+
+        @test measure_dc!(noise_dc, signal, noise_state, sampling_frequency) ==
+              measure_dc!(plain_dc, signal, plain_state, sampling_frequency)
+
+        # The box the descriptors are parked in is provisioned once and reused —
+        # which is what makes the launch cost flat rather than merely smaller — and
+        # it has to survive the `TrackState` copies `track` and `track!` make of it.
+        box = noise_state.noise_descriptor[]
+        @test box isa Base.RefValue
+        track!(
+            signal,
+            noise_state,
+            sampling_frequency;
+            downconvert_and_correlator = noise_dc,
+        )
+        @test noise_state.noise_descriptor[] === box
+        @test track(
+            signal,
+            noise_state,
+            sampling_frequency;
+            downconvert_and_correlator = noise_dc,
+        ).noise_descriptor === noise_state.noise_descriptor
+
+        # Nothing to measure parks nothing: a state whose C/N₀ estimators read no
+        # density never provisions a box, so the loop has nothing extra to root.
+        @test isnothing(plain_state.noise_descriptor[])
+    end
+end
+
 # Acquisition (pre-sync) allocation guard. Before bit sync, `track!` runs the
 # per-code-block bit-edge search (`_buffer_find_bit`) once per code block. A
 # regression there — e.g. a closure-capture `Core.Box` + boxed `SyncResult`


### PR DESCRIPTION
Stacked on #223 (`better-way-to-estimate-noise-for-cn0`) — review and merge that first.

Six commits, on two themes.

**Four of them** (`−146` lines of `src`): the noise reference and the per-satellite path were doing the same work through two parallel sets of machinery. Collapsing them onto one primitive removes the duplication, and — because the primitive already takes its scratch from the backend's per-thread slot — makes it cheap to run the despread *inside* the parallel loop instead of serially in front of it.

**Two more** (`+139`, merged in from #228): that fold cost the threaded backends a per-launch allocation, and these take it back to zero. Most of the `+139` is comment and docstring recording the Polyester cost model the fix turns on.

Full suite green single-threaded and under `-t8`; format clean at the pinned JuliaFormatter 2.8.5.

## Why

Two things prompted this, one structural and one measured.

**Structural.** `#223` reached the right architecture but paid for it in adapters: `_correlate_noise_reference!` existed four times, once per backend, each a near-copy of that backend's single-signal satellite correlate with `carrier_phase = 0.0`. The CPU one is explicitly documented as "the single-satellite template's body". Four adapters kept in step by hand have to be re-verified on every kernel change.

**Measured.** The noise pass was a serial pass in front of the group loop, so on a threaded backend it was pure Amdahl — threading compresses the satellite correlations but not the measurement:

| n_sats | correlate only | + noise pass | Δ | Δ / correlate |
|---:|---:|---:|---:|---:|
| 1 | 1.80 µs | 3.55 µs | 1.74 µs | **97 %** |
| 4 | 3.68 | 5.38 | 1.70 | 46 % |
| 8 | 4.23 | 5.76 | 1.53 | 36 % |
| 12 | 7.14 | 8.93 | 1.78 | 25 % |
| 24 | 11.27 | 13.11 | 1.84 | 16 % |

(8 threads, 1 ms chunk at 4 MHz, GPS L1 C/A, isolated with the `measure_noise` flag added here.) The Δ is flat — the pass is O(1) in satellite count, as designed — so the *fraction* is worst exactly where the parallel loop has the most spare capacity. At 8 satellites it is 36 % threaded against 12 % serial.

## What changed

### `refactor(dc)`: one despread primitive

`_despread_one_signal!` now carries every despread in the package — the per-satellite single-signal path and the open-loop noise reference alike. The noise measurement is model-free *structurally* rather than by agreement: the reference cannot traverse a different quantise → downconvert → despread → accumulate path than the prompt, because there is only one path.

| removed | count | why it could go |
|---|---:|---|
| `_correlate_noise_reference!` | 4 | the reference is the satellite call with `carrier_phase = 0.0` |
| single-signal `_correlate_signals` | 3 | Int16/one-bit/two-bit were the same shape; the shared method now serves every backend |
| `_correlate_one_signal!` | 1 | became the CPU hook's body |
| `_grow_noise_code_replica!` | 4 | gone with the estimator's `code_replica` field |

Only the *multi*-signal `_correlate_signals` is still per-backend: the tile-share kernels take all N signals at once and have no single-signal form.

`CorrelatorNoiseEstimator` loses its `code_replica` field. The reference now writes into the backend's own per-thread scratch slot, so there is **one** buffer instead of one per noise-referenced signal, and "which backends read a replica at all" is answered where the kernel is chosen rather than by a second dispatched hook. Safe by the existing ordering, and — as it turns out — a prerequisite for the parallel fold below.

The one thing the two callers genuinely disagree about became an argument rather than two functions: `use_band_cache`, false for the reference because it runs before any group packs the bit-wise backends' shared sign planes.

### `refactor(cn0)`: one entry point, one flag

Three variations on the same mistake — inferring what the caller knew:

- **`samples_unchanged` had a second meaning.** It answers "may the backend reuse a sample-derived cache", and the noise pass was reading `chunk_duration === nothing && samples_unchanged` as "this call re-covers measured samples" — a three-row truth table in a comment plus a docstring paragraph warning direct callers. Now an explicit `measure_noise` kwarg, which `track!` states on the one call that needs it.
- **`_groups_with_signal` + `_signals_with_id`** answered "which groups carry signal `K`" and threw all but the first away. Nothing needs the group: the band comes from the signal *type* and the estimator is already in hand. One `_first_signal_with_id`.
- **The one-bit and two-bit `downconvert_and_correlate(!)` methods were byte-identical** to the ones on `AbstractDownconvertAndCorrelator` apart from their docstrings — which is how the noise call site came to be pasted three times. Deleted; Int16 already inherited them.

### `refactor(dc)`: one group loop per threading strategy

The one-bit and two-bit backends each defined their own serial and `@batch` `_dc_group_loop!`, byte-identical to the two the `_threading` trait already dispatches. Four methods become two trait declarations — and two loop bodies to change below instead of six.

### `perf(cn0)`: the despread runs in the parallel loop

The despread is now one more work item on the end of the satellites' index range, so `@batch` schedules it across the same threads.

| n_sats | correlate | + noise, before | + noise, after |
|---:|---:|---:|---:|
| 1 | 1.80 µs | 3.55 µs (+97 %) | 1.98 µs (**+10 %**) |
| 4 | 3.70 | 5.38 (+46 %) | 3.59 (**−3 %**) |
| 12 | 6.85 | 8.93 (+25 %) | 6.96 (**+2 %**) |

It works because the despread is a well-sized item rather than a straggler: one chunk's despread costs about what one satellite's correlation does (1.75 µs against 1.80 µs).

Swept across 1..16 satellites it is hidden — under half its serial cost — at **12 to 14 counts out of 16**, run to run. The misses are systematic, not noise: they are the counts sitting one item below a scheduling step, where the extra item opens a new round and costs a full one (1.7–2.9 µs, i.e. about what the serial pass cost, sometimes slightly more). So the worst case is "no better than before", not "worse in a way that matters". **Where the step falls depends on the effective worker count, so the specific counts are not portable** — the shape of the result is. Worth re-running the sweep on target hardware.

Structurally, the work is resolved into per-signal descriptors *before* the loop (`_noise_items`), which keeps three things true:

- **Exactly-once survives.** Resolution is keyed off `noise_estimators`, so a signal two groups carry still yields one descriptor. The items then ride the *first* group's loop — they do not belong to it, each carries its own band measurement — which is why the work is not simply pushed into `_dc_one_group!`: that fires once per *group*, and a per-group site would double the window of a signal two groups carry.
- **`_check_sample_type` stays in front of every kernel**, on the caller's thread, so a wrong sample type still throws the curated `ArgumentError` rather than surfacing from a worker.
- **The tuple's type never depends on a runtime value.** An out-of-range chunk is left to `update_noise!`'s own `num_samples > 0` guard, and `measure_noise` is applied by the caller as a count. Folding either in here would have made the descriptor tuple's type runtime-dependent.

Thread-safety needed nothing new, which is the payoff from the first commit: each item is the only writer of its estimator's window, totals and RNG stream, so the seeded draw order is unchanged; and the replica scratch already comes from the backend's per-thread slot, which `@batch` pins for the duration of an iteration.

### `perf(dc)` ×2: the fold's allocation cost, removed (#228)

Merged in from #228, which carries the full write-up.

**One box instead of copies.** Polyester copies everything the `@batch` region references into **one** argument tuple and heap-allocates that tuple at its `sizeof`, copying an immutable struct **by value** and a mutable object as **one pointer**. So it is not struct-ness that costs, it is *immutability* — and that is what makes the cost removable. Measured on the flattened tuple: satellites alone come to 80 B, and one descriptor added **152 B** (`CorrelatorNoiseEstimator` 48, the band's `BandMeasurement` 24, the signal instance 56 — the largest single item, and the one the accounting below originally missed; trimming the `NoiseUpdateContext` wrapper could only ever have reached the 16 B it did). `_park_noise_items!` now parks the descriptors in a reusable box and hands the loop the box: **8 B, and nothing per descriptor**. `TrackState` gains one field to hold that box — a type-erased `Base.RefValue{Any}` cell, filled on the first correlate call with a concretely typed box and written into thereafter, so both the write and the loop-side read stay type-stable. Nothing to measure still passes `()`, so a state that reads no density roots nothing at all.

**`SVector` from the bit-wise kernels.** Checking every backend rather than only the float CPU one turned up a second allocation, unrelated to threading: the one-bit and two-bit `@generated` kernels returned their per-tap sums in a heap `Vector`, which the compiler elided at the per-satellite call site but *not* at the reference's — 112 B per sub-integration, ~1 kB per 10 ms chunk at 4 MHz, and on their **serial** paths too. `NC` is a parameter of those methods, so the cell was never needed; `SVector{NC}` is what `_int16_hybrid_blocked!` has always returned, which is why the integer backend measured 0 B where these two did not. This one **predates this PR**: it is already present at #223, where the reference first went through the shared primitive.

## Cost

**None, in the end.** The fold does hand the `@batch` closure the descriptors to root, which took the per-launch residual from ~96 B to 240 B; the two commits above take it back. Per `downconvert_and_correlate!` call, 2 satellites, 1 ms at 4 MHz, GPS L1 C/A:

| backend | serial, with a reference | 8-thread, no reference | 8-thread, after the fold | 8-thread, now |
|---|---:|---:|---:|---:|
| CPU | 0 B | 96 B | 240 B | **96 B** |
| Int16 | 0 B | 240 B | 400 B | **240 B** |
| one-bit | 0 B (was 112 B) | 112 B | 384 B | **128 B** |
| two-bit | 0 B (was 112 B) | 144 B | 400 B | **144 B** |

Every threaded figure is now that backend's *satellites-only* residual: the noise reference adds nothing at launch. The one-bit row's remaining 16 B is the box's pointer tipping the argument tuple into the next allocation bucket; it scales with nothing.

What the fold still changes is that a *single*-satellite threaded state pays the residual where it paid none, because the loop then has two items rather than one. The `CPUThreadedDownconvertAndCorrelator` docstring claimed no residual for a single satellite. It now says what is true.

**Serial backends**: same 1.75 µs, and now 0 B on *every* backend — two of the four were not, before.

Wall time is unaffected by either allocation commit: a noise-referenced `track!` at 1/2/4/8/12/16/24 satellites measures 2.73/3.33/5.54/8.93/13.82/15.73/22.82 µs against 2.77/3.36/5.68/10.19/13.20/15.99/22.86 µs, i.e. run-to-run noise, and the same holds on both bit-wise backends.

## Behaviour changes

Both against this PR's own unreleased API (`#223` introduces everything they touch), so they land as `refactor` / `perf` per `AGENTS.md`.

- An unchunked `downconvert_and_correlate!` call with `samples_unchanged = true` now measures, where before it silently did not. That was the wart.
- `CorrelatorNoiseEstimator` loses its `code_replica` field.
- `TrackState` gains a fourth field, `noise_descriptor` — per-call scratch holding the descriptor box, shared rather than copied by every state derived from one, exactly as the per-satellite scratch vectors are. Not breaking even against the latest release: the three-argument positional constructor is kept, and the type gains no parameter, so every `TrackState{G,DE,NE}` spelling still works.

## New regressions

- **The serial and threaded loops agree on `N₀` identically**, not to a tolerance — the one that would catch a shared-state slip in the parallel path.
- **An empty group may carry the despread.** The items only need a loop to run in; before the fold a group with no satellites returned early, which would have dropped the measurement.
- **The reference owns no scratch of its own** on any backend, and **the reference and the satellites despread out of one scratch slot** — replacing the four tests that pinned the per-backend buffer sizing this removes.
- `measure_noise` decides whether to measure and `samples_unchanged` no longer does.
- **The noise reference is free at launch**, asserted as an *equality* against an otherwise identical state whose C/N₀ estimator reads no density rather than against a byte count — the count is Polyester's and Julia's to change, "the reference is free" is ours.
- **The descriptor box is provisioned once** and survives the `TrackState` copies `track` and `track!` make (a per-call box would cost more than the copy it replaced), and a state with nothing to measure never provisions one.
- **The software measurement is allocation-free on every backend**, not only the float CPU one, and measured against the same state without a reference. The second bug above lived in a kernel, so every kernel is what has to be covered.

## Not done

The 96 B the CPU threaded backend still pays per launch is the *satellites'* own, and it is still the GNSS signal object not being `isbits`: removing it needs the GNSSSignals-side bare-array `gen_code!` that `CPUThreadedDownconvertAndCorrelator`'s docstring describes. Unchanged here, and now the only thing left in the way of 0 B.

The `use_band_cache` bonus is still out of reach: the items ride one group's loop but may measure a different band, so the shared sign planes are not safe to read. Getting it would need attributing each item to its own band's group — the canonical-group machinery this design deliberately avoids.

`docs/plans/2026-08-06-per-band-noise-estimation-for-cn0.md` still describes the four-adapter shape and the serial pass. Worth a `docs(cn0)` commit recording this as a divergence if the approach is accepted; left alone here rather than writing prose ahead of that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

