### PR TITLE
ci(bench): run the benchmarks with threads, not one

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -11,6 +11,16 @@ name: Benchmark this PR
 # Runs on both x86 (Ubuntu) and ARM (Apple Silicon, macos-14) so the NEON code path gets
 # benchmarked on real Apple-Silicon hardware, not just the x86 AVX2/AVX-512 paths.
 #
+# `--exeflags="-t auto"` is load-bearing, not a tuning knob. `benchpkg` spawns the benchmark
+# process as `julia --project=... --startup-file=no $exeflags`, and its `--exeflags` defaults
+# to *none* — so without this the benchmarks run with Julia's default of ONE thread, and
+# every `– threaded` entry in the suite silently measures the serial path: the Polyester
+# `@batch` in `_dc_group_loop!` runs its loop inline on the calling thread, so the threaded
+# backends and their vs-Float32 speedup rows compare two serial runs. `auto` rather than a
+# fixed count because the two runners differ (ubuntu-latest 4 vCPU, macos-14 3 cores) while
+# the base and head revisions of one PR always run on the same runner, so the comparison
+# stays fair. If a threading change ever shows no effect here, check this flag first.
+#
 # Security: runs as pull_request_target so the comment-posting token has write access. The
 # repo is checked out at the *base* (trusted) ref — which provides bench_table.jl — and
 # benchpkg benchmarks the PR's own benchmark/benchmarks.jl via --bench-on=<head sha>.
@@ -77,6 +87,7 @@ jobs:
             --rev=${{ github.event.pull_request.base.sha }},${{ github.event.pull_request.head.sha }} \
             --bench-on=${{ github.event.pull_request.head.sha }} \
             --add=GNSSSignals,Unitful,StaticArrays \
+            --exeflags="-t auto" \
             --output-dir=results/ \
             --tune
 


### PR DESCRIPTION
One line of workflow, plus the comment explaining why it is load-bearing.

## The bug

`benchpkg` spawns the benchmark process as

```
julia --project="$tmp_env" --startup-file=no $exeflags "$runner_filename"
```

and its `--exeflags` **defaults to none** (`AirspeedVelocity/src/BenchPkg.jl:37`). `benchmark_pr.yml` passed neither that nor `JULIA_NUM_THREADS`, so the benchmarks have been running with Julia's default of **one thread**.

With one thread the Polyester `@batch` in `_dc_group_loop!` runs its loop inline on the calling thread. So:

- every `– threaded` entry in `SUITE["track"]` has been measuring the **serial** path;
- the "Alternative backends vs Float32" table has been pairing two serial runs, so its threaded speedup rows say nothing about threading;
- and the suite is structurally blind to any change whose whole effect is on parallelism.

Nothing was wrong with the numbers as numbers. They simply were not measuring what their names say.

## How much it hides

Measured locally on the shape of `track/GPS L1CA, 8 sats, 5K @ 5 MHz – in-place, threaded` (`track!`, `CPUThreadedDownconvertAndCorrelator`, 8 satellites, 5000 samples at 5 MHz):

| threads | minimum `track!` |
|---|---|
| 1 | 21.6 µs |
| 4 | 10–14 µs |

A change that halves that benchmark currently reads as `1.00`. This surfaced on #226, where the whole point of the change is to move work into the parallel loop and the comment showed 1.01.

## Why `auto`

The two runners differ — ubuntu-latest has 4 vCPU, macos-14 has 3 cores — so a fixed count either oversubscribes one or under-uses the other. A PR's base and head revisions always run on the same runner, so base-vs-head stays a fair comparison whichever value `auto` resolves to. The table already reports the **minimum** rather than the median, which is what keeps the extra thread contention from manufacturing phantom regressions; that was already the reason for the custom table and it applies here unchanged.

## Rollout caveat

`pull_request_target` makes GitHub read this workflow from the PR's **base** branch. So merging this fixes new PRs based on `master`, but an existing PR keeps running the old workflow until this lands in *that* PR's base. For stacked PRs (e.g. #226 on top of #223) the fix has to reach the stack's base branch before its benchmark comment becomes meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
