### PR TITLE
Make the noise reference allocation-free: nothing per launch, nothing per despread

### DIFF
--- a/src/Tracking.jl
+++ b/src/Tracking.jl
@@ -264,12 +264,31 @@ entry only where its C/N₀ estimator reads a noise density (see
 [`requires_noise_density`](@ref)); signals with no such estimator get none, and
 then the noise measurement costs exactly nothing. Each estimator averages **in
 place**, so `TrackState` itself is never rebuilt for a noise update.
+
+`noise_descriptor` is per-call **scratch**, not state: one reusable heap cell in
+which the correlate step parks the chunk's noise descriptors so that a threaded
+backend's parallel loop can reach them through a single pointer instead of a
+by-value copy (see `_park_noise_items!`). It is shared — not copied — by every
+`TrackState` derived from this one, exactly as the per-satellite scratch vectors
+are, and nothing outside one `downconvert_and_correlate!` call reads it.
 """
 struct TrackState{G<:SignalGroups,DE<:AbstractDopplerEstimator,NE<:NoiseEstimators}
     groups::G
     doppler_estimator::DE
     noise_estimators::NE
+    noise_descriptor::Base.RefValue{Any}
 end
+
+# Three-argument construction: the descriptor cell is scratch, so a freshly built
+# `TrackState` starts with an empty one and fills it on its first correlate call.
+# Every *derived* state (`TrackState(track_state; …)` and the in-place mutators)
+# threads the existing cell through instead, which is what keeps the box inside it
+# alive across `track!`'s copies and the steady state allocation-free.
+TrackState(
+    groups::SignalGroups,
+    doppler_estimator::AbstractDopplerEstimator,
+    noise_estimators::NoiseEstimators,
+) = TrackState(groups, doppler_estimator, noise_estimators, Base.RefValue{Any}(nothing))
 
 include("sample_parameters.jl")
 include("downconvert_and_correlate.jl")

--- a/src/downconvert_and_correlate_cpu.jl
+++ b/src/downconvert_and_correlate_cpu.jl
@@ -80,31 +80,40 @@ blocks in the chunk rather than staying flat per `track!` call. With a single
 thread or the single-threaded `CPUDownconvertAndCorrelator` there is no such
 residual.
 
-The residual measures ~80 B per launch for satellites alone. A `TrackState`
-whose C/N₀ estimators read a measured noise density adds the chunk's noise
-despreads to the same loop as extra work items — see `_dc_group_loop!` — which
-gives the closure the descriptor tuple to root as well and takes the launch to
-~240 B; it also means a **single**-satellite state pays a residual where it
+The residual measures ~96 B per launch, and a `TrackState` whose C/N₀ estimators
+read a measured noise density measures the **same** ~96 B: the chunk's noise
+despreads ride the same loop as extra work items (see `_dc_group_loop!`), but the
+loop reaches their descriptors through one pointer into a reusable box rather than
+by value — see `_park_noise_items!` for why by-value copies cost 152 B of
+Polyester argument tuple and a pointer costs 8. The one thing the noise reference
+still changes is that a **single**-satellite state pays the residual where it
 previously paid none, because the loop then has two items rather than one. What
 that buys is the despread's wall time: as one more item in the parallel loop it
 usually costs a fraction of the ~1.75 µs it costs as a serial pass, and full
-price only when it happens to open a new scheduling step. Both figures are per
-launch and bounded; neither scales with the input buffer.
+price only when it happens to open a new scheduling step. The figure is per launch
+and bounded; it does not scale with the input buffer.
 
-Why it allocates at all — Polyester's `@batch` roots only *bare* `Array`s and
-`isbits` values into its worker tasks for free (that is why a `Vector{Float64}`
-kernel allocates nothing). It pays a small per-launch allocation to root any
-**non-`isbits` struct** referenced inside the region — and it is the struct-ness
-that costs, not the contents: capturing even a plain struct whose only fields
-are `Matrix`es and isbits scalars measures the same ~64 B/launch, whereas
-capturing those same bare arrays measures 0. The culprit here is the GNSS
-**signal**: `GPSL1CA`, for instance, is not `isbits` — it wraps a `Matrix{Int16}`
-code table and a (also non-`isbits`) `SignalLUT`. Each satellite's code-replica
-generation needs its signal, so every `@batch` launch touches that non-`isbits`
-object once. (The per-satellite `TrackedSat` is likewise non-`isbits` — it
-carries the signal plus the CN0/bit buffers — and the loop reaches the signal
-through it, so iterating `Vector{TrackedSat}` is not free the way iterating a
-`Vector{Float64}` is.)
+Why it allocates at all — Polyester copies everything the `@batch` region
+references into **one** argument tuple per launch and heap-allocates that tuple
+(`ManualMemory.Reference`) so the worker tasks can read it. Two rules decide what
+that costs:
+
+  - A tuple whose every member is `isbits` (bare `Array`s become `PtrArray`s, so
+    they qualify) does not escape and is elided outright — that is why a
+    `Vector{Float64}` kernel allocates nothing.
+  - As soon as one member is not, the whole tuple is allocated at its `sizeof`,
+    and each member is copied by *value* if it is an immutable struct, or as a
+    single pointer if it is a mutable object.
+
+Which is why "capture a struct or its bare arrays" is not a wash: a plain struct
+whose fields are `Matrix`es and isbits scalars costs its own `sizeof` in the
+tuple, where the same arrays passed separately cost 0. The culprit here is the
+GNSS **signal**: `GPSL1CA`, for instance, is not `isbits` — it wraps a
+`Matrix{Int16}` code table and a (also non-`isbits`) `SignalLUT` — and each
+satellite's code-replica generation needs it. (The per-satellite `TrackedSat` is
+likewise non-`isbits`, but it is reached *through* `Vector{TrackedSat}`, which is
+mutable and so costs one pointer; it is the loop's other captures that put the
+tuple over the isbits line.)
 
 Note that merely *hoisting* the `SignalLUT` out of the signal does not help — a
 `SignalLUT` is itself a non-`isbits` struct (it wraps `Matrix{Int8}` fields), so
@@ -122,7 +131,7 @@ the region (reconstructing one there sends the generator dynamic and allocates
 far more). Absent that, the only in-tree way to reach 0 is a serial code-gen
 pre-pass, which is allocation-free but serializes ~30 % of the work and slows
 the threaded pipeline — the inferior fallback. Neither is currently worth
-~64 B/block, which is bounded per call and dwarfed by the caller's input buffer.
+~96 B/block, which is bounded per call and dwarfed by the caller's input buffer.
 
 For real-time loops, construct the correlator **once outside** the
 `track!` loop and pass it via the `downconvert_and_correlator` keyword
@@ -928,7 +937,7 @@ function downconvert_and_correlate!(
     _dc_groups!(
         Tuple(track_state.groups),
         noise_items,
-        measure_noise ? length(noise_items) : 0,
+        measure_noise ? _num_noise_items(noise_items) : 0,
         dc,
         measurements,
         chunk_index,
@@ -997,7 +1006,7 @@ end
 # which is what keeps `_check_sample_type` in front of every kernel (so a wrong
 # sample type still throws the curated `ArgumentError` rather than surfacing as a
 # `MethodError` from a worker), and keeps what the `@batch` closure captures down
-# to one tuple.
+# to one pointer (see `_park_noise_items!`).
 #
 # Resolution is per *signal*, keyed off `noise_estimators`, which is what makes
 # "exactly once" structural: two groups carrying the same signal share the one
@@ -1023,16 +1032,81 @@ end
     chunk_duration,
 )
     noise_estimators = track_state.noise_estimators
-    _noise_items_walk(
-        Val(keys(noise_estimators)),
-        Tuple(noise_estimators),
-        dc,
-        track_state.groups,
-        measurements,
-        chunk_index,
-        chunk_duration,
+    _park_noise_items!(
+        track_state.noise_descriptor,
+        _noise_items_walk(
+            Val(keys(noise_estimators)),
+            Tuple(noise_estimators),
+            dc,
+            track_state.groups,
+            measurements,
+            chunk_index,
+            chunk_duration,
+        ),
     )
 end
+
+# Park the descriptors in the `TrackState`'s reusable cell and hand back the box
+# holding them — because *how* the parallel loop reaches its descriptors is what
+# the launch costs, not what they contain.
+#
+# Polyester copies every value the `@batch` region references into one argument
+# tuple it heap-allocates per launch, and the copy is by *value* for an immutable
+# struct: a descriptor carrying a `CorrelatorNoiseEstimator` (48 B), the band's
+# `BandMeasurement` (24 B) and the signal instance (`GPSL1CA` is 56 B) is 152 B of
+# argument tuple, which measured as a rise from ~96 B to 240 B per launch. A
+# *mutable* object is copied as a pointer instead — 8 B whatever it holds — so
+# handing the loop one box costs the launch 8 B and nothing per descriptor.
+#
+# The box has to outlive the launch and be reused across launches, or its own
+# allocation would cost more than the copy it replaces. It cannot be provisioned
+# up front: its type names the caller's `BandMeasurement`, which the `TrackState`
+# does not know until the first correlate call. So the cell is a type-erased
+# `Base.RefValue{Any}` filled on that call and reused thereafter; the *box* inside
+# it is concretely typed, so both the write here and the read in the loop are
+# type-stable, and a caller who changes sample types simply gets a new box once.
+#
+# Writing a descriptor tuple into the box is a store into an existing object —
+# allocation-free — and the box roots everything the descriptors point at, so
+# nothing here relies on the caller keeping anything alive. The flip side is that
+# the box keeps the *last* chunk's `BandMeasurement` — and so the caller's sample
+# buffer — reachable until the next call overwrites it. That is one buffer, and a
+# caller who hands `track!` a fresh buffer per chunk was holding this one anyway.
+#
+# Nothing to measure stays `()`: an empty descriptor set gives the loop nothing to
+# root at all, so a `TrackState` whose C/N₀ estimators read no noise density pays
+# exactly the launch cost it paid before any of this existed.
+@inline _park_noise_items!(::Base.RefValue{Any}, ::Tuple{}) = ()
+@inline function _park_noise_items!(
+    cell::Base.RefValue{Any},
+    items::T,
+) where {T<:Tuple{Any,Vararg{Any}}}
+    box = cell[]
+    box isa Base.RefValue{T} || return _new_noise_items_box!(cell, items)
+    box[] = items
+    box
+end
+
+# First call with this descriptor type (or the first after the caller changed one).
+# `@noinline` so the hot path above stays a load, a type check and a store.
+@noinline function _new_noise_items_box!(
+    cell::Base.RefValue{Any},
+    items::T,
+) where {T<:Tuple}
+    box = Base.RefValue{T}(items)
+    cell[] = box
+    box
+end
+
+# How many work items the loop must add to the satellites' range. A property of the
+# descriptor set's *type*, so it folds to a literal at every call site.
+@inline _num_noise_items(::Tuple{}) = 0
+@inline _num_noise_items(::Base.RefValue{<:Tuple{Vararg{Any,N}}}) where {N} = N
+
+# What a group loop is handed for the chunk's noise work: `()` when there is nothing
+# to measure — including for every group after the one that carries it — and
+# otherwise the single box the descriptors were parked in.
+const _NoiseWork = Union{Tuple{},Base.RefValue{<:Tuple}}
 
 @inline _noise_items_walk(
     ::Val{()},
@@ -1128,7 +1202,11 @@ end
 # Run the `j`-th descriptor. `j` is a runtime index into a heterogeneous tuple, so
 # the walk is a chain of compile-time-known steps rather than an index — it unrolls
 # to `n` comparisons for `n` measured signals, which is one or two in practice.
+# Reading the box is the one dereference the whole scheme costs, and it happens
+# inside the parallel region, on the thread that runs the item.
 @inline _run_noise_item!(::Int, ::Tuple{}, ::Any) = nothing
+@inline _run_noise_item!(j::Int, box::Base.RefValue{<:Tuple}, dc) =
+    _run_noise_item!(j, box[], dc)
 @inline _run_noise_item!(j::Int, items::Tuple, dc) =
     j == 1 ? _apply_noise_item!(first(items), dc) :
     _run_noise_item!(j - 1, Base.tail(items), dc)
@@ -1136,6 +1214,7 @@ end
 # All of them, in order — the serial backends' path, where there is no parallel
 # region to hide the despread in.
 @inline _run_noise_items!(::Tuple{}, ::Any) = nothing
+@inline _run_noise_items!(box::Base.RefValue{<:Tuple}, dc) = _run_noise_items!(box[], dc)
 @inline _run_noise_items!(items::Tuple, dc) =
     (_apply_noise_item!(first(items), dc); _run_noise_items!(Base.tail(items), dc))
 
@@ -1218,7 +1297,7 @@ end
     # The float backends derive nothing from the raw samples worth caching;
     # only the bit-wise backends act on `samples_unchanged`.
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -1258,7 +1258,7 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_onebit.jl
+++ b/src/downconvert_and_correlate_onebit.jl
@@ -388,10 +388,17 @@ const _OneBitDC =
 @inline _ob_num_ants_val(::AbstractCorrelator{M}) where {M} = NumAnts{M}()
 
 # ── The one-bit hybrid-blocked kernel ─────────────────────────────────────────
-# Returns this integration's correlation contribution: `Vector` of `NC` complex
+# Returns this integration's correlation contribution: `SVector{NC}` of complex
 # sums (one per tap) — `ComplexF64` (M=1) or `SVector{M,ComplexF64}` (M>1) — to be
 # added to the correlator's running accumulators. `@generated` over (NC, M): the
 # per-(antenna, tap) popcount accumulators live in named locals and unroll.
+#
+# `SVector` and not `Vector` because `NC` is a parameter here, so the result needs
+# no heap cell at all — matching `_int16_hybrid_blocked!`. It used to be a
+# `Vector`, which the compiler elided at the per-satellite call site but *not* at
+# the noise reference's, leaving that one call 112 B per despread (and so ~1 kB per
+# chunk at ten sub-integrations) on these two backends alone. This kernel's dynamic
+# fallback below, where `NC` is a runtime value, still returns a `Vector`.
 @generated function _onebit_hybrid_blocked!(
     dc::_OneBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -461,9 +468,7 @@ const _OneBitDC =
             :(SVector{$M,ComplexF64}(tuple($(ant...))))
         end
     end
-    ret =
-        M == 1 ? :(ComplexF64[$([tapval(k) for k = 1:NC]...)]) :
-        :(SVector{M,ComplexF64}[$([tapval(k) for k = 1:NC]...)])
+    ret = :(SVector{$NC}(tuple($([tapval(k) for k = 1:NC]...))))
 
     quote
         # Bit-wise correlation keeps only the code's SIGN, so it needs a binary (±1,
@@ -638,9 +643,12 @@ end
 # at runtime and horizontally sums each popcount chunk into per-(antenna, tap) Int64
 # totals. Not the hot path (it allocates the offset/total scratch and sums per chunk),
 # but bit-identical to the `@generated` kernel: `sum` over chunks of `sum(count_ones)`
-# equals `sum(count_ones)` over all chunks. Returns `Vector{ComplexF64}` (M=1) or
-# `Vector{SVector{M,ComplexF64}}` (M>1). `SVector` shifts are more specific and
-# dispatch to the `@generated` method above, so EPL/VEPL keep the fast unrolled path.
+# equals `sum(count_ones)` over all chunks. Returns a `Vector` — of `ComplexF64` (M=1)
+# or `SVector{M,ComplexF64}` (M>1) — rather than the `@generated` method's
+# `SVector{NC}`, because here the tap count is only known at runtime; the caller
+# broadcasts either shape onto the correlator's accumulators. `SVector` shifts are more
+# specific and dispatch to the `@generated` method above, so EPL/VEPL keep the fast
+# unrolled path.
 function _onebit_hybrid_blocked!(
     dc::_OneBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -1052,8 +1060,11 @@ end
         push!(sigs.args, signal_block(i))
     end
 
-    # Finalize: per signal, a Vector of NCᵢ tap sums — Iₓ = 2N − 2(A+B), Qₓ = 2(E − C)
-    # (matching the single-signal kernel's return so `_correlate_signals` is shared).
+    # Finalize: per signal, a Vector of NCᵢ tap sums — Iₓ = 2N − 2(A+B), Qₓ = 2(E − C).
+    # A `Vector` and not the single-signal kernel's `SVector{NC}`: these are consumed by
+    # the multi-signal `_correlate_signals`, which broadcasts each onto its signal's
+    # accumulators and lets the compiler elide the cell — which, unlike at the noise
+    # reference's call site, it does (measured 0 B for a two-signal satellite).
     function tapval(i, k)
         A(j) = s(Symbol("A_$(i)_$(j)_$k"))
         B(j) = s(Symbol("B_$(i)_$(j)_$k"))

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -1743,7 +1743,7 @@ end
     chunk_duration,
     stop_before_partial::Bool,
     samples_unchanged::Bool,
-    noise_items::Tuple,
+    noise_items::_NoiseWork,
     n_noise::Int,
 )
     vals = g.satellites.values

--- a/src/downconvert_and_correlate_twobit.jl
+++ b/src/downconvert_and_correlate_twobit.jl
@@ -738,10 +738,17 @@ const _TwoBitDC =
 end
 
 # ── The two-bit hybrid-blocked kernel ─────────────────────────────────────────
-# Returns this integration's correlation contribution: `Vector` of `NC` complex sums (one
+# Returns this integration's correlation contribution: `SVector{NC}` of complex sums (one
 # per tap) — `ComplexF64` (M=1) or `SVector{M,ComplexF64}` (M>1) — to be added to the
 # correlator's running accumulators. `@generated` over (NC, M): the per-(antenna, tap)
 # IS/IF/QS/QF and per-antenna GXA accumulators live in named locals and unroll.
+#
+# `SVector` and not `Vector` because `NC` is a parameter here, so the result needs no heap
+# cell at all — matching `_int16_hybrid_blocked!`. It used to be a `Vector`, which the
+# compiler elided at the per-satellite call site but *not* at the noise reference's,
+# leaving that one call 112 B per despread (and so ~1 kB per chunk at ten
+# sub-integrations) on this backend and the one-bit one alone. This kernel's dynamic
+# fallback below, where `NC` is a runtime value, still returns a `Vector`.
 @generated function _twobit_hybrid_blocked!(
     dc::_TwoBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},
@@ -858,9 +865,7 @@ end
             :(SVector{$M,ComplexF64}(tuple($([cplx(j) for j = 1:M]...))))
         end
     end
-    ret =
-        M == 1 ? :(ComplexF64[$([tapval(k) for k = 1:NC]...)]) :
-        :(SVector{M,ComplexF64}[$([tapval(k) for k = 1:NC]...)])
+    ret = :(SVector{$NC}(tuple($([tapval(k) for k = 1:NC]...))))
 
     quote
         _tb_check_modulation(signal_type)
@@ -1038,8 +1043,10 @@ end
 # runtime-sized `AbstractVector`. Mirrors the one-bit dynamic method: same block
 # pipeline, but loops taps/antennas at runtime and horizontally sums each popcount chunk
 # into per-(antenna, tap) Int64 totals. Not the hot path, but bit-identical to the
-# `@generated` kernel. `SVector` shifts dispatch to the `@generated` method above, so
-# EPL/VEPL keep the fast unrolled path.
+# `@generated` kernel. Returns a `Vector` rather than that kernel's `SVector{NC}`,
+# because here the tap count is only known at runtime; the caller broadcasts either
+# shape onto the correlator's accumulators. `SVector` shifts dispatch to the
+# `@generated` method above, so EPL/VEPL keep the fast unrolled path.
 function _twobit_hybrid_blocked!(
     dc::_TwoBitDC,
     signal::AbstractVecOrMat{Complex{Int16}},

--- a/src/track.jl
+++ b/src/track.jl
@@ -129,14 +129,20 @@ After one warmup call (which seats each satellite's `filtered_prompts`
 buffer capacity), the single-threaded path is fully allocation-free.
 
 The threaded path (`CPUThreadedDownconvertAndCorrelator`) keeps a small
-residual — about 64 B per **completed code-block integration** per group —
-but only when the process runs with more than one thread *and* the group
-holds more than one satellite (so Polyester's `@batch` actually distributes
-work). `track!` launches one `@batch` per code block, so this residual
-scales with the chunk length rather than staying flat per call; for a
+residual — about 96 B per **completed code-block integration** per group —
+but only when the process runs with more than one thread *and* the group's
+loop holds more than one work item (so Polyester's `@batch` actually
+distributes work). `track!` launches one `@batch` per code block, so this
+residual scales with the chunk length rather than staying flat per call; for a
 real-time loop with fixed-size chunks it is bounded per call and, in
 practice, dwarfed by the input sample buffer the caller allocates each
 chunk. The single-threaded backend has none of it.
+
+A `TrackState` whose C/N₀ estimators read a measured noise density pays the
+**same** ~96 B, even though its per-signal noise despread rides that same
+parallel loop: the loop reaches the despread's descriptor through one pointer
+rather than by value. It does mean a group with a *single* satellite now has
+two work items, so it pays the residual where it previously paid none.
 
 The root cause is not the per-satellite state per se — it is that the
 GNSS **signal** object is not an `isbits` type: `GPSL1CA`, for example, holds

--- a/src/tracking_state.jl
+++ b/src/tracking_state.jl
@@ -355,6 +355,7 @@ function TrackState(
         isnothing(groups) ? track_state.groups : groups,
         isnothing(doppler_estimator) ? track_state.doppler_estimator : doppler_estimator,
         isnothing(noise_estimators) ? track_state.noise_estimators : noise_estimators,
+        track_state.noise_descriptor,
     )
 end
 
@@ -506,7 +507,12 @@ function merge_sats(
     _assert_sats_match_slot_type(g, new_sats_dict, group_idx)
     new_group = SignalGroup(g; satellites = merge(g.satellites, new_sats_dict))
     new_groups = @set groups[group_idx] = new_group
-    TrackState{G,DE,NE}(new_groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        new_groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 function merge_sats(
@@ -598,7 +604,12 @@ function add_satellite!(
     # identical object (the contract guarantees the concrete type either
     # way), and then the input `track_state` is handed back unchanged.
     new_estimator === track_state.doppler_estimator && return track_state
-    TrackState{G,DE,NE}(track_state.groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        track_state.groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 # Verify that `sat` has exactly the concrete type the group's
@@ -698,7 +709,12 @@ function add_satellite(
     new_dict = merge(g.satellites, dictionary((sat.prn => sat,)))
     new_group = SignalGroup(g; satellites = new_dict)
     new_groups = @set groups[group] = new_group
-    TrackState{G,DE,NE}(new_groups, new_estimator, track_state.noise_estimators)
+    TrackState{G,DE,NE}(
+        new_groups,
+        new_estimator,
+        track_state.noise_estimators,
+        track_state.noise_descriptor,
+    )
 end
 
 """
@@ -764,6 +780,7 @@ function remove_satellite(
         new_groups,
         track_state.doppler_estimator,
         track_state.noise_estimators,
+        track_state.noise_descriptor,
     )
 end
 

--- a/test/noise_estimators/correlator.jl
+++ b/test/noise_estimators/correlator.jl
@@ -498,23 +498,51 @@ end
 # 1.11+ get zero. Asserting `== 0` unconditionally would either fail on a
 # supported version or have to be weakened into something that no longer catches
 # a real regression.
+#
+# Asserted on **every** backend, because the despread is the same primitive on each
+# and only the kernel behind it differs — and the kernel is where this last went
+# wrong. The one-bit and two-bit `@generated` kernels used to return their per-tap
+# sums in a heap `Vector`; the compiler elided it at the per-satellite call site but
+# not at the reference's, so the measurement alone allocated ~112 B per
+# sub-integration (about 1 kB per 10 ms chunk) on those two backends while every
+# other path measured 0. They now return an `SVector{NC}`, as the integer kernel
+# always did, so `NC` being a compile-time constant means no heap cell at all.
 if VERSION >= v"1.11"
-    @testset "the software measurement is allocation-free in steady state" begin
+    @testset "the software measurement is allocation-free in steady state ($(nameof(DC)))" for (
+        DC,
+        build,
+        quantise,
+    ) in (
+        (CPUDownconvertAndCorrelator, () -> CPUDownconvertAndCorrelator(), false),
+        (
+            Int16DownconvertAndCorrelator,
+            () -> Int16DownconvertAndCorrelator(NUM_SAMPLES),
+            true,
+        ),
+        (OneBitDownconvertAndCorrelator, () -> OneBitDownconvertAndCorrelator(), true),
+        (TwoBitDownconvertAndCorrelator, () -> TwoBitDownconvertAndCorrelator(), true),
+    )
         function measure(dc, measurements, ts)
             for _ = 1:8
                 downconvert_and_correlate!(dc, measurements, ts; chunk_index = 0)
             end
             @allocated downconvert_and_correlate!(dc, measurements, ts; chunk_index = 0)
         end
-        signal = ComplexF32.(_sky(45.0; seed = 8))
+        raw = _sky(45.0; seed = 8)
+        signal = quantise ? _to_int16(raw) : ComplexF32.(raw)
         measurements = (L1 = BandMeasurement(signal, FS),)
-        ts = TrackState(
-            GPSL1,
-            [TrackedSat(GPSL1, 1, 0.0, 0.0Hz; cn0_estimator = NoiseRefCN0Estimator())],
-        )
-        dc = CPUDownconvertAndCorrelator()
+        # Measured against the same state without a reference, so the assertion is
+        # about the *measurement* rather than about the correlate stage as a whole.
+        state(cn0) =
+            TrackState(GPSL1, [TrackedSat(GPSL1, 1, 0.0, 0.0Hz; cn0_estimator = cn0())])
+        ts = state(NoiseRefCN0Estimator)
+        plain_ts = state(() -> NWPRCN0Estimator(GPSL1))
+        dc = build()
+        plain_dc = build()
         track!(measurements, ts; downconvert_and_correlator = dc)
+        track!(measurements, plain_ts; downconvert_and_correlator = plain_dc)
         @test measure(dc, measurements, ts) == 0
+        @test measure(plain_dc, measurements, plain_ts) == 0
     end
 end
 

--- a/test/track_in_place.jl
+++ b/test/track_in_place.jl
@@ -215,6 +215,85 @@ end
     end
 end
 
+# What the noise reference costs the *threaded* backend at launch, which the loose
+# cap above cannot see. Polyester heap-allocates one argument tuple per `@batch`
+# launch, sized by what the region references and copying an immutable struct into
+# it by value — so a noise descriptor reached by value put the estimator (48 B), the
+# band measurement (24 B) and the signal instance (56 B) in there and took the
+# launch from ~96 B to 240 B. Reached through one box it costs a pointer, and the
+# contract is that it costs nothing measurable at all.
+#
+# Asserted as equality against an otherwise identical state whose C/N₀ estimator
+# reads no density, not against a byte count: the count is Polyester's and Julia's
+# to change, "the reference is free at launch" is ours. Two satellites, so the
+# comparison is not made at the one satellite count where the loop has a single
+# item and no residual to speak of.
+@static if VERSION >= v"1.11"
+    @testset "the noise reference adds nothing to the threaded launch residual" begin
+        sampling_frequency = 4e6Hz
+        signal, gpsl1, carrier_doppler, start_code_phase = make_signal(sampling_frequency)
+        make_state(make_cn0_estimator) = TrackState(
+            gpsl1,
+            [
+                TrackedSat(
+                    gpsl1,
+                    prn,
+                    start_code_phase,
+                    carrier_doppler - 20Hz;
+                    cn0_estimator = make_cn0_estimator(),
+                ) for prn = 1:2
+            ],
+        )
+        plain_state = make_state(() -> NWPRCN0Estimator(gpsl1))
+        noise_state = make_state(NoiseRefCN0Estimator)
+        @test keys(plain_state.noise_estimators) == ()
+        @test keys(noise_state.noise_estimators) == (:GPSL1CA,)
+
+        plain_dc = CPUThreadedDownconvertAndCorrelator()
+        noise_dc = CPUThreadedDownconvertAndCorrelator()
+        for _ = 1:8
+            track!(
+                signal,
+                plain_state,
+                sampling_frequency;
+                downconvert_and_correlator = plain_dc,
+            )
+            track!(
+                signal,
+                noise_state,
+                sampling_frequency;
+                downconvert_and_correlator = noise_dc,
+            )
+        end
+
+        @test measure_dc!(noise_dc, signal, noise_state, sampling_frequency) ==
+              measure_dc!(plain_dc, signal, plain_state, sampling_frequency)
+
+        # The box the descriptors are parked in is provisioned once and reused —
+        # which is what makes the launch cost flat rather than merely smaller — and
+        # it has to survive the `TrackState` copies `track` and `track!` make of it.
+        box = noise_state.noise_descriptor[]
+        @test box isa Base.RefValue
+        track!(
+            signal,
+            noise_state,
+            sampling_frequency;
+            downconvert_and_correlator = noise_dc,
+        )
+        @test noise_state.noise_descriptor[] === box
+        @test track(
+            signal,
+            noise_state,
+            sampling_frequency;
+            downconvert_and_correlator = noise_dc,
+        ).noise_descriptor === noise_state.noise_descriptor
+
+        # Nothing to measure parks nothing: a state whose C/N₀ estimators read no
+        # density never provisions a box, so the loop has nothing extra to root.
+        @test isnothing(plain_state.noise_descriptor[])
+    end
+end
+
 # Acquisition (pre-sync) allocation guard. Before bit sync, `track!` runs the
 # per-code-block bit-edge search (`_buffer_find_bit`) once per code block. A
 # regression there — e.g. a closure-capture `Core.Box` + boxed `SyncResult`


### PR DESCRIPTION
Stacked on #226 (`share-the-noise-correlation-path`) — review and merge that first.

Two commits, both `perf`, both about the same complaint: on a threaded backend a
`TrackState` whose C/N₀ estimators read a measured noise density allocated more per
call than one that does not. It now allocates the **same**, and on the bit-wise
backends' serial paths it allocates **nothing**.

Full suite green single-threaded and under `-t8`; format clean at the pinned
JuliaFormatter 2.8.5.

## Why

#226's own accounting put the threaded launch residual at "~80 B to ~240 B" and
attributed it to rooting a non-`isbits` struct. Measuring the argument tuple Polyester
actually builds gives a sharper rule, and the sharper rule is what makes the cost
removable:

Polyester copies everything the `@batch` region references into **one** argument tuple
and heap-allocates that tuple at its `sizeof`. Within it,

- a tuple whose every member is `isbits` (bare `Array`s become `PtrArray`s, so they
  qualify) does not escape and is elided outright — hence a `Vector{Float64}` kernel
  allocating nothing;
- as soon as one member is not, the whole tuple is allocated, and each member is copied
  **by value** if it is an immutable struct, or as **one pointer** if it is a mutable
  object.

So it is not struct-ness that costs, it is *immutability*. Measured on the flattened
tuple: satellites alone come to 80 B (→ 96 B allocated), and one noise descriptor added
**152 B** — `CorrelatorNoiseEstimator` 48 B, the band's `BandMeasurement` 24 B, and the
signal instance 56 B (`GPSL1CA`). The signal was the largest single item, and the one
the earlier accounting missed; trimming the `NoiseUpdateContext` wrapper could only ever
have reached the 16 B it did.

The second finding came out of checking the other backends rather than only the float
CPU one: the one-bit and two-bit despreads allocated a further **112 B per
sub-integration** — ~1 kB per 10 ms chunk at 4 MHz, i.e. more than the whole launch
residual on those backends — and did so on their *serial* variants too. That one
predates this PR and #226: it is already there at #223, where the reference first went
through the shared despread primitive.

## What changed

### `perf(dc)`: the loop gets one box, not copies

`_park_noise_items!` writes the chunk's descriptors into a box and hands the loop the
box. 152 B by value becomes 8 B by pointer, and nothing per descriptor.

The box has to outlive a launch and be reused across launches, or its own allocation
would cost more than the copy it replaces — and it cannot be provisioned up front,
because its type names the caller's `BandMeasurement`, which the `TrackState` does not
know until the first correlate call. So `TrackState` gains one field: a type-erased
`Base.RefValue{Any}` cell that the first call fills with a concretely typed box and
every later call writes into. Both the write and the loop-side read stay type-stable
(the box is concrete), a caller who changes sample types gets a new box once, and the
box roots everything the descriptors point at, so nothing relies on the caller keeping
anything alive.

Nothing to measure still passes `()`, so a state that reads no noise density roots
nothing and pays exactly the launch it paid before any of this existed.

### `perf(dc)`: the bit-wise kernels return an `SVector`

The one-bit and two-bit `@generated` kernels returned their per-tap sums in a heap
`Vector`. At the per-satellite call site the compiler elided it; at the noise
reference's it did not. `NC` is a parameter of those methods, so the cell was never
needed: `SVector{NC}`, which is what `_int16_hybrid_blocked!` has always returned — and
exactly why the integer backend measured 0 B where these two did not.

Only the single-signal `@generated` methods change. The dynamic fallbacks keep returning
a `Vector` (their tap count is a runtime value), and so do the multi-signal tile-share
kernels, whose call site *does* elide it — a two-signal satellite measures 0 B on both
backends, so changing them would be churn on a path that does not allocate.

## Numbers

Per `downconvert_and_correlate!` call, 2 satellites, 1 ms at 4 MHz, GPS L1 C/A, with a
noise reference. "before" is #226's head.

| backend | serial, before | serial, after | 8-thread, before | 8-thread, after | 8-thread, no reference |
|---|---:|---:|---:|---:|---:|
| CPU | 0 B | 0 B | 240 B | **96 B** | 96 B |
| Int16 | 0 B | 0 B | 400 B | **240 B** | 240 B |
| one-bit | 112 B | **0 B** | 384 B | **128 B** | 112 B |
| two-bit | 112 B | **0 B** | 400 B | **144 B** | 144 B |

Each threaded figure is now that backend's satellites-only residual: the noise reference
adds nothing. The one-bit column's remaining 16 B is the box's pointer tipping the
argument tuple into the next allocation bucket; it does not scale with anything.

Serial backends are allocation-free with a reference on every backend now, where before
two of the four were not.

Wall time is unchanged. Noise-referenced `track!` on the CPU threaded backend at
1/2/4/8/12/16/24 satellites measures 2.73/3.33/5.54/8.93/13.82/15.73/22.82 µs against
2.77/3.36/5.68/10.19/13.20/15.99/22.86 µs before — run-to-run noise, and the same on
both bit-wise backends at 1 and 8 satellites in both threading modes. Neither commit
touches a kernel's arithmetic.

## API

`TrackState` gains a fourth field, `noise_descriptor`. **Not breaking**: the
three-argument positional constructor is kept, so released call sites still compile, and
the type gains no parameter, so every `TrackState{G,DE,NE}` spelling still works. The
field is per-call scratch, not state — shared, not copied, by every `TrackState` derived
from one, exactly as the per-satellite scratch vectors are, and nothing outside one
`downconvert_and_correlate!` call reads it. One consequence worth knowing: it keeps the
*last* chunk's `BandMeasurement` reachable until the next call overwrites it, which is
one sample buffer a `track!` caller was holding anyway.

## New regressions

- **The noise reference is free at launch**, asserted as an *equality* against an
  otherwise identical state whose C/N₀ estimator reads no density rather than against a
  byte count — the count is Polyester's and Julia's to change, "the reference is free"
  is ours. Two satellites, so the comparison is not made at the one count where the loop
  has a single item and no residual to speak of.
- **The box is provisioned once and survives the `TrackState` copies** `track` and
  `track!` make, since a per-call box would be worse than the copy it replaced — and a
  state with nothing to measure never provisions one at all.
- **The software measurement is allocation-free on every backend**, not only the float
  CPU one, and measured against the same state without a reference. This last went wrong
  in a kernel, so every kernel is what has to be covered.

## Not done

The remaining per-launch residual (96 B on the CPU threaded backend) is the satellites'
own, and it is still the GNSS signal object: removing it needs the GNSSSignals-side
bare-array `gen_code!` that `CPUThreadedDownconvertAndCorrelator`'s docstring describes.
Unchanged by this PR, and now the only thing left in the way of 0 B.

The `use_band_cache` bonus #226 lists as out of reach stays out of reach — the box
changes how descriptors are *reached*, not which group's loop they ride.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
